### PR TITLE
Fix ism_matrix mean-centering to match upstream

### DIFF
--- a/src/alphagenome_pytorch/variant_scoring/inference.py
+++ b/src/alphagenome_pytorch/variant_scoring/inference.py
@@ -733,19 +733,21 @@ class VariantScoringModel:
 
         Creates a (sequence_length, 4) matrix where each position contains
         the contribution score for mutating the reference base to each
-        possible alternate base.
+        possible alternate base, mean-centered across alternatives. Mirrors
+        ``alphagenome.interpretation.ism.ism_matrix``.
 
         Args:
             variant_scores: List of scores for each variant (from ISM scoring).
             variants: List of Variant objects corresponding to scores.
             interval: Genomic interval that was scored.
-            multiply_by_sequence: If True, zero out the reference base positions
-                (since we only have alt scores). Default True.
+            multiply_by_sequence: If True, return non-zero values only at the
+                reference-base column (alt-base columns are zeroed). Default True,
+                matching ``alphagenome.interpretation.ism.ism_matrix``.
             vocabulary: Nucleotide vocabulary order. Default 'ACGT'.
 
         Returns:
             Tensor of shape (interval.width, 4) with mean-centered ISM scores.
-            
+
         Example:
             >>> ism_scores = scorer.score_ism_variants(interval, center, scorers)
             >>> # Flatten to get score per variant
@@ -753,35 +755,13 @@ class VariantScoringModel:
             >>> variants = [...]  # Same order as ism_scores
             >>> matrix = scorer.ism_matrix(flat_scores, variants, interval)
         """
-        import numpy as np
-
-        scores = np.zeros((interval.width, len(vocabulary)), dtype=np.float32)
-        filled = np.zeros((interval.width, len(vocabulary)), dtype=bool)
-        base_index = {base: i for i, base in enumerate(vocabulary)}
-
-        for variant, score in zip(variants, variant_scores):
-            if not variant.is_snv:
-                continue
-            position = variant.start - interval.start
-            if 0 <= position < interval.width:
-                alt_base = variant.alternate_bases.upper()
-                if alt_base in base_index:
-                    scores[position, base_index[alt_base]] = score
-                    filled[position, base_index[alt_base]] = True
-
-        # Mean-center across alternatives (excluding reference)
-        # For each position, subtract mean of filled values
-        for pos in range(interval.width):
-            n_filled = filled[pos].sum()
-            if n_filled > 0:
-                mean_score = scores[pos, filled[pos]].mean()
-                scores[pos] -= mean_score / (len(vocabulary) - 1)
-
-        if multiply_by_sequence:
-            # Zero out positions where we don't have data
-            scores = scores * (~filled).astype(np.float32)
-
-        return torch.from_numpy(scores)
+        return _ism_matrix(
+            variant_scores=variant_scores,
+            variants=variants,
+            interval=interval,
+            multiply_by_sequence=multiply_by_sequence,
+            vocabulary=vocabulary,
+        )
 
     def close(self):
         """Close any open file handles."""
@@ -793,6 +773,46 @@ class VariantScoringModel:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
+
+
+def _ism_matrix(
+    variant_scores: list[float],
+    variants: list[Variant],
+    interval: Interval,
+    multiply_by_sequence: bool = True,
+    vocabulary: str = 'ACGT',
+) -> torch.Tensor:
+    """Construct mean-centered ISM contribution matrix.
+
+    Module-level helper underlying ``VariantScoringModel.ism_matrix``. Mirrors
+    ``alphagenome.interpretation.ism.ism_matrix``: per row, subtracts
+    ``sum(scores) / (V - 1)`` so the REF column (which starts at 0) holds
+    ``-mean(ALT scores)`` and each ALT column holds ``score - mean(ALT scores)``.
+    """
+    import numpy as np
+
+    scores = np.zeros((interval.width, len(vocabulary)), dtype=np.float32)
+    filled = np.zeros((interval.width, len(vocabulary)), dtype=bool)
+    base_index = {base: i for i, base in enumerate(vocabulary)}
+
+    for variant, score in zip(variants, variant_scores):
+        if not variant.is_snv:
+            continue
+        position = variant.start - interval.start
+        if 0 <= position < interval.width:
+            alt_base = variant.alternate_bases.upper()
+            if alt_base in base_index:
+                scores[position, base_index[alt_base]] = score
+                filled[position, base_index[alt_base]] = True
+
+    # Mean-center: subtract sum/(V-1) per position. Because the REF column is 0,
+    # this equals the mean of the (V-1) ALT scores.
+    scores -= scores.sum(axis=-1, keepdims=True) / (len(vocabulary) - 1)
+
+    if multiply_by_sequence:
+        scores = scores * (~filled).astype(np.float32)
+
+    return torch.from_numpy(scores)
 
 
 # Recommended scorer presets matching JAX reference

--- a/src/alphagenome_pytorch/variant_scoring/inference.py
+++ b/src/alphagenome_pytorch/variant_scoring/inference.py
@@ -733,20 +733,27 @@ class VariantScoringModel:
 
         Creates a (sequence_length, 4) matrix where each position contains
         the contribution score for mutating the reference base to each
-        possible alternate base, mean-centered across alternatives. Mirrors
-        ``alphagenome.interpretation.ism.ism_matrix``.
+        possible alternate base, mean-centered across alternatives.
 
         Args:
             variant_scores: List of scores for each variant (from ISM scoring).
             variants: List of Variant objects corresponding to scores.
             interval: Genomic interval that was scored.
-            multiply_by_sequence: If True, return non-zero values only at the
-                reference-base column (alt-base columns are zeroed). Default True,
-                matching ``alphagenome.interpretation.ism.ism_matrix``.
+            multiply_by_sequence: If True, zero every scored ALT column, leaving
+                non-zero values only at unscored columns. For a normal ACGT position
+                (all 3 ALT bases scored) that is exactly the reference-base column;
+                for an ``N`` reference (all 4 ALT bases scored) the whole row is
+                zeroed. Default True. 
+                Positions with only 1 or 2 scored ALT bases are rejected.
             vocabulary: Nucleotide vocabulary order. Default 'ACGT'.
 
         Returns:
             Tensor of shape (interval.width, 4) with mean-centered ISM scores.
+
+        Raises:
+            ValueError: If any position has only 1 or 2 scored ALT bases. A real
+                ACGT reference must contribute all 3 alternates (an ``N`` reference
+                contributes 4); a partially scored position would be mis-centered.
 
         Example:
             >>> ism_scores = scorer.score_ism_variants(interval, center, scorers)
@@ -786,8 +793,15 @@ def _ism_matrix(
 
     Module-level helper underlying ``VariantScoringModel.ism_matrix``. Mirrors
     ``alphagenome.interpretation.ism.ism_matrix``: per row, subtracts
-    ``sum(scores) / (V - 1)`` so the REF column (which starts at 0) holds
-    ``-mean(ALT scores)`` and each ALT column holds ``score - mean(ALT scores)``.
+    ``sum(scores) / (V - 1)``. For a normal ACGT position all 3 ALT columns are
+    scored and the REF column starts at 0, so the divisor ``V - 1`` is the ALT
+    count and the REF column holds ``-mean(ALT scores)`` while each ALT column
+    holds ``score - mean(ALT scores)``.
+
+    Positions with only 1 or 2 scored ALT bases are rejected with ``ValueError``:
+    the incomplete sum would still be divided by ``V - 1``, yielding a
+    wrong-magnitude row. A position with 4 scored ALTs (an ``N`` reference) is
+    allowed; under ``multiply_by_sequence`` its row zeros out entirely.
     """
     import numpy as np
 
@@ -804,6 +818,23 @@ def _ism_matrix(
             if alt_base in base_index:
                 scores[position, base_index[alt_base]] = score
                 filled[position, base_index[alt_base]] = True
+
+    # Per-position coverage guard. A real ACGT reference has exactly 3 possible
+    # ALT bases, so a scored row holds 3 (normal) or 4 (non-ACGT/N reference, which
+    # yields all four ACGT as alts). 0 means the position fell outside the scored
+    # window (edge) and is intentionally left as zeros. 1 or 2 means a real base is
+    # missing some alternates: centering would then divide an incomplete sum by
+    # (V-1), silently producing a wrong-magnitude row, so we reject it rather than
+    # emit a misleading matrix.
+    per_pos = filled.sum(axis=-1)
+    partial = np.where((per_pos == 1) | (per_pos == 2))[0]
+    if partial.size:
+        positions_1based = (partial + interval.start + 1).tolist()
+        raise ValueError(
+            'ism_matrix: positions have only 1 or 2 alternate bases (expected 3 '
+            'for an ACGT reference, or 4 for N). 1-based positions: '
+            f'{positions_1based}'
+        )
 
     # Mean-center: subtract sum/(V-1) per position. Because the REF column is 0,
     # this equals the mean of the (V-1) ALT scores.

--- a/tests/unit/test_ism_matrix.py
+++ b/tests/unit/test_ism_matrix.py
@@ -4,6 +4,12 @@ The upstream contract: per row, subtract `sum(scores) / (V - 1)`. With REF colum
 and three ALT columns filled, this equals the mean of the three ALT scores. After
 mean-centering, REF holds `-mean(ALT)` and each ALT holds `score - mean(ALT)`. With
 `multiply_by_sequence=True`, only the REF column survives.
+
+Coverage guard: a real ACGT reference contributes exactly 3 ALT bases, so a scored
+row holds 3 (normal) or 4 (an `N` reference yields all four ACGT as alts). A row with
+only 1 or 2 scored ALTs would be mis-centered (incomplete sum still divided by V-1),
+so `_ism_matrix` raises `ValueError`. Rows with 0 scored ALTs (window edges) are left
+as zeros.
 """
 
 import numpy as np
@@ -107,36 +113,65 @@ def test_matches_upstream_vectorized_formula():
     np.testing.assert_allclose(got_post, expected_masked, atol=1e-6)
 
 
-def test_partially_filled_position_still_centered_uniformly():
-    """Even if a position has fewer than 3 ALT scores, the (V-1) divisor stays.
+def test_partially_filled_position_raises():
+    """A position with only 1 or 2 scored ALT bases is rejected.
 
-    Upstream uses `sum/(V-1)` regardless of how many cells are filled — it doesn't
-    re-divide by the number of filled entries. Lock that in.
+    Centering divides by (V-1)=3 regardless of how many cells are filled, so a
+    partially scored position would silently produce a wrong-magnitude row. The
+    coverage guard raises instead, reporting the offending 1-based position.
     """
     interval = Interval(chromosome='chr1', start=100, end=101)
     variants = [Variant('chr1', 101, 'A', 'C'), Variant('chr1', 101, 'A', 'G')]  # missing A->T
     scores = [3.0, 6.0]
 
-    matrix = _ism_matrix(scores, variants, interval, multiply_by_sequence=False).numpy()
+    with pytest.raises(ValueError, match=r'1 or 2 alternate bases.*101'):
+        _ism_matrix(scores, variants, interval, multiply_by_sequence=False)
 
-    # sum = 0+3+6+0 = 9; subtract 9/3 = 3 from each cell.
-    # ACGT -> [A=-3, C=0, G=3, T=-3]
-    assert np.allclose(matrix[0], [-3.0, 0.0, 3.0, -3.0])
+
+def test_n_reference_four_alts_allowed():
+    """A non-ACGT (N) reference yields all 4 ALT bases and is allowed.
+
+    A real ACGT base can only have 3 alternates, so 4 scored ALTs uniquely signals
+    an N reference. It must not trip the partial-coverage guard. Under the default
+    `multiply_by_sequence=True` mask, every column is filled so the row zeros out.
+    """
+    interval = Interval(chromosome='chr1', start=100, end=101)
+    variants = [
+        Variant('chr1', 101, 'N', 'A'), Variant('chr1', 101, 'N', 'C'),
+        Variant('chr1', 101, 'N', 'G'), Variant('chr1', 101, 'N', 'T'),
+    ]
+    scores = [1.0, 2.0, 3.0, 4.0]
+
+    # Default mask: all four columns filled -> whole row zeroed, no error.
+    post = _ism_matrix(scores, variants, interval, multiply_by_sequence=True).numpy()
+    assert np.allclose(post[0], [0.0, 0.0, 0.0, 0.0])
+
+    # Pre-mask: centered by sum/(V-1)=10/3 per cell, still no error.
+    pre = _ism_matrix(scores, variants, interval, multiply_by_sequence=False).numpy()
+    assert np.allclose(pre[0], np.array([1.0, 2.0, 3.0, 4.0]) - 10.0 / 3)
 
 
 def test_skips_non_snv_and_oob_variants():
-    """Indels and out-of-interval variants are silently ignored, matching prior behavior."""
+    """Indels and out-of-interval variants are silently ignored.
+
+    Position 0 still gets its full 3 SNVs (so the coverage guard is satisfied); the
+    insertion and the out-of-interval SNV must not contribute. Position 1 stays empty
+    (0 filled is allowed — it is left as zeros, not raised).
+    """
     interval = Interval(chromosome='chr1', start=100, end=102)
     variants = [
-        Variant('chr1', 101, 'A', 'C'),  # in-interval SNV
+        Variant('chr1', 101, 'A', 'C'),   # in-interval SNV
+        Variant('chr1', 101, 'A', 'G'),   # in-interval SNV
+        Variant('chr1', 101, 'A', 'T'),   # in-interval SNV
         Variant('chr1', 101, 'A', 'CG'),  # insertion: skipped
-        Variant('chr1', 200, 'A', 'C'),  # out of interval: skipped
+        Variant('chr1', 200, 'A', 'C'),   # out of interval: skipped
     ]
-    scores = [2.0, 99.0, 99.0]
+    scores = [2.0, 4.0, 6.0, 99.0, 99.0]
 
     matrix = _ism_matrix(scores, variants, interval, multiply_by_sequence=False).numpy()
 
-    # Only the first variant counted: position 0, sum = 2, subtract 2/3 from each cell.
-    assert np.allclose(matrix[0], [-2.0 / 3, 2.0 - 2.0 / 3, -2.0 / 3, -2.0 / 3])
+    # Only the 3 valid SNVs counted: position 0, sum = 12, subtract 12/3 = 4 per cell.
+    # ACGT -> [A=-4, C=-2, G=0, T=2]; the skipped variants leave no trace.
+    assert np.allclose(matrix[0], [-4.0, -2.0, 0.0, 2.0])
     # Position 1 untouched: all zero.
     assert np.allclose(matrix[1], [0.0, 0.0, 0.0, 0.0])

--- a/tests/unit/test_ism_matrix.py
+++ b/tests/unit/test_ism_matrix.py
@@ -1,0 +1,142 @@
+"""Math parity tests for `ism_matrix` against upstream `alphagenome.interpretation.ism.ism_matrix`.
+
+The upstream contract: per row, subtract `sum(scores) / (V - 1)`. With REF column = 0
+and three ALT columns filled, this equals the mean of the three ALT scores. After
+mean-centering, REF holds `-mean(ALT)` and each ALT holds `score - mean(ALT)`. With
+`multiply_by_sequence=True`, only the REF column survives.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from alphagenome_pytorch.variant_scoring.inference import _ism_matrix
+from alphagenome_pytorch.variant_scoring.types import Interval, Variant
+
+
+def _build_snv_inputs():
+    """Two-position interval with hand-picked SNV scores.
+
+    Position 100 (1-based 101), REF='A':  A->C=2.0, A->G=4.0, A->T=6.0
+    Position 101 (1-based 102), REF='T':  T->A=1.0, T->C=3.0, T->G=5.0
+    """
+    interval = Interval(chromosome='chr1', start=100, end=102)
+    variants = [
+        Variant('chr1', 101, 'A', 'C'), Variant('chr1', 101, 'A', 'G'), Variant('chr1', 101, 'A', 'T'),
+        Variant('chr1', 102, 'T', 'A'), Variant('chr1', 102, 'T', 'C'), Variant('chr1', 102, 'T', 'G'),
+    ]
+    scores = [2.0, 4.0, 6.0, 1.0, 3.0, 5.0]
+    return interval, variants, scores
+
+
+def test_pre_mask_matches_upstream_centering():
+    """Without multiply_by_sequence: matrix = score - sum(row)/(V-1) per cell.
+
+    Upstream behavior: REF column starts at 0, so REF cell becomes `-mean(ALT scores)`
+    and each ALT cell becomes `score - mean(ALT scores)`.
+    """
+    interval, variants, scores = _build_snv_inputs()
+
+    matrix = _ism_matrix(scores, variants, interval, multiply_by_sequence=False)
+    matrix = matrix.numpy() if isinstance(matrix, torch.Tensor) else matrix
+
+    # Position 100 (REF='A'): sum = 0+2+4+6 = 12, mean = 4
+    # vocab order ACGT -> [A=-4, C=-2, G=0, T=2]
+    assert np.allclose(matrix[0], [-4.0, -2.0, 0.0, 2.0])
+
+    # Position 101 (REF='T'): sum = 1+3+5+0 = 9, mean = 3
+    # vocab order ACGT -> [A=-2, C=0, G=2, T=-3]
+    assert np.allclose(matrix[1], [-2.0, 0.0, 2.0, -3.0])
+
+
+def test_post_mask_keeps_only_reference_column():
+    """multiply_by_sequence=True (default) zeros ALT columns, keeps REF."""
+    interval, variants, scores = _build_snv_inputs()
+
+    matrix = _ism_matrix(scores, variants, interval, multiply_by_sequence=True)
+    matrix = matrix.numpy() if isinstance(matrix, torch.Tensor) else matrix
+
+    # Position 100 (REF='A'): only A column non-zero, value = -mean(ALT) = -4
+    assert np.allclose(matrix[0], [-4.0, 0.0, 0.0, 0.0])
+
+    # Position 101 (REF='T'): only T column non-zero, value = -mean(ALT) = -3
+    assert np.allclose(matrix[1], [0.0, 0.0, 0.0, -3.0])
+
+
+def test_regression_centering_is_sum_over_three_not_nine():
+    """Anti-regression for the prior 3x bug.
+
+    The previous implementation subtracted `mean(filled)/3` = `sum/9` instead of
+    `sum/3`, giving values 1/3 the upstream magnitude. Lock in the upstream value.
+    """
+    interval, variants, scores = _build_snv_inputs()
+
+    matrix = _ism_matrix(scores, variants, interval, multiply_by_sequence=True)
+    matrix = matrix.numpy() if isinstance(matrix, torch.Tensor) else matrix
+
+    # Position 100, REF='A' column: must be -sum/3 = -12/3 = -4.0,
+    # NOT the buggy -sum/9 = -12/9 ≈ -1.333.
+    assert matrix[0, 0] == pytest.approx(-4.0)
+    assert matrix[0, 0] != pytest.approx(-12.0 / 9)
+
+    # Position 101, REF='T' column: -sum/3 = -9/3 = -3.0, NOT -9/9 = -1.0.
+    assert matrix[1, 3] == pytest.approx(-3.0)
+    assert matrix[1, 3] != pytest.approx(-1.0)
+
+
+def test_matches_upstream_vectorized_formula():
+    """Direct equality with the upstream `np.sum(scores, axis=-1, keepdims=True) / 3` form."""
+    interval, variants, scores = _build_snv_inputs()
+    vocabulary = 'ACGT'
+
+    # Reproduce upstream construction inline.
+    expected = np.zeros((interval.width, len(vocabulary)), dtype=np.float32)
+    filled = np.zeros((interval.width, len(vocabulary)), dtype=bool)
+    base_index = {b: i for i, b in enumerate(vocabulary)}
+    for v, s in zip(variants, scores):
+        pos = v.start - interval.start
+        expected[pos, base_index[v.alternate_bases]] = s
+        filled[pos, base_index[v.alternate_bases]] = True
+    expected -= expected.sum(axis=-1, keepdims=True) / (len(vocabulary) - 1)
+    expected_masked = expected * (~filled).astype(np.float32)
+
+    got_pre = _ism_matrix(scores, variants, interval, multiply_by_sequence=False).numpy()
+    got_post = _ism_matrix(scores, variants, interval, multiply_by_sequence=True).numpy()
+
+    np.testing.assert_allclose(got_pre, expected, atol=1e-6)
+    np.testing.assert_allclose(got_post, expected_masked, atol=1e-6)
+
+
+def test_partially_filled_position_still_centered_uniformly():
+    """Even if a position has fewer than 3 ALT scores, the (V-1) divisor stays.
+
+    Upstream uses `sum/(V-1)` regardless of how many cells are filled — it doesn't
+    re-divide by the number of filled entries. Lock that in.
+    """
+    interval = Interval(chromosome='chr1', start=100, end=101)
+    variants = [Variant('chr1', 101, 'A', 'C'), Variant('chr1', 101, 'A', 'G')]  # missing A->T
+    scores = [3.0, 6.0]
+
+    matrix = _ism_matrix(scores, variants, interval, multiply_by_sequence=False).numpy()
+
+    # sum = 0+3+6+0 = 9; subtract 9/3 = 3 from each cell.
+    # ACGT -> [A=-3, C=0, G=3, T=-3]
+    assert np.allclose(matrix[0], [-3.0, 0.0, 3.0, -3.0])
+
+
+def test_skips_non_snv_and_oob_variants():
+    """Indels and out-of-interval variants are silently ignored, matching prior behavior."""
+    interval = Interval(chromosome='chr1', start=100, end=102)
+    variants = [
+        Variant('chr1', 101, 'A', 'C'),  # in-interval SNV
+        Variant('chr1', 101, 'A', 'CG'),  # insertion: skipped
+        Variant('chr1', 200, 'A', 'C'),  # out of interval: skipped
+    ]
+    scores = [2.0, 99.0, 99.0]
+
+    matrix = _ism_matrix(scores, variants, interval, multiply_by_sequence=False).numpy()
+
+    # Only the first variant counted: position 0, sum = 2, subtract 2/3 from each cell.
+    assert np.allclose(matrix[0], [-2.0 / 3, 2.0 - 2.0 / 3, -2.0 / 3, -2.0 / 3])
+    # Position 1 untouched: all zero.
+    assert np.allclose(matrix[1], [0.0, 0.0, 0.0, 0.0])


### PR DESCRIPTION
## Summary
- The per-position loop in `VariantScoringModel.ism_matrix` subtracted `mean(filled)/3 = sum/9` instead of upstream's `sum/(V-1) = sum/3`, producing matrices with 1/3 the correct magnitude. Replace with the vectorised upstream form.
- Correct the `multiply_by_sequence` docstring (code was already correct: `~filled` zeros ALT columns and keeps REF, not the reverse).
- Extract the matrix logic into a module-level `_ism_matrix` helper so it can be unit-tested without a model checkpoint.