### PR TITLE
Add --save-every-steps for mid-epoch checkpointing with resume support

### DIFF
--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -60,6 +60,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import math
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -317,6 +318,7 @@ def parse_args() -> argparse.Namespace:
     out.add_argument("--output-dir", type=str, default=DEFAULTS["output_dir"])
     out.add_argument("--run-name", type=str, default=None)
     out.add_argument("--save-every", type=int, default=DEFAULTS["save_every"])
+    out.add_argument("--save-every-steps", type=int, default=None, help="Save preemption checkpoint every N optimizer steps (None = disabled)")
 
     # Resume arguments
     resume = parser.add_argument_group("Resume / Checkpointing")
@@ -993,6 +995,7 @@ def main() -> None:
     start_epoch = 1
     best_val_loss = float("inf")
     wandb_run_id = None
+    skip_batches = 0
 
     if resume_path and resume_path.exists():
         print_rank0(f"Resuming from: {resume_path}", rank)
@@ -1022,6 +1025,7 @@ def main() -> None:
                 device="cpu",
             )
             start_epoch = ckpt["epoch"] + 1
+            skip_batches = ckpt.get("batch_idx", 0)
             best_val_loss = ckpt.get("best_val_loss", ckpt.get("val_loss", float("inf")))
             wandb_run_id = ckpt.get("wandb_run_id")
             print_rank0(f"  Resumed at epoch {start_epoch}, best_val_loss={best_val_loss:.4f}", rank)
@@ -1069,6 +1073,8 @@ def main() -> None:
     }
 
     # Logger (rank 0 only)
+    steps_per_epoch = math.ceil(len(train_loader) / args.gradient_accumulation_steps)
+    resume_step = (start_epoch - 1) * steps_per_epoch + skip_batches // args.gradient_accumulation_steps
     logger = TrainingLogger(
         output_dir=output_dir,
         rank=rank,
@@ -1078,12 +1084,14 @@ def main() -> None:
         run_name=run_name,
         config=config,
         resume_id=wandb_run_id if resume_path else None,
+        initial_step=resume_step,
     )
 
     use_amp = not args.no_amp
 
     # Preemption handler state
     current_epoch = start_epoch
+    _save_state: dict = {"batch_idx": 0}
 
     def _save_preempt():
         """Save preemption checkpoint."""
@@ -1100,6 +1108,7 @@ def main() -> None:
                 scheduler=scheduler,
                 best_val_loss=best_val_loss,
                 wandb_run_id=logger.wandb_run_id,
+                batch_idx=_save_state["batch_idx"],
             )
             print(f"Preemption checkpoint saved to {output_dir / 'checkpoint_preempt.pth'}")
 
@@ -1135,6 +1144,8 @@ def main() -> None:
                 torch.cuda.empty_cache()
 
             # Training
+            epoch_skip = skip_batches if epoch == start_epoch else 0
+            global_step_offset = (epoch - 1) * steps_per_epoch + epoch_skip // args.gradient_accumulation_steps
             if args.is_multimodal:
                 train_loss, per_modality_train_loss = train_epoch_multihead(
                     model=model,
@@ -1161,6 +1172,11 @@ def main() -> None:
                     profile_batches=args.profile_batches if epoch == start_epoch else 0,
                     log_fn=logger.log_step if is_main_process(rank) else None,
                     encoder_only=encoder_only,
+                    save_every_steps=args.save_every_steps,
+                    save_fn=_save_preempt,
+                    global_step_offset=global_step_offset,
+                    skip_batches=epoch_skip,
+                    save_state=_save_state,
                 )
             else:
                 # Single modality: use the standard train_epoch_ddp
@@ -1189,7 +1205,15 @@ def main() -> None:
                     profile_batches=args.profile_batches if epoch == start_epoch else 0,
                     log_fn=logger.log_step if is_main_process(rank) else None,
                     encoder_only=encoder_only,
+                    save_every_steps=args.save_every_steps,
+                    save_fn=_save_preempt,
+                    global_step_offset=global_step_offset,
+                    skip_batches=epoch_skip,
+                    save_state=_save_state,
                 )
+
+            skip_batches = 0  # Only skip on first resumed epoch
+            _save_state["batch_idx"] = 0
 
             if handler.preempted:
                 print_rank0("Preemption flag set - saving and exiting.", rank)

--- a/src/alphagenome_pytorch/extensions/finetuning/logging.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/logging.py
@@ -49,6 +49,7 @@ class TrainingLogger:
         run_name: str | None = None,
         config: dict | None = None,
         resume_id: str | None = None,
+        initial_step: int = 0,
     ) -> None:
         """Initialize the training logger.
 
@@ -65,7 +66,7 @@ class TrainingLogger:
         self.output_dir = Path(output_dir)
         self.rank = rank
         self.use_wandb = use_wandb and is_main_process(rank)
-        self.step = 0
+        self.step = initial_step
         self.resume_id = resume_id
 
         # Only main process handles logging

--- a/src/alphagenome_pytorch/extensions/finetuning/training.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/training.py
@@ -601,6 +601,11 @@ def train_epoch_ddp(
     profile_batches: int = 0,
     log_fn: Any | None = None,
     encoder_only: bool = False,
+    save_every_steps: int | None = None,
+    save_fn: Any | None = None,
+    global_step_offset: int = 0,
+    skip_batches: int = 0,
+    save_state: dict | None = None,
 ) -> float:
     """Train for one epoch with DDP and profiling support.
 
@@ -672,8 +677,12 @@ def train_epoch_ddp(
     t_batch_start = time.perf_counter()
     running_loss = 0.0
     accumulated_batches = 0
+    opt_step = 0
 
     for batch_idx, (sequences, targets_dict) in enumerate(pbar):
+        if batch_idx < skip_batches:
+            continue
+
         is_profiling = do_profile and batch_idx < profile_batches
 
         # --- Data loading time (time since last batch ended) ---
@@ -827,10 +836,18 @@ def train_epoch_ddp(
             optimizer.step()
             scheduler.step()
             optimizer.zero_grad()
+            opt_step += 1
 
             if is_profiling:
                 _cuda_sync(device)
                 profile_stats.add("6_optimizer", time.perf_counter() - t0)
+
+            if save_every_steps is not None and save_fn is not None:
+                global_step = global_step_offset + opt_step
+                if global_step % save_every_steps == 0:
+                    if save_state is not None:
+                        save_state["batch_idx"] = batch_idx + 1
+                    save_fn()
 
         # Update totals
         raw_loss = loss.item()
@@ -1128,6 +1145,11 @@ def train_epoch_multihead(
     profile_batches: int = 0,
     log_fn: Any | None = None,
     encoder_only: bool = False,
+    save_every_steps: int | None = None,
+    save_fn: Any | None = None,
+    global_step_offset: int = 0,
+    skip_batches: int = 0,
+    save_state: dict | None = None,
 ) -> tuple[float, dict[str, float]]:
     """Train for one epoch with multiple modality heads.
 
@@ -1196,8 +1218,12 @@ def train_epoch_multihead(
     t_batch_start = time.perf_counter()
     running_loss = 0.0
     accumulated_batches = 0
+    opt_step = 0
 
     for batch_idx, (sequences, modality_targets) in enumerate(pbar):
+        if batch_idx < skip_batches:
+            continue
+
         is_profiling = do_profile and batch_idx < profile_batches
 
         if is_profiling and batch_idx > 0:
@@ -1354,10 +1380,18 @@ def train_epoch_multihead(
             optimizer.step()
             scheduler.step()
             optimizer.zero_grad()
+            opt_step += 1
 
             if is_profiling:
                 _cuda_sync(device)
                 profile_stats.add("6_optimizer", time.perf_counter() - t0)
+
+            if save_every_steps is not None and save_fn is not None:
+                global_step = global_step_offset + opt_step
+                if global_step % save_every_steps == 0:
+                    if save_state is not None:
+                        save_state["batch_idx"] = batch_idx + 1
+                    save_fn()
 
         raw_loss = loss.item()
         total_loss_accum += raw_loss


### PR DESCRIPTION
## Summary                                                                                                                     
  - Adds `--save-every-steps` to save a preemption checkpoint every N optimizer steps during an epoch (default: disabled)
  - Saves `batch_idx` in the checkpoint so training can resume mid-epoch by skipping already-processed batches                   
  - Fixes duplicate step numbers in `training_log.csv` on resume by initialising the logger's step counter from the correct      
  global step offset