### PR TITLE
Decouple serving adapter and add serving attribution endpoint

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ PyTorch implementation of the `AlphaGenome DNA sequence-to-function model <https
    named_outputs
    full_chromosome_prediction
    cli
+   serving/index
    performance
    finetuning/index
    api/index

--- a/docs/serving/rest.rst
+++ b/docs/serving/rest.rst
@@ -129,7 +129,8 @@ Request fields
      - Organism identifier (default ``"HOMO_SAPIENS"``).
    * - ``reduction``
      -
-     - Window reduction: ``"sum"`` (default), ``"mean"``, or ``"peak"``.
+     - Window reduction: ``"sum"`` (default), ``"mean"``, or ``"max"``.
+       (``"max"`` suits gradient saliency; ``"sum"``/``"mean"`` suit ISM.)
    * - ``include_raw_gradient``
      -
      - If ``true``, include the full ``(W, 4, T)`` gradient tensor. Only

--- a/docs/serving/rest.rst
+++ b/docs/serving/rest.rst
@@ -42,6 +42,7 @@ Endpoints
 - ``POST /v1/score_variant``
 - ``POST /v1/score_variants``
 - ``POST /v1/score_ism_variants``
+- ``POST /v1/explain_interval``
 - ``GET /v1/output_metadata?organism=HOMO_SAPIENS``
 
 Example ``POST`` Request
@@ -80,3 +81,153 @@ Example ``GET`` Request
 .. code-block:: bash
 
    curl -s "http://127.0.0.1:8080/v1/output_metadata?organism=HOMO_SAPIENS"
+
+``/v1/explain_interval`` — Nucleotide Attribution
+--------------------------------------------------
+
+This endpoint computes per-nucleotide attribution scores for a target window
+inside a genomic interval. Two methods are supported:
+
+- **input_x_gradient** — gradient × input projection (one forward + backward
+  per track; always runs in fp32).
+- **saturation_ism** — saturation in-silico mutagenesis (batched forward passes
+  mutating every position to every alternate base).
+
+Request fields
+~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 25 10 65
+   :header-rows: 1
+
+   * - Field
+     - Required
+     - Description
+   * - ``interval``
+     - ✓
+     - Full input interval (must be a supported sequence length: 16 384,
+       131 072, 524 288, or 1 048 576 bp). Object with ``chromosome``,
+       ``start``, ``end``.
+   * - ``target_interval``
+     - ✓
+     - Sub-interval to attribute over — must be contained within
+       ``interval``. Same object shape.
+   * - ``requested_output``
+     - ✓
+     - Head name (e.g. ``"dnase"``, ``"atac"``, ``"cage"``).
+   * - ``resolution``
+     - ✓
+     - Output resolution in bp (``1`` or ``128``).
+   * - ``track_indices``
+     - ✓
+     - List of track indices to attribute (e.g. ``[0]``).
+   * - ``method``
+     - ✓
+     - ``"input_x_gradient"`` or ``"saturation_ism"``.
+   * - ``organism``
+     -
+     - Organism identifier (default ``"HOMO_SAPIENS"``).
+   * - ``reduction``
+     -
+     - Window reduction: ``"sum"`` (default), ``"mean"``, or ``"peak"``.
+   * - ``include_raw_gradient``
+     -
+     - If ``true``, include the full ``(W, 4, T)`` gradient tensor. Only
+       valid for gradient methods.
+   * - ``strand_averaged``
+     -
+     - If ``true``, average forward and reverse-complement attributions.
+   * - ``batch_size``
+     -
+     - Batch size for the ISM mutation loop (default ``8``).
+
+Response
+~~~~~~~~
+
+The response wraps an ``attribution`` object:
+
+.. code-block:: json
+
+   {
+     "attribution": {
+       "method": "input_x_gradient",
+       "kind": "base_matrix",
+       "bases": ["A", "C", "G", "T"],
+       "values": [[[0.12], [null], [null], [null]], ...],
+       "sequence": "AAAC...",
+       "target_start": 100,
+       "target_end": 200,
+       "resolution": 1,
+       "track_indices": [0],
+       "reduction": "sum",
+       "raw_gradient": null,
+       "metadata": {"strand_averaged": false}
+     }
+   }
+
+``values`` has shape ``(W, 4, T)`` where ``W = target_end - target_start``
+(in bp), ``4`` is the base axis (A, C, G, T), and ``T`` is the number of
+requested tracks.
+
+- For **gradient** methods, only the reference-base cell is filled; all other
+  base cells are ``null``.
+- For **ISM**, only the mutated cells are filled (the reference-base column is
+  ``null``).
+- Positions with ``N`` in the reference are all-``null``.
+
+Example: gradient × input
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   import json
+   import urllib.request
+
+   payload = {
+       "interval": {"chromosome": "chr12", "start": 7654368, "end": 7785440},
+       "target_interval": {"chromosome": "chr12", "start": 7720000, "end": 7720512},
+       "organism": "HOMO_SAPIENS",
+       "requested_output": "dnase",
+       "resolution": 1,
+       "track_indices": [0],
+       "method": "input_x_gradient",
+       "reduction": "sum",
+   }
+
+   req = urllib.request.Request(
+       "http://127.0.0.1:8080/v1/explain_interval",
+       data=json.dumps(payload).encode("utf-8"),
+       headers={"Content-Type": "application/json"},
+       method="POST",
+   )
+
+   with urllib.request.urlopen(req, timeout=600) as resp:
+       data = json.loads(resp.read().decode("utf-8"))
+
+   attr = data["attribution"]
+   print("method:", attr["method"])      # input_x_gradient
+   print("shape:", len(attr["values"]),   # 512 positions
+         len(attr["values"][0]),           # 4 bases
+         len(attr["values"][0][0]))        # 1 track
+
+Example: saturation ISM
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+   payload = {
+       "interval": {"chromosome": "chr12", "start": 7654368, "end": 7785440},
+       "target_interval": {"chromosome": "chr12", "start": 7720000, "end": 7720064},
+       "requested_output": "dnase",
+       "resolution": 1,
+       "track_indices": [0],
+       "method": "saturation_ism",
+       "batch_size": 16,
+   }
+
+   # ... same request pattern as above ...
+
+   # ISM reference-base cells are null; mutated cells have deltas
+   attr = data["attribution"]
+   print("method:", attr["method"])      # saturation_ism
+

--- a/src/alphagenome_pytorch/cli/serve.py
+++ b/src/alphagenome_pytorch/cli/serve.py
@@ -23,7 +23,13 @@ def register(subparsers: argparse._SubParsersAction) -> None:
     )
 
     p.add_argument("--weights", required=True,
-                   help="Path to AlphaGenome PyTorch weights file.")
+                   help="Path to AlphaGenome PyTorch weights file. With --checkpoint, this is the base/pretrained weights path.")
+    p.add_argument("--checkpoint", default=None,
+                   help="Optional fine-tuned checkpoint to serve for raw predictions.")
+    p.add_argument("--transfer-config", default=None,
+                   help="Optional TransferConfig JSON for older fine-tuned checkpoints.")
+    p.add_argument("--no-merge-adapters", action="store_true",
+                   help="Keep fine-tuned adapter modules separate instead of merging.")
     p.add_argument("--fasta", required=True,
                    help="Path to reference FASTA file.")
     p.add_argument("--gtf", default=None,

--- a/src/alphagenome_pytorch/extensions/attribution/__init__.py
+++ b/src/alphagenome_pytorch/extensions/attribution/__init__.py
@@ -1,0 +1,39 @@
+"""Nucleotide attribution methods for AlphaGenome models.
+
+Pure-Torch attribution primitives (gradient x input, saturation ISM) and a
+small method registry for wiring them into serving / scripts. No dependency
+on variant scoring, FASTA, or REST.
+
+Example:
+    >>> from alphagenome_pytorch.extensions.attribution import (
+    ...     gradient_x_input, saturation_ism, default_head_selector,
+    ... )
+    >>> scores = gradient_x_input(
+    ...     model, onehot=onehot, organism_index=0,
+    ...     head_selector=default_head_selector,
+    ...     output_type='dnase', resolution=1,
+    ...     target_slice=slice(1000, 2000),
+    ...     track_indices=[0, 5, 17], reduction='sum',
+    ... )
+"""
+
+from .gradient import gradient_x_input
+from .heads import HeadSelector, default_head_selector
+from .ism import saturation_ism
+from .registry import METHODS, MethodSpec, UnsupportedMethodError, get_method
+from .types import AttributionResult
+from .window import reduce_window, target_slice_for_resolution
+
+__all__ = [
+    "AttributionResult",
+    "HeadSelector",
+    "METHODS",
+    "MethodSpec",
+    "UnsupportedMethodError",
+    "default_head_selector",
+    "get_method",
+    "gradient_x_input",
+    "reduce_window",
+    "saturation_ism",
+    "target_slice_for_resolution",
+]

--- a/src/alphagenome_pytorch/extensions/attribution/gradient.py
+++ b/src/alphagenome_pytorch/extensions/attribution/gradient.py
@@ -1,0 +1,205 @@
+"""Input-gradient nucleotide attribution.
+
+Lifted (and generalized) from ``scripts/ism_locus.py:_gradient_attribution``.
+Always runs in fp32: the per-track loss surface is small, gradient stability
+matters, and the original script's comment explicitly notes "gradient
+deliberately uses fp32".
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import torch
+from torch import nn
+
+from .heads import HeadSelector, default_head_selector
+from .types import BASES, AttributionResult
+from .window import reduce_window
+
+
+# Order: A, C, G, T -> complement T, G, C, A -> indices [3, 2, 1, 0].
+_RC_BASE_PERM = (3, 2, 1, 0)
+
+
+def _reverse_complement_onehot(onehot: torch.Tensor) -> torch.Tensor:
+    """Reverse-complement a one-hot tensor of shape ``(B, L, 4)``.
+
+    Reverses the position axis and swaps base channels A<->T, C<->G.
+    """
+    return onehot.flip(dims=(1,))[..., list(_RC_BASE_PERM)]
+
+
+def _align_rc_to_forward(values: np.ndarray) -> np.ndarray:
+    """Flip RC-frame ``(W, 4, T)`` attribution back to forward coordinates.
+
+    Reverses the position axis and inverts the base-channel permutation
+    (A<->T, C<->G).
+    """
+    return values[::-1, list(_RC_BASE_PERM), :].copy()
+
+
+def _gradient_pass(
+    model: nn.Module,
+    onehot: torch.Tensor,
+    organism_index: torch.Tensor,
+    *,
+    head_selector: HeadSelector,
+    output_type: str,
+    resolution: int,
+    target_slice: slice,
+    track_indices: Sequence[int],
+    reduction: str,
+) -> np.ndarray:
+    """Single-direction (no RC) gradient pass.
+
+    Returns ``(W, 4, T)`` raw input gradient ``dL/dx`` evaluated over the
+    target window, where W = ``target_slice.stop - target_slice.start`` in
+    *input* positions.
+    """
+    L = onehot.shape[1]
+    T = len(track_indices)
+    target_lo_bp = target_slice.start * resolution
+    target_hi_bp = target_slice.stop * resolution
+    W = target_hi_bp - target_lo_bp
+
+    raw_grad = np.zeros((W, 4, T), dtype=np.float32)
+
+    for t_i, track_idx in enumerate(track_indices):
+        x = onehot.clone().detach().float().requires_grad_(True)
+        pred = head_selector(
+            model, x, organism_index,
+            output_type=output_type, resolution=resolution,
+        )  # (1, T_bins, n_tracks)
+        window_pred = pred[:, target_slice, track_idx]  # (1, W_bins)
+        scalar = reduce_window(window_pred.unsqueeze(-1), reduction).squeeze()
+        if scalar.dim() != 0:
+            raise RuntimeError(
+                f"Reduction returned non-scalar tensor of shape {tuple(scalar.shape)}; "
+                "gradient attribution expects a single scalar per track."
+            )
+        scalar.backward()
+        if x.grad is None:
+            raise RuntimeError(
+                "Backward did not populate input gradients. The model may have "
+                "detached the input or run under torch.no_grad()."
+            )
+        g = x.grad.detach().float().cpu().numpy()[0]  # (L, 4)
+        raw_grad[:, :, t_i] = g[target_lo_bp:target_hi_bp]
+        model.zero_grad(set_to_none=True)
+
+    _ = L  # silence unused-warning in tooling that flags it; L is implicit above.
+    return raw_grad
+
+
+def gradient_x_input(
+    model: nn.Module,
+    *,
+    onehot: torch.Tensor,
+    organism_index: int,
+    output_type: str,
+    resolution: int,
+    target_slice: slice,
+    track_indices: Sequence[int],
+    reduction: str = "sum",
+    include_raw_gradient: bool = False,
+    strand_averaged: bool = False,
+    head_selector: HeadSelector = default_head_selector,
+    sequence: str = "",
+    target_start: int = 0,
+    target_end: int = 0,
+) -> AttributionResult:
+    """Gradient x input attribution.
+
+    Args:
+        model: The model. Must be on the same device as ``onehot``.
+        onehot: Reference one-hot tensor of shape ``(1, L, 4)``.
+        organism_index: 0 (human) or 1 (mouse).
+        output_type: Head name (e.g. ``"dnase"``).
+        resolution: Output resolution in bp (1 or 128).
+        target_slice: Resolution-bin slice covering the target window.
+        track_indices: Tracks to attribute.
+        reduction: Window reduction passed to :func:`reduce_window`.
+        include_raw_gradient: If True, also include ``raw_gradient`` of shape
+            ``(W, 4, T)`` on the result.
+        strand_averaged: If True, run a second forward+backward on the
+            reverse-complement input and average the projected (and raw)
+            attributions. Doubles compute. Recommended only for unstranded heads.
+        head_selector: Strategy for forward + head extraction. Defaults to the
+            base AlphaGenome path.
+        sequence: Optional reference sequence for the result; passed through to
+            the dataclass for downstream serialization.
+        target_start, target_end: Absolute genomic coordinates of the target
+            window; passed through.
+
+    Returns:
+        AttributionResult with ``kind == "base_matrix"``. ``values[w, b, t]``
+        is the projected attribution at position ``w`` for the reference base;
+        all non-reference base cells are NaN. If ``include_raw_gradient``, the
+        full ``(W, 4, T)`` gradient (with all four base columns filled) is
+        attached as ``raw_gradient``.
+    """
+    if onehot.dim() != 3 or onehot.shape[0] != 1 or onehot.shape[2] != 4:
+        raise ValueError(
+            f"onehot must have shape (1, L, 4); got {tuple(onehot.shape)}."
+        )
+    if reduction not in ("sum", "mean", "peak"):
+        raise ValueError(f"Unknown reduction {reduction!r}.")
+
+    L = onehot.shape[1]
+    device = onehot.device
+    organism_t = torch.tensor([int(organism_index)], dtype=torch.long, device=device)
+
+    raw_fwd = _gradient_pass(
+        model, onehot.float(), organism_t,
+        head_selector=head_selector,
+        output_type=output_type, resolution=resolution,
+        target_slice=target_slice, track_indices=track_indices,
+        reduction=reduction,
+    )
+
+    if strand_averaged:
+        rc_onehot = _reverse_complement_onehot(onehot.float())
+        # Flip target window into RC coordinates (in resolution bins).
+        L_bins = L // resolution
+        rc_target_slice = slice(L_bins - target_slice.stop, L_bins - target_slice.start)
+        raw_rc = _gradient_pass(
+            model, rc_onehot, organism_t,
+            head_selector=head_selector,
+            output_type=output_type, resolution=resolution,
+            target_slice=rc_target_slice, track_indices=track_indices,
+            reduction=reduction,
+        )
+        raw_grad = 0.5 * (raw_fwd + _align_rc_to_forward(raw_rc))
+    else:
+        raw_grad = raw_fwd
+
+    # Project onto reference base: (raw_grad * input).sum(base) gives a per-position
+    # scalar per track. To stay shape-compatible with the (W, 4, T) "base_matrix"
+    # convention used by ISM, we encode the projection into the reference-base cell
+    # and leave the others as NaN.
+    onehot_window = onehot[0, target_slice.start * resolution:target_slice.stop * resolution].cpu().numpy()  # (W, 4)
+    W, _, T = raw_grad.shape
+    values = np.full((W, 4, T), np.nan, dtype=np.float32)
+    ref_base_idx = onehot_window.argmax(axis=1)  # (W,)
+    has_ref = onehot_window.sum(axis=1) > 0.5  # False at N positions
+    proj = (raw_grad * onehot_window[:, :, None]).sum(axis=1)  # (W, T)
+    for w in range(W):
+        if has_ref[w]:
+            values[w, ref_base_idx[w], :] = proj[w]
+
+    return AttributionResult(
+        method="input_x_gradient",
+        kind="base_matrix",
+        bases=BASES,
+        values=values,
+        sequence=sequence,
+        target_start=target_start,
+        target_end=target_end,
+        resolution=resolution,
+        track_indices=tuple(int(i) for i in track_indices),
+        reduction=reduction,
+        raw_gradient=raw_grad if include_raw_gradient else None,
+        metadata={"strand_averaged": bool(strand_averaged)},
+    )

--- a/src/alphagenome_pytorch/extensions/attribution/gradient.py
+++ b/src/alphagenome_pytorch/extensions/attribution/gradient.py
@@ -127,7 +127,8 @@ def gradient_x_input(
             reverse-complement input and average the projected (and raw)
             attributions. Doubles compute. Recommended only for unstranded heads.
         head_selector: Strategy for forward + head extraction. Defaults to the
-            base AlphaGenome path.
+            AlphaGenome-compatible forward path used by base, adapter-backed,
+            and fine-tuned models.
         sequence: Optional reference sequence for the result; passed through to
             the dataclass for downstream serialization.
         target_start, target_end: Absolute genomic coordinates of the target

--- a/src/alphagenome_pytorch/extensions/attribution/gradient.py
+++ b/src/alphagenome_pytorch/extensions/attribution/gradient.py
@@ -8,7 +8,8 @@ deliberately uses fp32".
 
 from __future__ import annotations
 
-from typing import Sequence
+import warnings
+from typing import Callable, Sequence
 
 import numpy as np
 import torch
@@ -40,6 +41,41 @@ def _align_rc_to_forward(values: np.ndarray) -> np.ndarray:
     return values[::-1, list(_RC_BASE_PERM), :].copy()
 
 
+def strand_average(
+    forward: np.ndarray,
+    run_pass: "Callable[[torch.Tensor, slice], np.ndarray]",
+    *,
+    onehot: torch.Tensor,
+    target_slice: slice,
+    resolution: int,
+) -> np.ndarray:
+    """Average a forward-strand attribution with its reverse-complement.
+
+    ``run_pass(input_onehot, slice_)`` runs a single-direction attribution pass
+    and returns a ``(W, 4, T)`` array. This helper runs it once more on the
+    reverse-complemented input over the RC-flipped target window, maps the
+    result back to forward coordinates, and combines it with ``forward`` via
+    elementwise ``nanmean`` — cells that are NaN on both strands (e.g. N
+    positions, or the non-reference cells of an ISM matrix) stay NaN.
+
+    Shared by gradient and ISM attribution so the RC-coordinate math lives in
+    one place.
+    """
+    rc_onehot = _reverse_complement_onehot(onehot)
+    L_bins = onehot.shape[1] // resolution
+    rc_slice = slice(L_bins - target_slice.stop, L_bins - target_slice.start)
+    rc = _align_rc_to_forward(run_pass(rc_onehot, rc_slice))
+
+    stacked = np.stack([forward, rc], axis=0)
+    both_nan = np.isnan(forward) & np.isnan(rc)
+    with warnings.catch_warnings():
+        # All-NaN cells warn ("Mean of empty slice"); we overwrite them below.
+        warnings.simplefilter("ignore", RuntimeWarning)
+        averaged = np.nanmean(stacked, axis=0).astype(np.float32)
+    averaged[both_nan] = np.nan
+    return averaged
+
+
 def _gradient_pass(
     model: nn.Module,
     onehot: torch.Tensor,
@@ -58,7 +94,6 @@ def _gradient_pass(
     target window, where W = ``target_slice.stop - target_slice.start`` in
     *input* positions.
     """
-    L = onehot.shape[1]
     T = len(track_indices)
     target_lo_bp = target_slice.start * resolution
     target_hi_bp = target_slice.stop * resolution
@@ -66,12 +101,18 @@ def _gradient_pass(
 
     raw_grad = np.zeros((W, 4, T), dtype=np.float32)
 
+    # The forward pass is identical for every track (same input, same model);
+    # only which track's window we reduce-and-backprop differs. Run it once and
+    # take one backward per track (a Jacobian row), retaining the graph between
+    # tracks and zeroing the input grad in between. Numerically identical to a
+    # per-track forward, but T forwards collapse to one.
+    x = onehot.clone().detach().float().requires_grad_(True)
+    pred = head_selector(
+        model, x, organism_index,
+        output_type=output_type, resolution=resolution,
+    )  # (1, T_bins, n_tracks)
+
     for t_i, track_idx in enumerate(track_indices):
-        x = onehot.clone().detach().float().requires_grad_(True)
-        pred = head_selector(
-            model, x, organism_index,
-            output_type=output_type, resolution=resolution,
-        )  # (1, T_bins, n_tracks)
         window_pred = pred[:, target_slice, track_idx]  # (1, W_bins)
         scalar = reduce_window(window_pred.unsqueeze(-1), reduction).squeeze()
         if scalar.dim() != 0:
@@ -79,7 +120,8 @@ def _gradient_pass(
                 f"Reduction returned non-scalar tensor of shape {tuple(scalar.shape)}; "
                 "gradient attribution expects a single scalar per track."
             )
-        scalar.backward()
+        x.grad = None  # discard the previous track's gradient before accumulating.
+        scalar.backward(retain_graph=t_i < T - 1)
         if x.grad is None:
             raise RuntimeError(
                 "Backward did not populate input gradients. The model may have "
@@ -87,9 +129,8 @@ def _gradient_pass(
             )
         g = x.grad.detach().float().cpu().numpy()[0]  # (L, 4)
         raw_grad[:, :, t_i] = g[target_lo_bp:target_hi_bp]
-        model.zero_grad(set_to_none=True)
 
-    _ = L  # silence unused-warning in tooling that flags it; L is implicit above.
+    model.zero_grad(set_to_none=True)
     return raw_grad
 
 
@@ -145,34 +186,27 @@ def gradient_x_input(
         raise ValueError(
             f"onehot must have shape (1, L, 4); got {tuple(onehot.shape)}."
         )
-    if reduction not in ("sum", "mean", "peak"):
+    if reduction not in ("sum", "mean", "max"):
         raise ValueError(f"Unknown reduction {reduction!r}.")
 
-    L = onehot.shape[1]
     device = onehot.device
     organism_t = torch.tensor([int(organism_index)], dtype=torch.long, device=device)
 
-    raw_fwd = _gradient_pass(
-        model, onehot.float(), organism_t,
-        head_selector=head_selector,
-        output_type=output_type, resolution=resolution,
-        target_slice=target_slice, track_indices=track_indices,
-        reduction=reduction,
-    )
-
-    if strand_averaged:
-        rc_onehot = _reverse_complement_onehot(onehot.float())
-        # Flip target window into RC coordinates (in resolution bins).
-        L_bins = L // resolution
-        rc_target_slice = slice(L_bins - target_slice.stop, L_bins - target_slice.start)
-        raw_rc = _gradient_pass(
-            model, rc_onehot, organism_t,
+    def run_pass(input_onehot: torch.Tensor, slice_: slice) -> np.ndarray:
+        return _gradient_pass(
+            model, input_onehot, organism_t,
             head_selector=head_selector,
             output_type=output_type, resolution=resolution,
-            target_slice=rc_target_slice, track_indices=track_indices,
+            target_slice=slice_, track_indices=track_indices,
             reduction=reduction,
         )
-        raw_grad = 0.5 * (raw_fwd + _align_rc_to_forward(raw_rc))
+
+    raw_fwd = run_pass(onehot.float(), target_slice)
+    if strand_averaged:
+        raw_grad = strand_average(
+            raw_fwd, run_pass,
+            onehot=onehot.float(), target_slice=target_slice, resolution=resolution,
+        )
     else:
         raw_grad = raw_fwd
 

--- a/src/alphagenome_pytorch/extensions/attribution/heads.py
+++ b/src/alphagenome_pytorch/extensions/attribution/heads.py
@@ -1,0 +1,67 @@
+"""Head selection strategy for attribution.
+
+Attribution methods need a thin abstraction over "run the model and give me
+``(B, T_bins, n_tracks)`` for the requested head + resolution." Both the base
+pretrained AlphaGenome and a fine-tuned variant share this signature, so a
+single default selector works for both — it just calls ``model.forward`` with
+``heads=`` and ``resolutions=`` filters and indexes the result.
+
+Callers can pass a custom ``HeadSelector`` for non-standard wrapping.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import torch
+from torch import nn
+
+
+class HeadSelector(Protocol):
+    """Strategy: forward pass + extract per-resolution prediction tensor."""
+
+    def __call__(
+        self,
+        model: nn.Module,
+        onehot: torch.Tensor,
+        organism_index: torch.Tensor,
+        *,
+        output_type: str,
+        resolution: int,
+    ) -> torch.Tensor:  # (B, T_bins, n_tracks), channels_last
+        ...
+
+
+def default_head_selector(
+    model: nn.Module,
+    onehot: torch.Tensor,
+    organism_index: torch.Tensor,
+    *,
+    output_type: str,
+    resolution: int,
+) -> torch.Tensor:
+    """Run AlphaGenome.forward filtered to one head and resolution.
+
+    Returns predictions in experimental space (``return_scaled_predictions=False``)
+    in NLC layout, matching what ``GenomeTracksHead`` produces by default.
+    """
+    outputs = model(
+        onehot,
+        organism_index,
+        heads=(output_type,),
+        resolutions=(resolution,),
+        channels_last=True,
+        return_scaled_predictions=False,
+    )
+    if output_type not in outputs:
+        raise KeyError(
+            f"Model did not produce head {output_type!r}. "
+            f"Available heads: {sorted(outputs.keys())}."
+        )
+    head_outputs = outputs[output_type]
+    if resolution not in head_outputs:
+        raise KeyError(
+            f"Head {output_type!r} did not produce resolution {resolution}. "
+            f"Available: {sorted(head_outputs.keys())}."
+        )
+    return head_outputs[resolution]

--- a/src/alphagenome_pytorch/extensions/attribution/heads.py
+++ b/src/alphagenome_pytorch/extensions/attribution/heads.py
@@ -1,10 +1,10 @@
 """Head selection strategy for attribution.
 
 Attribution methods need a thin abstraction over "run the model and give me
-``(B, T_bins, n_tracks)`` for the requested head + resolution." Both the base
-pretrained AlphaGenome and a fine-tuned variant share this signature, so a
-single default selector works for both — it just calls ``model.forward`` with
-``heads=`` and ``resolutions=`` filters and indexes the result.
+``(B, T_bins, n_tracks)`` for the requested head + resolution." Base,
+adapter-backed, and fine-tuned AlphaGenome models share this public forward
+contract, so a single default selector works for all of them. Adapters are an
+internal implementation detail of the model trunk, not a separate serving API.
 
 Callers can pass a custom ``HeadSelector`` for non-standard wrapping.
 """
@@ -40,7 +40,7 @@ def default_head_selector(
     output_type: str,
     resolution: int,
 ) -> torch.Tensor:
-    """Run AlphaGenome.forward filtered to one head and resolution.
+    """Run an AlphaGenome-compatible forward pass for one head/resolution.
 
     Returns predictions in experimental space (``return_scaled_predictions=False``)
     in NLC layout, matching what ``GenomeTracksHead`` produces by default.

--- a/src/alphagenome_pytorch/extensions/attribution/ism.py
+++ b/src/alphagenome_pytorch/extensions/attribution/ism.py
@@ -14,7 +14,7 @@ import numpy as np
 import torch
 from torch import nn
 
-from .gradient import _align_rc_to_forward, _reverse_complement_onehot
+from .gradient import strand_average
 from .heads import HeadSelector, default_head_selector
 from .types import BASES, AttributionResult
 from .window import reduce_window
@@ -37,7 +37,6 @@ def _ism_pass(
     """Single-direction saturation ISM. Returns ``(W, 4, T)`` with NaN at
     reference-base cells and at N positions.
     """
-    L = onehot.shape[1]
     target_lo_bp = target_slice.start * resolution
     target_hi_bp = target_slice.stop * resolution
     W = target_hi_bp - target_lo_bp
@@ -111,7 +110,6 @@ def _ism_pass(
         for i, (p, alt_b) in enumerate(chunk):
             values[p, alt_b, :] = alt_scalar[i] - ref_scalar
 
-    _ = L  # variable referenced for clarity; not used downstream.
     return values
 
 
@@ -138,44 +136,30 @@ def saturation_ism(
         raise ValueError(
             f"onehot must have shape (1, L, 4); got {tuple(onehot.shape)}."
         )
-    if reduction not in ("sum", "mean", "peak"):
+    if reduction not in ("sum", "mean", "max"):
         raise ValueError(f"Unknown reduction {reduction!r}.")
     if batch_size < 1:
         raise ValueError("batch_size must be >= 1.")
 
-    L = onehot.shape[1]
     device = onehot.device
     organism_t = torch.tensor([int(organism_index)], dtype=torch.long, device=device)
 
-    fwd = _ism_pass(
-        model, onehot, organism_t,
-        head_selector=head_selector,
-        output_type=output_type, resolution=resolution,
-        target_slice=target_slice, track_indices=track_indices,
-        reduction=reduction, batch_size=batch_size,
-        autocast_dtype=autocast_dtype,
-    )
-
-    if strand_averaged:
-        rc_onehot = _reverse_complement_onehot(onehot)
-        L_bins = L // resolution
-        rc_target_slice = slice(L_bins - target_slice.stop, L_bins - target_slice.start)
-        rc = _ism_pass(
-            model, rc_onehot, organism_t,
+    def run_pass(input_onehot: torch.Tensor, slice_: slice) -> np.ndarray:
+        return _ism_pass(
+            model, input_onehot, organism_t,
             head_selector=head_selector,
             output_type=output_type, resolution=resolution,
-            target_slice=rc_target_slice, track_indices=track_indices,
+            target_slice=slice_, track_indices=track_indices,
             reduction=reduction, batch_size=batch_size,
             autocast_dtype=autocast_dtype,
         )
-        rc_aligned = _align_rc_to_forward(rc)
-        # nanmean elementwise: where one side is NaN (ref or N), keep the other.
-        stacked = np.stack([fwd, rc_aligned], axis=0)
-        with np.errstate(invalid="ignore"):
-            values = np.nanmean(stacked, axis=0).astype(np.float32)
-        # Restore NaN rows where BOTH inputs were NaN (e.g. N positions).
-        all_nan = np.isnan(fwd) & np.isnan(rc_aligned)
-        values[all_nan] = np.nan
+
+    fwd = run_pass(onehot, target_slice)
+    if strand_averaged:
+        values = strand_average(
+            fwd, run_pass,
+            onehot=onehot, target_slice=target_slice, resolution=resolution,
+        )
     else:
         values = fwd
 

--- a/src/alphagenome_pytorch/extensions/attribution/ism.py
+++ b/src/alphagenome_pytorch/extensions/attribution/ism.py
@@ -1,0 +1,195 @@
+"""Saturation in-silico mutagenesis (ISM) attribution.
+
+Lifted from ``scripts/ism_locus.py:_saturation_ism``, generalized to any
+``HeadSelector``. Returns a JSON-friendly ``(W, 4, T)`` matrix in which the
+reference-base column is NaN and all other cells hold the score delta vs. the
+unmutated reference.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import torch
+from torch import nn
+
+from .gradient import _align_rc_to_forward, _reverse_complement_onehot
+from .heads import HeadSelector, default_head_selector
+from .types import BASES, AttributionResult
+from .window import reduce_window
+
+
+def _ism_pass(
+    model: nn.Module,
+    onehot: torch.Tensor,
+    organism_index: torch.Tensor,
+    *,
+    head_selector: HeadSelector,
+    output_type: str,
+    resolution: int,
+    target_slice: slice,
+    track_indices: Sequence[int],
+    reduction: str,
+    batch_size: int,
+    autocast_dtype: torch.dtype | None,
+) -> np.ndarray:
+    """Single-direction saturation ISM. Returns ``(W, 4, T)`` with NaN at
+    reference-base cells and at N positions.
+    """
+    L = onehot.shape[1]
+    target_lo_bp = target_slice.start * resolution
+    target_hi_bp = target_slice.stop * resolution
+    W = target_hi_bp - target_lo_bp
+    T = len(track_indices)
+    device = onehot.device
+
+    values = np.full((W, 4, T), np.nan, dtype=np.float32)
+
+    onehot_np = onehot[0].detach().float().cpu().numpy()  # (L, 4)
+    is_ref = onehot_np.sum(axis=1) > 0.5
+    ref_idx = onehot_np.argmax(axis=1)  # 0..3 (meaningless when not is_ref)
+
+    # Reference scalar per track.
+    with torch.no_grad():
+        if autocast_dtype is not None and device.type == "cuda":
+            with torch.autocast(device_type="cuda", dtype=autocast_dtype):
+                ref_pred = head_selector(
+                    model, onehot, organism_index,
+                    output_type=output_type, resolution=resolution,
+                )
+        else:
+            ref_pred = head_selector(
+                model, onehot, organism_index,
+                output_type=output_type, resolution=resolution,
+            )
+    ref_window = ref_pred[:, target_slice, :][:, :, list(track_indices)]
+    ref_scalar = reduce_window(ref_window, reduction).float().cpu().numpy()[0]  # (T,)
+
+    # Build mutation plan: (pos_in_window, alt_base) for each non-ref non-N cell.
+    plan: list[tuple[int, int]] = []
+    for p in range(W):
+        L_pos = target_lo_bp + p
+        if not is_ref[L_pos]:
+            continue  # N position: leave row as NaN.
+        ref_b = int(ref_idx[L_pos])
+        for alt_b in range(4):
+            if alt_b == ref_b:
+                continue
+            plan.append((p, alt_b))
+
+    if not plan:
+        return values
+
+    track_idx_list = list(track_indices)
+
+    for bstart in range(0, len(plan), batch_size):
+        chunk = plan[bstart:bstart + batch_size]
+        B = len(chunk)
+        batch = onehot.repeat(B, 1, 1).contiguous().float()
+        for i, (p, alt_b) in enumerate(chunk):
+            L_pos = target_lo_bp + p
+            batch[i, L_pos, :] = 0.0
+            batch[i, L_pos, alt_b] = 1.0
+        batch_org = organism_index.expand(B).contiguous()
+
+        with torch.no_grad():
+            if autocast_dtype is not None and device.type == "cuda":
+                with torch.autocast(device_type="cuda", dtype=autocast_dtype):
+                    pred = head_selector(
+                        model, batch, batch_org,
+                        output_type=output_type, resolution=resolution,
+                    )
+            else:
+                pred = head_selector(
+                    model, batch, batch_org,
+                    output_type=output_type, resolution=resolution,
+                )
+        alt_window = pred[:, target_slice, :][:, :, track_idx_list]
+        alt_scalar = reduce_window(alt_window, reduction).float().cpu().numpy()  # (B, T)
+
+        for i, (p, alt_b) in enumerate(chunk):
+            values[p, alt_b, :] = alt_scalar[i] - ref_scalar
+
+    _ = L  # variable referenced for clarity; not used downstream.
+    return values
+
+
+def saturation_ism(
+    model: nn.Module,
+    *,
+    onehot: torch.Tensor,
+    organism_index: int,
+    output_type: str,
+    resolution: int,
+    target_slice: slice,
+    track_indices: Sequence[int],
+    reduction: str = "sum",
+    batch_size: int = 8,
+    strand_averaged: bool = False,
+    autocast_dtype: torch.dtype | None = None,
+    head_selector: HeadSelector = default_head_selector,
+    sequence: str = "",
+    target_start: int = 0,
+    target_end: int = 0,
+) -> AttributionResult:
+    """Saturation ISM. Returns ``(W, 4, T)`` deltas vs. reference."""
+    if onehot.dim() != 3 or onehot.shape[0] != 1 or onehot.shape[2] != 4:
+        raise ValueError(
+            f"onehot must have shape (1, L, 4); got {tuple(onehot.shape)}."
+        )
+    if reduction not in ("sum", "mean", "peak"):
+        raise ValueError(f"Unknown reduction {reduction!r}.")
+    if batch_size < 1:
+        raise ValueError("batch_size must be >= 1.")
+
+    L = onehot.shape[1]
+    device = onehot.device
+    organism_t = torch.tensor([int(organism_index)], dtype=torch.long, device=device)
+
+    fwd = _ism_pass(
+        model, onehot, organism_t,
+        head_selector=head_selector,
+        output_type=output_type, resolution=resolution,
+        target_slice=target_slice, track_indices=track_indices,
+        reduction=reduction, batch_size=batch_size,
+        autocast_dtype=autocast_dtype,
+    )
+
+    if strand_averaged:
+        rc_onehot = _reverse_complement_onehot(onehot)
+        L_bins = L // resolution
+        rc_target_slice = slice(L_bins - target_slice.stop, L_bins - target_slice.start)
+        rc = _ism_pass(
+            model, rc_onehot, organism_t,
+            head_selector=head_selector,
+            output_type=output_type, resolution=resolution,
+            target_slice=rc_target_slice, track_indices=track_indices,
+            reduction=reduction, batch_size=batch_size,
+            autocast_dtype=autocast_dtype,
+        )
+        rc_aligned = _align_rc_to_forward(rc)
+        # nanmean elementwise: where one side is NaN (ref or N), keep the other.
+        stacked = np.stack([fwd, rc_aligned], axis=0)
+        with np.errstate(invalid="ignore"):
+            values = np.nanmean(stacked, axis=0).astype(np.float32)
+        # Restore NaN rows where BOTH inputs were NaN (e.g. N positions).
+        all_nan = np.isnan(fwd) & np.isnan(rc_aligned)
+        values[all_nan] = np.nan
+    else:
+        values = fwd
+
+    return AttributionResult(
+        method="saturation_ism",
+        kind="base_matrix",
+        bases=BASES,
+        values=values,
+        sequence=sequence,
+        target_start=target_start,
+        target_end=target_end,
+        resolution=resolution,
+        track_indices=tuple(int(i) for i in track_indices),
+        reduction=reduction,
+        raw_gradient=None,
+        metadata={"strand_averaged": bool(strand_averaged)},
+    )

--- a/src/alphagenome_pytorch/extensions/attribution/registry.py
+++ b/src/alphagenome_pytorch/extensions/attribution/registry.py
@@ -1,0 +1,43 @@
+"""Registry of attribution methods.
+
+Adding a new method = one row here. Clients need not change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from .gradient import gradient_x_input
+from .ism import saturation_ism
+from .types import AttributionResult
+
+
+@dataclass(frozen=True)
+class MethodSpec:
+    func: Callable[..., AttributionResult]
+    kind: str  # discriminator carried into JSON, e.g. "base_matrix"
+    supports_raw_gradient: bool
+
+
+class UnsupportedMethodError(KeyError):
+    """Raised when the requested attribution method is not in the registry."""
+
+
+METHODS: dict[str, MethodSpec] = {
+    "input_x_gradient": MethodSpec(
+        func=gradient_x_input, kind="base_matrix", supports_raw_gradient=True,
+    ),
+    "saturation_ism": MethodSpec(
+        func=saturation_ism, kind="base_matrix", supports_raw_gradient=False,
+    ),
+}
+
+
+def get_method(name: str) -> MethodSpec:
+    if name not in METHODS:
+        raise UnsupportedMethodError(
+            f"Unknown attribution method {name!r}. "
+            f"Supported: {sorted(METHODS)}."
+        )
+    return METHODS[name]

--- a/src/alphagenome_pytorch/extensions/attribution/types.py
+++ b/src/alphagenome_pytorch/extensions/attribution/types.py
@@ -1,0 +1,47 @@
+"""Shared dataclasses for attribution results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import numpy as np
+
+
+BASES: tuple[str, ...] = ("A", "C", "G", "T")
+
+
+@dataclass
+class AttributionResult:
+    """Output of an attribution method.
+
+    Attributes:
+        method: Method name from the registry (e.g. ``"input_x_gradient"``).
+        kind: Score kind. ``"base_matrix"`` means ``values`` has shape
+            ``(W, 4, T)``. Future methods may emit other kinds.
+        bases: Base ordering for the second axis when ``kind == "base_matrix"``.
+        values: ``(W, 4, T)`` numpy array. For gradient methods, only the
+            reference-base column is filled (others are NaN). For ISM, only
+            the mutated cells are filled (the reference-base column is NaN).
+        sequence: One-letter DNA sequence covering the whole input interval.
+        target_start: Absolute genomic coordinate of the first reported base.
+        target_end: Absolute genomic coordinate just past the last reported base.
+        resolution: Resolution of the head used to compute the score.
+        track_indices: Indices selected from the head's track axis.
+        reduction: Reduction applied across the target window.
+        raw_gradient: Optional ``(W, 4, T)`` raw input gradient. Only set when
+            the caller requested it for a gradient-based method.
+    """
+
+    method: str
+    kind: str
+    bases: tuple[str, ...]
+    values: np.ndarray
+    sequence: str
+    target_start: int
+    target_end: int
+    resolution: int
+    track_indices: tuple[int, ...]
+    reduction: str
+    raw_gradient: Optional[np.ndarray] = None
+    metadata: dict = field(default_factory=dict)

--- a/src/alphagenome_pytorch/extensions/attribution/window.py
+++ b/src/alphagenome_pytorch/extensions/attribution/window.py
@@ -9,19 +9,20 @@ from __future__ import annotations
 import torch
 
 
-_REDUCTIONS = ("sum", "mean", "peak")
+_REDUCTIONS = ("sum", "mean", "max")
 
 
 def reduce_window(window_pred: torch.Tensor, reduction: str) -> torch.Tensor:
     """Reduce ``(B, W_bins, n_tracks)`` -> ``(B, n_tracks)``.
 
-    ``peak`` returns the per-track maximum across the window.
+    ``max`` returns the per-track maximum across the window bins.
+    It can be used e.g. for gradient saliency. 
     """
     if reduction == "sum":
         return window_pred.sum(dim=1)
     if reduction == "mean":
         return window_pred.mean(dim=1)
-    if reduction == "peak":
+    if reduction == "max":
         return window_pred.amax(dim=1)
     raise ValueError(
         f"Unknown reduction {reduction!r}. Expected one of {_REDUCTIONS}."

--- a/src/alphagenome_pytorch/extensions/attribution/window.py
+++ b/src/alphagenome_pytorch/extensions/attribution/window.py
@@ -1,0 +1,43 @@
+"""Target-window helpers for attribution methods.
+
+Lifted from ``scripts/ism_locus.py`` so the attribution library does not depend
+on the script.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+_REDUCTIONS = ("sum", "mean", "peak")
+
+
+def reduce_window(window_pred: torch.Tensor, reduction: str) -> torch.Tensor:
+    """Reduce ``(B, W_bins, n_tracks)`` -> ``(B, n_tracks)``.
+
+    ``peak`` returns the per-track maximum across the window.
+    """
+    if reduction == "sum":
+        return window_pred.sum(dim=1)
+    if reduction == "mean":
+        return window_pred.mean(dim=1)
+    if reduction == "peak":
+        return window_pred.amax(dim=1)
+    raise ValueError(
+        f"Unknown reduction {reduction!r}. Expected one of {_REDUCTIONS}."
+    )
+
+
+def target_slice_for_resolution(
+    interval_start: int,
+    target_start: int,
+    target_end: int,
+    resolution: int,
+) -> slice:
+    """Resolution-bin slice covering ``[target_start, target_end)``.
+
+    Bin alignment is the caller's responsibility — pass already-aligned offsets.
+    """
+    lo = (target_start - interval_start) // resolution
+    hi = (target_end - interval_start) // resolution
+    return slice(lo, hi)

--- a/src/alphagenome_pytorch/extensions/finetuning/datasets.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/datasets.py
@@ -93,7 +93,6 @@ class CachedGenome:
             fasta_path,
             chromosomes=chromosomes,
             cache=True,
-            ambiguous="zero",
         )
         self.chrom_sizes = self._source.chrom_sizes
         self._cache = self._source._cache

--- a/src/alphagenome_pytorch/extensions/finetuning/datasets.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/datasets.py
@@ -46,6 +46,7 @@ import numpy as np
 import torch
 from torch.utils.data import Dataset
 
+from alphagenome_pytorch.genome import GenomeSequenceSource
 from alphagenome_pytorch.utils.sequence import sequence_to_onehot
 
 # Lazy imports for pyfaidx/pyBigWig to avoid import errors when not needed
@@ -85,26 +86,17 @@ class CachedGenome:
     """
 
     def __init__(self, fasta_path: str, chromosomes: set[str] | None = None):
-        _ensure_genomic_deps()
         self.fasta_path = fasta_path
-        self._cache: dict[str, np.ndarray] = {}
-        self.chrom_sizes: dict[str, int] = {}
 
         print(f"CachedGenome: Loading genome from {fasta_path}...")
-        fasta = pyfaidx.Fasta(fasta_path)
-        try:
-            refs_to_load = chromosomes if chromosomes else set(fasta.keys())
-
-            for ref in fasta.keys():
-                length = len(fasta[ref])
-                self.chrom_sizes[ref] = length
-
-                if ref in refs_to_load:
-                    # Fetch and encode the entire chromosome
-                    seq_str = str(fasta[ref][:])
-                    self._cache[ref] = sequence_to_onehot(seq_str)
-        finally:
-            fasta.close()
+        self._source = GenomeSequenceSource(
+            fasta_path,
+            chromosomes=chromosomes,
+            cache=True,
+            ambiguous="zero",
+        )
+        self.chrom_sizes = self._source.chrom_sizes
+        self._cache = self._source._cache
 
         cached_size_mb = sum(arr.nbytes for arr in self._cache.values()) / 1e6
         print(f"CachedGenome: Loaded {len(self._cache)} chromosomes ({cached_size_mb:.1f} MB)")

--- a/src/alphagenome_pytorch/extensions/inference/full_chromosome.py
+++ b/src/alphagenome_pytorch/extensions/inference/full_chromosome.py
@@ -147,13 +147,12 @@ class GenomeSequenceProvider:
             source,
             chromosomes=chromosomes,
             cache=cache,
-            ambiguous="uniform",
             verbose=True,
         )
         self.chrom_sizes = self._source.chrom_sizes
 
     def fetch(self, chrom: str, start: int, end: int) -> np.ndarray:
-        """Fetch one-hot encoded sequence, padding out-of-bounds with N (0.25).
+        """Fetch one-hot encoded sequence, padding out-of-bounds with zeros.
 
         Args:
             chrom: Chromosome name.
@@ -163,7 +162,7 @@ class GenomeSequenceProvider:
         Returns:
             One-hot encoded array of shape (end - start, 4).
         """
-        return self._source.fetch_onehot(chrom, start, end, pad=True, ambiguous="uniform")
+        return self._source.fetch_onehot(chrom, start, end, pad=True)
 
     def close(self):
         """Close the FASTA file handle."""
@@ -178,7 +177,7 @@ class GenomeSequenceProvider:
 
     def _fetch_from_fasta(self, chrom: str, start: int, end: int) -> np.ndarray:
         """Fetch and encode sequence directly from FASTA."""
-        return self._source.fetch_onehot(chrom, start, end, ambiguous="uniform")
+        return self._source.fetch_onehot(chrom, start, end)
 
 
 def _sequence_to_onehot(seq: str) -> np.ndarray:
@@ -189,9 +188,9 @@ def _sequence_to_onehot(seq: str) -> np.ndarray:
 
     Returns:
         One-hot encoded array of shape (len(seq), 4) with columns [A, C, G, T].
-        Unknown bases (N, etc.) are encoded as [0.25, 0.25, 0.25, 0.25].
+        Unknown bases (N, etc.) are encoded as [0, 0, 0, 0].
     """
-    return sequence_to_onehot(seq, ambiguous="uniform")
+    return sequence_to_onehot(seq)
 
 
 def _generate_tiles(

--- a/src/alphagenome_pytorch/extensions/inference/full_chromosome.py
+++ b/src/alphagenome_pytorch/extensions/inference/full_chromosome.py
@@ -36,6 +36,9 @@ import numpy as np
 import torch
 from tqdm import tqdm
 
+from alphagenome_pytorch.genome import GenomeSequenceSource
+from alphagenome_pytorch.utils.sequence import sequence_to_onehot
+
 # Lazy imports
 pyBigWig = None
 pyfaidx = None
@@ -138,32 +141,16 @@ class GenomeSequenceProvider:
             chromosomes: Optional set of chromosomes to load. If None, loads all.
             cache: Whether to cache chromosomes in memory. Default: True.
         """
-        _ensure_deps()
-
         self.chrom_sizes: dict[str, int] = {}
-        self._cache: dict[str, np.ndarray] = {}
-        self._fasta_path = str(source)
-        self._cache_enabled = cache
-        self._fasta = None  # Lazy-loaded pyfaidx.Fasta instance
-
-        # Load chromosome sizes and optionally cache sequences
         print(f"Loading genome from {source}...")
-        fasta = pyfaidx.Fasta(self._fasta_path)
-        try:
-            for ref in fasta.keys():
-                self.chrom_sizes[ref] = len(fasta[ref])
-
-            if cache:
-                refs_to_load = chromosomes if chromosomes else set(fasta.keys())
-                for ref in refs_to_load:
-                    if ref in self.chrom_sizes:
-                        seq_str = str(fasta[ref][:])
-                        self._cache[ref] = _sequence_to_onehot(seq_str)
-
-                cached_mb = sum(arr.nbytes for arr in self._cache.values()) / 1e6
-                print(f"Cached {len(self._cache)} chromosomes ({cached_mb:.1f} MB)")
-        finally:
-            fasta.close()
+        self._source = GenomeSequenceSource(
+            source,
+            chromosomes=chromosomes,
+            cache=cache,
+            ambiguous="uniform",
+            verbose=True,
+        )
+        self.chrom_sizes = self._source.chrom_sizes
 
     def fetch(self, chrom: str, start: int, end: int) -> np.ndarray:
         """Fetch one-hot encoded sequence, padding out-of-bounds with N (0.25).
@@ -176,39 +163,12 @@ class GenomeSequenceProvider:
         Returns:
             One-hot encoded array of shape (end - start, 4).
         """
-        seq_len = end - start
-        chrom_len = self.chrom_sizes.get(chrom, 0)
-
-        # Fast path: fully within chromosome and cached
-        if start >= 0 and end <= chrom_len:
-            if chrom in self._cache:
-                return self._cache[chrom][start:end].copy()
-            else:
-                return self._fetch_from_fasta(chrom, start, end)
-
-        # Need padding for out-of-bounds regions
-        result = np.full((seq_len, 4), 0.25, dtype=np.float32)  # N = uniform
-
-        valid_start = max(0, start)
-        valid_end = min(chrom_len, end)
-
-        if valid_start < valid_end:
-            if chrom in self._cache:
-                seq = self._cache[chrom][valid_start:valid_end]
-            else:
-                seq = self._fetch_from_fasta(chrom, valid_start, valid_end)
-
-            dest_start = valid_start - start
-            dest_end = dest_start + (valid_end - valid_start)
-            result[dest_start:dest_end] = seq
-
-        return result
+        return self._source.fetch_onehot(chrom, start, end, pad=True, ambiguous="uniform")
 
     def close(self):
         """Close the FASTA file handle."""
-        if self._fasta is not None:
-            self._fasta.close()
-            self._fasta = None
+        if hasattr(self, "_source"):
+            self._source.close()
 
     def __enter__(self):
         return self
@@ -218,11 +178,7 @@ class GenomeSequenceProvider:
 
     def _fetch_from_fasta(self, chrom: str, start: int, end: int) -> np.ndarray:
         """Fetch and encode sequence directly from FASTA."""
-        # Lazy-load pyfaidx.Fasta for non-cached access
-        if self._fasta is None:
-            self._fasta = pyfaidx.Fasta(self._fasta_path)
-        seq_str = str(self._fasta[chrom][start:end])
-        return _sequence_to_onehot(seq_str)
+        return self._source.fetch_onehot(chrom, start, end, ambiguous="uniform")
 
 
 def _sequence_to_onehot(seq: str) -> np.ndarray:
@@ -235,18 +191,7 @@ def _sequence_to_onehot(seq: str) -> np.ndarray:
         One-hot encoded array of shape (len(seq), 4) with columns [A, C, G, T].
         Unknown bases (N, etc.) are encoded as [0.25, 0.25, 0.25, 0.25].
     """
-    seq = seq.upper()
-    n = len(seq)
-    onehot = np.full((n, 4), 0.25, dtype=np.float32)
-
-    seq_array = np.frombuffer(seq.encode('ascii'), dtype=np.uint8)
-
-    onehot[seq_array == ord('A')] = [1, 0, 0, 0]
-    onehot[seq_array == ord('C')] = [0, 1, 0, 0]
-    onehot[seq_array == ord('G')] = [0, 0, 1, 0]
-    onehot[seq_array == ord('T')] = [0, 0, 0, 1]
-
-    return onehot
+    return sequence_to_onehot(seq, ambiguous="uniform")
 
 
 def _generate_tiles(

--- a/src/alphagenome_pytorch/extensions/inference/regions.py
+++ b/src/alphagenome_pytorch/extensions/inference/regions.py
@@ -142,7 +142,7 @@ def read_fasta_sequences(path: str | Path) -> list[tuple[str, np.ndarray]]:
     """Read a FASTA file as a list of (name, one_hot) pairs.
 
     Uses pyfaidx for indexed access. Each sequence is one-hot encoded with
-    the same scheme as :class:`GenomeSequenceProvider` (unknown bases → 0.25).
+    the same scheme as :class:`GenomeSequenceProvider` (unknown bases → zeros).
     """
     _ensure_deps()
     fasta = _fc.pyfaidx.Fasta(str(path))
@@ -158,7 +158,7 @@ def read_fasta_sequences(path: str | Path) -> list[tuple[str, np.ndarray]]:
 
 
 def pad_to_window(seq: np.ndarray, window_size: int) -> tuple[np.ndarray, int]:
-    """Center ``seq`` in a window of ``window_size`` bp, padding with N (0.25).
+    """Center ``seq`` in a window of ``window_size`` bp, padding with N (zeros).
 
     Returns (padded, left_pad) where ``left_pad`` is the bp offset at which
     the original sequence starts in the padded window.
@@ -170,7 +170,7 @@ def pad_to_window(seq: np.ndarray, window_size: int) -> tuple[np.ndarray, int]:
         raise ValueError(f"Sequence ({L}bp) longer than window ({window_size}bp)")
     if L == window_size:
         return seq.copy(), 0
-    padded = np.full((window_size, 4), 0.25, dtype=np.float32)
+    padded = np.zeros((window_size, 4), dtype=seq.dtype)
     left_pad = (window_size - L) // 2
     padded[left_pad:left_pad + L] = seq
     return padded, left_pad
@@ -571,7 +571,7 @@ def _predict_raw_sequence_tiled(
 
     Mirrors :func:`predict_region` but pulls sub-sequences from the in-memory
     array rather than a genome provider. Tiles that extend past the sequence
-    end are right-padded with N (0.25) — same convention as
+    end are right-padded with N (zeros) — same convention as
     GenomeSequenceProvider for out-of-bounds fetches.
     """
     L = seq.shape[0]
@@ -600,8 +600,8 @@ def _predict_raw_sequence_tiled(
         batch = tiles[bstart:bstart + config.batch_size]
         sequences = []
         for ws, we, _, _ in batch:
-            # Slice with N-padding for out-of-bounds ends
-            window = np.full((W, 4), 0.25, dtype=np.float32)
+            # Slice with N-padding (zeros) for out-of-bounds ends
+            window = np.zeros((W, 4), dtype=seq.dtype)
             valid_start = max(0, ws)
             valid_end = min(L, we)
             if valid_start < valid_end:

--- a/src/alphagenome_pytorch/extensions/serving/__init__.py
+++ b/src/alphagenome_pytorch/extensions/serving/__init__.py
@@ -11,11 +11,11 @@ from .adapter import (
     SUPPORTED_SEQUENCE_LENGTHS,
     LocalDnaModelAdapter,
 )
-from .variant_scoring_adapter import VariantScoringAdapter
+from .scorer import VariantScorer
 
 __all__ = [
     'LocalDnaModelAdapter',
-    'VariantScoringAdapter',
+    'VariantScorer',
     'SUPPORTED_SEQUENCE_LENGTHS',
     'SEQUENCE_LENGTH_16KB',
     'SEQUENCE_LENGTH_100KB',

--- a/src/alphagenome_pytorch/extensions/serving/__init__.py
+++ b/src/alphagenome_pytorch/extensions/serving/__init__.py
@@ -11,9 +11,11 @@ from .adapter import (
     SUPPORTED_SEQUENCE_LENGTHS,
     LocalDnaModelAdapter,
 )
+from .variant_scoring_adapter import VariantScoringAdapter
 
 __all__ = [
     'LocalDnaModelAdapter',
+    'VariantScoringAdapter',
     'SUPPORTED_SEQUENCE_LENGTHS',
     'SEQUENCE_LENGTH_16KB',
     'SEQUENCE_LENGTH_100KB',

--- a/src/alphagenome_pytorch/extensions/serving/adapter.py
+++ b/src/alphagenome_pytorch/extensions/serving/adapter.py
@@ -475,6 +475,19 @@ class LocalDnaModelAdapter:
         ).unsqueeze(0)  # (1, L, 4)
 
         # --- target window bookkeeping -----------------------------------
+        if resolution <= 0:
+            raise ValueError(
+                f"resolution must be a positive integer, got {resolution}."
+            )
+        start_offset = target_interval.start - interval.start
+        end_offset = target_interval.end - interval.start
+        if start_offset % resolution != 0 or end_offset % resolution != 0:
+            raise ValueError(
+                f"target_interval offsets relative to interval.start must be "
+                f"multiples of resolution ({resolution}); got start offset "
+                f"{start_offset}, end offset {end_offset}."
+            )
+
         target_slice = target_slice_for_resolution(
             interval.start, target_interval.start, target_interval.end, resolution,
         )

--- a/src/alphagenome_pytorch/extensions/serving/adapter.py
+++ b/src/alphagenome_pytorch/extensions/serving/adapter.py
@@ -23,6 +23,13 @@ from alphagenome.models import dna_output
 from alphagenome.protos import dna_model_pb2
 
 from alphagenome_pytorch.prediction import AlphaGenomePredictionRuntime
+from alphagenome_pytorch.extensions.attribution import (
+    AttributionResult,
+    get_method,
+    UnsupportedMethodError,
+)
+from alphagenome_pytorch.extensions.attribution.heads import default_head_selector
+from alphagenome_pytorch.extensions.attribution.window import target_slice_for_resolution
 from alphagenome_pytorch.variant_scoring.types import (
     Interval as PTInterval,
     OutputType as PTOutputType,
@@ -199,24 +206,10 @@ class LocalDnaModelAdapter:
     """
 
     supports_variant_scoring = False
-    supports_attribution = False
+    supports_attribution = True
 
     def __init__(self, runtime: AlphaGenomePredictionRuntime):
         self.runtime = runtime
-
-    def explain_interval(self, *args, **kwargs):
-        """Attribution placeholder.
-
-        The attribution endpoint (``/v1/explain_interval``) is being added on a
-        separate branch. The base prediction-only adapter doesn't implement it
-        yet, so we expose a clean ``NotImplementedError`` rather than letting
-        the route blow up with ``AttributeError``. The REST/gRPC layers should
-        gate on ``self.supports_attribution`` before calling this.
-        """
-        del args, kwargs
-        raise NotImplementedError(
-            'Attribution (explain_interval) is not implemented on this adapter.'
-        )
 
     def predict_sequence(
         self,
@@ -316,6 +309,118 @@ class LocalDnaModelAdapter:
     def score_ism_variants(self, *args, **kwargs):
         del args, kwargs
         raise NotImplementedError('Variant scoring not available for this model.')
+
+    def explain_interval(
+        self,
+        *,
+        interval: genome.Interval,
+        target_interval: genome.Interval,
+        organism: Any = dna_model_pb2.ORGANISM_HOMO_SAPIENS,
+        requested_output: str,
+        resolution: int,
+        track_indices: Sequence[int],
+        method: str,
+        reduction: str = "sum",
+        include_raw_gradient: bool = False,
+        strand_averaged: bool = False,
+        batch_size: int = 8,
+    ) -> 'AttributionResult':
+        """Nucleotide attribution over a target window inside an interval.
+
+        This is the serving surface for per-base attribution (gradient × input
+        and saturation ISM).  It calls into
+        :mod:`alphagenome_pytorch.extensions.attribution` — **not** through
+        ``VariantScoringModel.predict()`` — because gradient methods require an
+        active autograd graph.
+
+        Args:
+            interval: Full input interval (must be a supported sequence length).
+            target_interval: Sub-interval to attribute over — must be contained
+                in ``interval``.
+            organism: Organism identifier (proto enum, string, or int).
+            requested_output: Head name, e.g. ``"dnase"``.
+            resolution: Output resolution in bp (1 or 128).
+            track_indices: Which tracks to attribute.
+            method: ``"input_x_gradient"`` or ``"saturation_ism"``.
+            reduction: Window reduction (``"sum"``, ``"mean"``, ``"peak"``).
+            include_raw_gradient: Return full ``(W, 4, T)`` gradient tensor
+                (only valid for gradient-based methods).
+            strand_averaged: Average forward and reverse-complement attributions.
+            batch_size: Batch size for ISM mutation loop.
+
+        Returns:
+            :class:`~alphagenome_pytorch.extensions.attribution.types.AttributionResult`.
+
+        Raises:
+            ValueError: On invalid inputs (containment, unknown head, bad indices, …).
+            UnsupportedMethodError: If ``method`` is not in the registry.
+        """
+        # --- validation -------------------------------------------------
+        _validate_sequence_length(interval.width)
+
+        if target_interval.chromosome != interval.chromosome:
+            raise ValueError(
+                f"target_interval chromosome ({target_interval.chromosome}) "
+                f"must match interval chromosome ({interval.chromosome})."
+            )
+        if target_interval.start < interval.start or target_interval.end > interval.end:
+            raise ValueError(
+                f"target_interval {target_interval.chromosome}:"
+                f"{target_interval.start}-{target_interval.end} is not "
+                f"contained within interval {interval.chromosome}:"
+                f"{interval.start}-{interval.end}."
+            )
+
+        # Method lookup (raises UnsupportedMethodError on unknown method).
+        method_spec = get_method(method)
+
+        if include_raw_gradient and not method_spec.supports_raw_gradient:
+            raise ValueError(
+                f"include_raw_gradient is not supported for method {method!r}."
+            )
+
+        if not track_indices:
+            raise ValueError("track_indices must be non-empty.")
+
+        # --- sequence → one-hot -----------------------------------------
+        organism_index = self.runtime.resolve_organism_index(organism)
+        sequence = self.runtime.get_sequence(interval)
+
+        from alphagenome_pytorch.utils.sequence import sequence_to_onehot_tensor
+
+        device = self.runtime.device
+        onehot = sequence_to_onehot_tensor(
+            sequence, dtype=torch.float32, device=device,
+        ).unsqueeze(0)  # (1, L, 4)
+
+        # --- target window bookkeeping -----------------------------------
+        target_slice = target_slice_for_resolution(
+            interval.start, target_interval.start, target_interval.end, resolution,
+        )
+
+        # --- dispatch ----------------------------------------------------
+        model = self.runtime.model
+
+        kwargs: dict[str, Any] = dict(
+            onehot=onehot,
+            organism_index=organism_index,
+            output_type=requested_output,
+            resolution=resolution,
+            target_slice=target_slice,
+            track_indices=track_indices,
+            reduction=reduction,
+            strand_averaged=strand_averaged,
+            head_selector=default_head_selector,
+            sequence=sequence,
+            target_start=target_interval.start,
+            target_end=target_interval.end,
+        )
+        if method_spec.supports_raw_gradient:
+            kwargs["include_raw_gradient"] = include_raw_gradient
+        if method == "saturation_ism":
+            kwargs["batch_size"] = batch_size
+
+        return method_spec.func(model, **kwargs)
 
     def output_metadata(
         self,

--- a/src/alphagenome_pytorch/extensions/serving/adapter.py
+++ b/src/alphagenome_pytorch/extensions/serving/adapter.py
@@ -1,16 +1,14 @@
 """Local serving adapter for AlphaGenome notebook-compatible APIs.
 
 This module provides a local implementation of the notebook-facing AlphaGenome
-surface (`predict_*`, `score_*`, `output_metadata`) by wrapping
-`VariantScoringModel` and converting outputs to upstream-compatible containers.
+prediction surface (`predict_*`, `output_metadata`) by wrapping the shared
+``AlphaGenomePredictionRuntime`` and converting outputs to upstream-compatible
+containers. Variant scoring lives in ``variant_scoring_adapter.py``.
 """
 
 from __future__ import annotations
 
-import concurrent.futures
 import dataclasses
-import importlib
-import itertools
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any
 
@@ -24,24 +22,12 @@ from alphagenome.data import track_data as ag_track_data
 from alphagenome.models import dna_output
 from alphagenome.protos import dna_model_pb2
 
-from alphagenome_pytorch.variant_scoring.inference import VariantScoringModel, get_recommended_scorers
-from alphagenome_pytorch.variant_scoring.scorers import (
-    BaseVariantScorer as PTBaseVariantScorer,
-    CenterMaskScorer as PTCenterMaskScorer,
-    ContactMapScorer as PTContactMapScorer,
-    GeneMaskActiveScorer as PTGeneMaskActiveScorer,
-    GeneMaskLFCScorer as PTGeneMaskLFCScorer,
-    GeneMaskSplicingScorer as PTGeneMaskSplicingScorer,
-    PolyadenylationScorer as PTPolyadenylationScorer,
-    SpliceJunctionScorer as PTSpliceJunctionScorer,
-)
+from alphagenome_pytorch.prediction import AlphaGenomePredictionRuntime
 from alphagenome_pytorch.variant_scoring.types import (
-    AggregationType as PTAggregationType,
     Interval as PTInterval,
     OutputType as PTOutputType,
     TrackMetadata as PTTrackMetadata,
     Variant as PTVariant,
-    VariantScore,
 )
 from alphagenome_pytorch.utils.splicing import unstack_junction_predictions
 
@@ -58,21 +44,9 @@ SUPPORTED_SEQUENCE_LENGTHS: Mapping[str, int] = {
     'SEQUENCE_LENGTH_1MB': SEQUENCE_LENGTH_1MB,
 }
 
-MAX_VARIANT_SCORERS_PER_REQUEST = 20
 DEFAULT_MAX_WORKERS = 5
+MAX_VARIANT_SCORERS_PER_REQUEST = 20
 VALID_SEQUENCE_CHARACTERS = frozenset('ACGTN')
-ISM_NUCLEOTIDES = 'ACGT'
-
-_ORGANISM_TO_INDEX = {
-    dna_model_pb2.ORGANISM_HOMO_SAPIENS: 0,
-    dna_model_pb2.ORGANISM_MUS_MUSCULUS: 1,
-    'HOMO_SAPIENS': 0,
-    'MUS_MUSCULUS': 1,
-    'human': 0,
-    'mouse': 1,
-    0: 0,
-    1: 1,
-}
 
 _PT_OUTPUT_TO_OFFICIAL = {
     PTOutputType.ATAC: dna_output.OutputType.ATAC,
@@ -117,44 +91,12 @@ _PRODUCED_PT_OUTPUTS = {
     PTOutputType.PROCAP,
 }
 
-_PT_AGGREGATION_BY_NAME = {a.name: a for a in PTAggregationType}
-
-
 def _validate_sequence_length(length: int) -> None:
     if length not in SUPPORTED_SEQUENCE_LENGTHS.values():
         raise ValueError(
             f'Sequence length {length} not supported. '
             f'Supported lengths: {list(SUPPORTED_SEQUENCE_LENGTHS.values())}'
         )
-
-
-def _resolve_organism_index(organism: Any) -> int:
-    if organism is None:
-        return 0
-    if hasattr(organism, 'value'):
-        candidate = getattr(organism, 'value')
-        if candidate in _ORGANISM_TO_INDEX:
-            return _ORGANISM_TO_INDEX[candidate]
-    if hasattr(organism, 'name'):
-        candidate = getattr(organism, 'name')
-        if candidate in _ORGANISM_TO_INDEX:
-            return _ORGANISM_TO_INDEX[candidate]
-        if isinstance(candidate, str) and candidate.startswith('ORGANISM_'):
-            stripped = candidate.removeprefix('ORGANISM_')
-            if stripped in _ORGANISM_TO_INDEX:
-                return _ORGANISM_TO_INDEX[stripped]
-    if organism in _ORGANISM_TO_INDEX:
-        return _ORGANISM_TO_INDEX[organism]
-    if isinstance(organism, str):
-        normalized = organism.upper().removeprefix('ORGANISM_')
-        if normalized in _ORGANISM_TO_INDEX:
-            return _ORGANISM_TO_INDEX[normalized]
-        lower = organism.lower()
-        if lower in _ORGANISM_TO_INDEX:
-            return _ORGANISM_TO_INDEX[lower]
-    raise ValueError(
-        f'Unsupported organism "{organism}". Expected Homo sapiens or Mus musculus.'
-    )
 
 
 def _organism_proto_from_index(idx: int) -> int:
@@ -171,11 +113,6 @@ def _as_numpy(value: Any) -> np.ndarray:
     if torch.is_tensor(value):
         return value.detach().cpu().numpy()
     return np.asarray(value)
-
-
-def _import_anndata_module():
-    # Import lazily to keep serving optional and avoid importing at module load.
-    return importlib.import_module('anndata')
 
 
 def _interval_to_pt(interval: genome.Interval) -> PTInterval:
@@ -257,12 +194,29 @@ class LocalDnaModelAdapter:
     """Notebook-compatible local model adapter.
 
     This class mirrors the notebook-critical subset of the AlphaGenome API:
-    `predict_sequence`, `predict_interval`, `predict_variant`, `score_variant`,
-    `score_variants`, `score_ism_variants`, and `output_metadata`.
+    `predict_sequence`, `predict_interval`, `predict_variant`, and
+    `output_metadata`.
     """
 
-    def __init__(self, scoring_model: VariantScoringModel):
-        self.scoring_model = scoring_model
+    supports_variant_scoring = False
+    supports_attribution = False
+
+    def __init__(self, runtime: AlphaGenomePredictionRuntime):
+        self.runtime = runtime
+
+    def explain_interval(self, *args, **kwargs):
+        """Attribution placeholder.
+
+        The attribution endpoint (``/v1/explain_interval``) is being added on a
+        separate branch. The base prediction-only adapter doesn't implement it
+        yet, so we expose a clean ``NotImplementedError`` rather than letting
+        the route blow up with ``AttributeError``. The REST/gRPC layers should
+        gate on ``self.supports_attribution`` before calling this.
+        """
+        del args, kwargs
+        raise NotImplementedError(
+            'Attribution (explain_interval) is not implemented on this adapter.'
+        )
 
     def predict_sequence(
         self,
@@ -280,8 +234,8 @@ class LocalDnaModelAdapter:
                 f'Invalid DNA sequence. Allowed characters are A/C/G/T/N. Found: {bad}'
             )
         _validate_sequence_length(len(sequence))
-        organism_index = _resolve_organism_index(organism)
-        outputs = self.scoring_model.predict(sequence, organism=organism_index)
+        organism_index = self.runtime.resolve_organism_index(organism)
+        outputs = self.runtime.predict(sequence, organism=organism_index)
         requested = _normalize_requested_outputs(requested_outputs)
         ontology = _normalize_ontology_terms(ontology_terms)
         return self._convert_output(
@@ -301,8 +255,7 @@ class LocalDnaModelAdapter:
         ontology_terms: Iterable[Any] | None = None,
     ) -> dna_output.Output:
         _validate_sequence_length(interval.width)
-        pt_interval = _interval_to_pt(interval)
-        sequence = self.scoring_model.get_sequence(pt_interval)
+        sequence = self.runtime.get_sequence(interval)
         return self.predict_sequence(
             sequence=sequence,
             organism=organism,
@@ -321,13 +274,11 @@ class LocalDnaModelAdapter:
         ontology_terms: Iterable[Any] | None = None,
     ) -> dna_output.VariantOutput:
         _validate_sequence_length(interval.width)
-        organism_index = _resolve_organism_index(organism)
-        pt_interval = _interval_to_pt(interval)
-        pt_variant = _variant_to_pt(variant)
+        organism_index = self.runtime.resolve_organism_index(organism)
 
-        ref_outputs, alt_outputs = self.scoring_model.predict_variant(
-            interval=pt_interval,
-            variant=pt_variant,
+        ref_outputs, alt_outputs = self.runtime.predict_variant(
+            interval=interval,
+            variant=variant,
             organism=organism_index,
         )
 
@@ -354,174 +305,33 @@ class LocalDnaModelAdapter:
         del args, kwargs  # Unused for the local serving MVP.
         raise NotImplementedError('score_interval is not implemented in LocalDnaModelAdapter.')
 
-    def score_variant(
-        self,
-        interval: genome.Interval,
-        variant: genome.Variant,
-        variant_scorers: Sequence[Any] = (),
-        *,
-        organism: Any = dna_model_pb2.ORGANISM_HOMO_SAPIENS,
-    ) -> list[Any]:
-        _validate_sequence_length(interval.width)
-        organism_index = _resolve_organism_index(organism)
+    def score_variant(self, *args, **kwargs):
+        del args, kwargs
+        raise NotImplementedError('Variant scoring not available for this model.')
 
-        if not variant_scorers:
-            organism_name = 'human' if organism_index == 0 else 'mouse'
-            variant_scorers = list(get_recommended_scorers(organism_name))
+    def score_variants(self, *args, **kwargs):
+        del args, kwargs
+        raise NotImplementedError('Variant scoring not available for this model.')
 
-        if len(variant_scorers) > MAX_VARIANT_SCORERS_PER_REQUEST:
-            raise ValueError(
-                f'Too many variant scorers requested: {len(variant_scorers)} '
-                f'(max {MAX_VARIANT_SCORERS_PER_REQUEST}).'
-            )
-        if len(variant_scorers) != len(set(map(str, variant_scorers))):
-            raise ValueError(f'Duplicate variant scorers requested: {variant_scorers}.')
-
-        local_scorers = [self._to_local_variant_scorer(vs) for vs in variant_scorers]
-        pt_interval = _interval_to_pt(interval)
-        pt_variant = _variant_to_pt(variant)
-
-        scorer_results = self.scoring_model.score_variant(
-            interval=pt_interval,
-            variant=pt_variant,
-            scorers=local_scorers,
-            organism=organism_index,
-        )
-
-        outputs = []
-        for original_scorer, local_result in zip(
-            variant_scorers, scorer_results, strict=True
-        ):
-            adata = self._scores_to_anndata(
-                scores=local_result,
-                organism_index=organism_index,
-                fallback_variant_scorer=original_scorer,
-                interval=interval,
-                variant=variant,
-            )
-            outputs.append(adata)
-        return outputs
-
-    def score_variants(
-        self,
-        intervals: genome.Interval | Sequence[genome.Interval],
-        variants: Sequence[genome.Variant],
-        variant_scorers: Sequence[Any] = (),
-        *,
-        organism: Any = dna_model_pb2.ORGANISM_HOMO_SAPIENS,
-        progress_bar: bool = True,
-        max_workers: int = DEFAULT_MAX_WORKERS,
-    ) -> list[list[Any]]:
-        if not isinstance(intervals, Sequence):
-            intervals = [intervals] * len(variants)
-        if len(intervals) != len(variants):
-            raise ValueError(
-                'Intervals and variants must have the same length. '
-                f'Got {len(intervals)} intervals and {len(variants)} variants.'
-            )
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = [
-                executor.submit(
-                    self.score_variant,
-                    interval=interval,
-                    variant=variant,
-                    variant_scorers=variant_scorers,
-                    organism=organism,
-                )
-                for interval, variant in zip(intervals, variants, strict=True)
-            ]
-
-            iterator: Iterable[Any]
-            if progress_bar:
-                try:
-                    import tqdm.auto
-
-                    iterator = tqdm.auto.tqdm(
-                        concurrent.futures.as_completed(futures),
-                        total=len(futures),
-                        desc='Scoring variants',
-                    )
-                except ImportError:
-                    iterator = concurrent.futures.as_completed(futures)
-            else:
-                iterator = concurrent.futures.as_completed(futures)
-
-            for future in iterator:
-                if (exc := future.exception()) is not None:
-                    executor.shutdown(wait=False, cancel_futures=True)
-                    raise exc
-
-            return [future.result() for future in futures]
-
-    def score_ism_variants(
-        self,
-        interval: genome.Interval,
-        ism_interval: genome.Interval,
-        variant_scorers: Sequence[Any] = (),
-        *,
-        organism: Any = dna_model_pb2.ORGANISM_HOMO_SAPIENS,
-        interval_variant: genome.Variant | None = None,
-        progress_bar: bool = True,
-        max_workers: int = DEFAULT_MAX_WORKERS,
-    ) -> list[list[Any]]:
-        _validate_sequence_length(interval.width)
-        if ism_interval.negative_strand:
-            raise ValueError('ISM interval must be on the positive strand.')
-        if ism_interval.chromosome != interval.chromosome:
-            raise ValueError('ISM interval chromosome must match interval chromosome.')
-        if ism_interval.start < interval.start or ism_interval.end > interval.end:
-            raise ValueError('ISM interval must be contained within interval.')
-
-        pt_interval = _interval_to_pt(interval)
-        pt_interval_variant = _variant_to_pt(interval_variant) if interval_variant else None
-        sequence = self.scoring_model.get_sequence(pt_interval, variant=pt_interval_variant)
-
-        variants: list[genome.Variant] = []
-        for genomic_pos_0b in range(ism_interval.start, ism_interval.end):
-            rel = genomic_pos_0b - interval.start
-            if rel < 0 or rel >= len(sequence):
-                continue
-            ref_base = sequence[rel].upper()
-            if ref_base not in ISM_NUCLEOTIDES:
-                continue
-            for alt_base in ISM_NUCLEOTIDES:
-                if alt_base == ref_base:
-                    continue
-                variants.append(
-                    genome.Variant(
-                        chromosome=interval.chromosome,
-                        position=genomic_pos_0b + 1,
-                        reference_bases=ref_base,
-                        alternate_bases=alt_base,
-                    )
-                )
-
-        if not variants:
-            return []
-
-        return self.score_variants(
-            intervals=interval,
-            variants=variants,
-            variant_scorers=variant_scorers,
-            organism=organism,
-            progress_bar=progress_bar,
-            max_workers=max_workers,
-        )
+    def score_ism_variants(self, *args, **kwargs):
+        del args, kwargs
+        raise NotImplementedError('Variant scoring not available for this model.')
 
     def output_metadata(
         self,
         organism: Any = dna_model_pb2.ORGANISM_HOMO_SAPIENS,
     ) -> dna_output.OutputMetadata:
-        organism_index = _resolve_organism_index(organism)
-        track_metadata = self.scoring_model.get_track_metadata(organism_index)
+        organism_index = self.runtime.resolve_organism_index(organism)
 
         metadata_kwargs: dict[str, pd.DataFrame | None] = {
             field.name: None for field in dataclasses.fields(dna_output.OutputMetadata)
         }
         for official_output_type, field_name in _OFFICIAL_OUTPUT_FIELD.items():
             pt_output_type = _OFFICIAL_TO_PT_OUTPUT[official_output_type]
-            entries = track_metadata.get(pt_output_type, [])
+            entries = self.runtime.get_track_metadata(
+                organism_index,
+                output_name=pt_output_type.value,
+            )
             if not entries:
                 continue
             if official_output_type == dna_output.OutputType.SPLICE_JUNCTIONS:
@@ -696,7 +506,10 @@ class LocalDnaModelAdapter:
         organism_index: int,
         num_tracks: int,
     ) -> pd.DataFrame:
-        metadata = self.scoring_model.get_track_metadata(organism_index).get(pt_output_type, [])
+        metadata = self.runtime.get_track_metadata(
+            organism_index,
+            output_name=pt_output_type.value,
+        )
         return self._pt_metadata_to_track_df(metadata, num_tracks=num_tracks)
 
     def _build_junction_metadata_df(
@@ -705,8 +518,9 @@ class LocalDnaModelAdapter:
         organism_index: int,
         num_tracks: int,
     ) -> pd.DataFrame:
-        metadata = self.scoring_model.get_track_metadata(organism_index).get(
-            PTOutputType.SPLICE_JUNCTIONS, []
+        metadata = self.runtime.get_track_metadata(
+            organism_index,
+            output_name=PTOutputType.SPLICE_JUNCTIONS.value,
         )
         return self._pt_metadata_to_junction_df(metadata, num_tracks=num_tracks)
 
@@ -717,17 +531,21 @@ class LocalDnaModelAdapter:
     ) -> pd.DataFrame:
         rows = []
         for i, meta in enumerate(metadata):
+            extras_get = getattr(meta, 'get', None)
+            get = extras_get if callable(extras_get) else lambda name, default=None: getattr(meta, name, default)
+            track_name = getattr(meta, 'track_name', None) or get('name', None)
+            track_strand = getattr(meta, 'track_strand', None) or get('strand', '.')
             rows.append(
                 {
-                    'name': meta.track_name or f'track_{i}',
-                    'strand': meta.track_strand or '.',
-                    'ontology_curie': meta.ontology_curie,
-                    'gtex_tissue': meta.gtex_tissue,
-                    'Assay title': meta.assay_title,
-                    'biosample_name': meta.biosample_name,
-                    'biosample_type': meta.biosample_type,
-                    'transcription_factor': meta.transcription_factor,
-                    'histone_mark': meta.histone_mark,
+                    'name': track_name or f'track_{i}',
+                    'strand': track_strand or '.',
+                    'ontology_curie': get('ontology_curie', None),
+                    'gtex_tissue': get('gtex_tissue', None),
+                    'Assay title': get('assay_title', None) or get('Assay title', None),
+                    'biosample_name': get('biosample_name', None),
+                    'biosample_type': get('biosample_type', None),
+                    'transcription_factor': get('transcription_factor', None),
+                    'histone_mark': get('histone_mark', None),
                 }
             )
         if not rows and num_tracks is not None:
@@ -755,14 +573,17 @@ class LocalDnaModelAdapter:
     ) -> pd.DataFrame:
         rows = []
         for i, meta in enumerate(metadata):
+            extras_get = getattr(meta, 'get', None)
+            get = extras_get if callable(extras_get) else lambda name, default=None: getattr(meta, name, default)
+            track_name = getattr(meta, 'track_name', None) or get('name', None)
             rows.append(
                 {
-                    'name': meta.track_name or f'track_{i}',
-                    'ontology_curie': meta.ontology_curie,
-                    'gtex_tissue': meta.gtex_tissue,
-                    'Assay title': meta.assay_title,
-                    'biosample_name': meta.biosample_name,
-                    'biosample_type': meta.biosample_type,
+                    'name': track_name or f'track_{i}',
+                    'ontology_curie': get('ontology_curie', None),
+                    'gtex_tissue': get('gtex_tissue', None),
+                    'Assay title': get('assay_title', None) or get('Assay title', None),
+                    'biosample_name': get('biosample_name', None),
+                    'biosample_type': get('biosample_type', None),
                 }
             )
         if not rows and num_tracks is not None:
@@ -778,171 +599,6 @@ class LocalDnaModelAdapter:
                 df = df.iloc[:num_tracks].copy()
         return df.reset_index(drop=True)
 
-    def _to_local_variant_scorer(self, scorer: Any) -> PTBaseVariantScorer:
-        if isinstance(scorer, PTBaseVariantScorer):
-            return scorer
-
-        base = getattr(scorer, 'base_variant_scorer', None)
-        base_name = getattr(base, 'name', None)
-        class_name = scorer.__class__.__name__
-        scorer_kind = (base_name or class_name or '').upper()
-        requested_output = getattr(scorer, 'requested_output', None)
-
-        if scorer_kind in {'CENTER_MASK', 'CENTERMASKSCORER'}:
-            aggregation = getattr(scorer, 'aggregation_type', None)
-            aggregation_name = getattr(aggregation, 'name', None)
-            if aggregation_name is None:
-                raise ValueError(f'Unsupported center-mask scorer: {scorer}')
-            return PTCenterMaskScorer(
-                requested_output=_OFFICIAL_TO_PT_OUTPUT[_normalize_output_type(requested_output)],
-                width=getattr(scorer, 'width', None),
-                aggregation_type=_PT_AGGREGATION_BY_NAME[aggregation_name],
-            )
-        if scorer_kind in {'CONTACT_MAP', 'CONTACTMAPSCORER'}:
-            return PTContactMapScorer()
-        if scorer_kind in {'GENE_MASK_LFC', 'GENEMASKLFCSCORER'}:
-            return PTGeneMaskLFCScorer(
-                requested_output=_OFFICIAL_TO_PT_OUTPUT[_normalize_output_type(requested_output)],
-                resolution=1,
-            )
-        if scorer_kind in {'GENE_MASK_ACTIVE', 'GENEMASKACTIVESCORER'}:
-            return PTGeneMaskActiveScorer(
-                requested_output=_OFFICIAL_TO_PT_OUTPUT[_normalize_output_type(requested_output)],
-                resolution=1,
-            )
-        if scorer_kind in {'GENE_MASK_SPLICING', 'GENEMASKSPLICINGSCORER'}:
-            return PTGeneMaskSplicingScorer(
-                requested_output=_OFFICIAL_TO_PT_OUTPUT[_normalize_output_type(requested_output)],
-                width=getattr(scorer, 'width', None),
-            )
-        if scorer_kind in {'PA_QTL', 'POLYADENYLATIONSCORER'}:
-            return PTPolyadenylationScorer()
-        if scorer_kind in {'SPLICE_JUNCTION', 'SPLICEJUNCTIONSCORER'}:
-            return PTSpliceJunctionScorer()
-
-        # Proto-style scorer descriptor support.
-        which = getattr(scorer, 'WhichOneof', None)
-        if callable(which):
-            field = scorer.WhichOneof('scorer')
-            if field == 'center_mask':
-                center = scorer.center_mask
-                return PTCenterMaskScorer(
-                    requested_output=_OFFICIAL_TO_PT_OUTPUT[dna_output.OutputType(center.requested_output)],
-                    width=center.width if center.HasField('width') else None,
-                    aggregation_type=_PT_AGGREGATION_BY_NAME[
-                        dna_model_pb2.AggregationType.Name(center.aggregation_type)
-                        .removeprefix('AGGREGATION_TYPE_')
-                    ],
-                )
-            if field == 'contact_map':
-                return PTContactMapScorer()
-            if field == 'gene_mask':
-                return PTGeneMaskLFCScorer(
-                    requested_output=_OFFICIAL_TO_PT_OUTPUT[dna_output.OutputType(scorer.gene_mask.requested_output)],
-                    resolution=1,
-                )
-            if field == 'gene_mask_active':
-                return PTGeneMaskActiveScorer(
-                    requested_output=_OFFICIAL_TO_PT_OUTPUT[
-                        dna_output.OutputType(scorer.gene_mask_active.requested_output)
-                    ],
-                    resolution=1,
-                )
-            if field == 'gene_mask_splicing':
-                return PTGeneMaskSplicingScorer(
-                    requested_output=_OFFICIAL_TO_PT_OUTPUT[
-                        dna_output.OutputType(scorer.gene_mask_splicing.requested_output)
-                    ],
-                    width=scorer.gene_mask_splicing.width
-                    if scorer.gene_mask_splicing.HasField('width')
-                    else None,
-                )
-            if field == 'pa_qtl':
-                return PTPolyadenylationScorer()
-            if field == 'splice_junction':
-                return PTSpliceJunctionScorer()
-
-        raise ValueError(f'Unsupported variant scorer type: {scorer!r}')
-
-    def _scores_to_anndata(
-        self,
-        *,
-        scores: VariantScore | list[VariantScore],
-        organism_index: int,
-        fallback_variant_scorer: Any,
-        interval: genome.Interval,
-        variant: genome.Variant,
-    ):
-        anndata = _import_anndata_module()
-
-        score_list = scores if isinstance(scores, list) else [scores]
-        if not score_list:
-            return anndata.AnnData(
-                X=np.zeros((0, 0), dtype=np.float32),
-                obs=pd.DataFrame(),
-                var=pd.DataFrame(columns=['name', 'strand']),
-                uns={'interval': interval, 'variant': variant, 'variant_scorer': fallback_variant_scorer},
-            )
-
-        x_rows = []
-        obs_rows = []
-        has_gene_metadata = False
-        for i, score in enumerate(score_list):
-            values = _as_numpy(score.scores).astype(np.float32, copy=False)
-            if values.ndim != 1:
-                values = values.reshape(-1)
-            x_rows.append(values)
-
-            row = {
-                'gene_id': score.gene_id,
-                'gene_name': score.gene_name,
-                'gene_type': score.gene_type,
-                'strand': score.gene_strand,
-                'junction_Start': score.junction_start,
-                'junction_End': score.junction_end,
-            }
-            if any(v is not None for v in row.values()):
-                has_gene_metadata = True
-            obs_rows.append(row)
-
-        X = np.stack(x_rows, axis=0).astype(np.float32, copy=False)
-        n_tracks = X.shape[1] if X.ndim == 2 else 0
-
-        scorer_for_output = score_list[0].scorer if score_list else None
-        requested_output = getattr(scorer_for_output, 'requested_output', None)
-        if isinstance(requested_output, PTOutputType):
-            pt_output = requested_output
-        else:
-            pt_output = _OFFICIAL_TO_PT_OUTPUT.get(
-                _normalize_output_type(getattr(fallback_variant_scorer, 'requested_output', dna_output.OutputType.RNA_SEQ)),
-                PTOutputType.RNA_SEQ,
-            )
-        var_df = self._build_track_metadata_df(
-            pt_output_type=pt_output,
-            organism_index=organism_index,
-            num_tracks=n_tracks,
-        )
-
-        if has_gene_metadata:
-            obs_df = pd.DataFrame(obs_rows)
-            obs_df.index = obs_df.index.map(str)
-        else:
-            obs_df = pd.DataFrame(index=[str(i) for i in range(X.shape[0])])
-
-        var_df = var_df.reset_index(drop=True)
-        var_df.index = var_df.index.map(str)
-
-        return anndata.AnnData(
-            X=X,
-            obs=obs_df,
-            var=var_df,
-            uns={
-                'interval': interval,
-                'variant': variant,
-                'variant_scorer': fallback_variant_scorer,
-            },
-        )
-
     @staticmethod
     def _squeeze_batch(values: np.ndarray) -> np.ndarray:
         if values.ndim > 0 and values.shape[0] == 1:
@@ -951,9 +607,12 @@ class LocalDnaModelAdapter:
 
     @staticmethod
     def _ensure_batch(values: np.ndarray) -> np.ndarray:
-        if values.ndim > 0 and values.shape[0] != 1:
-            return values
-        if values.ndim == 0:
-            return values[None]
-        return values if values.shape[0] == 1 else values[None]
+        """Promote a 0-d scalar to a length-1 array; pass arrays through unchanged.
 
+        This intentionally does **not** wrap arrays whose leading dim is not 1.
+        Callers in :py:meth:`_build_junction_data` rely on existing batch
+        dimensions being preserved as-is. If you need "wrap any non-1 leading
+        dim with a fresh batch axis" semantics, that is a different contract —
+        introduce a new helper rather than changing this one.
+        """
+        return values[None] if values.ndim == 0 else values

--- a/src/alphagenome_pytorch/extensions/serving/adapter.py
+++ b/src/alphagenome_pytorch/extensions/serving/adapter.py
@@ -3,7 +3,7 @@
 This module provides a local implementation of the notebook-facing AlphaGenome
 prediction surface (`predict_*`, `output_metadata`) by wrapping the shared
 ``AlphaGenomePredictionRuntime`` and converting outputs to upstream-compatible
-containers. Variant scoring lives in ``variant_scoring_adapter.py``.
+containers. Variant scoring lives in ``scorer.py``.
 """
 
 from __future__ import annotations
@@ -197,6 +197,81 @@ def _normalize_ontology_terms(ontology_terms: Iterable[Any] | None) -> list[str]
     return list(dict.fromkeys(normalized))
 
 
+def _pt_metadata_to_track_df(
+    metadata: Sequence[PTTrackMetadata],
+    num_tracks: int | None = None,
+) -> pd.DataFrame:
+    rows = []
+    for i, meta in enumerate(metadata):
+        extras_get = getattr(meta, 'get', None)
+        get = extras_get if callable(extras_get) else lambda name, default=None: getattr(meta, name, default)
+        track_name = getattr(meta, 'track_name', None) or get('name', None)
+        track_strand = getattr(meta, 'track_strand', None) or get('strand', '.')
+        rows.append(
+            {
+                'name': track_name or f'track_{i}',
+                'strand': track_strand or '.',
+                'ontology_curie': get('ontology_curie', None),
+                'gtex_tissue': get('gtex_tissue', None),
+                'Assay title': get('assay_title', None) or get('Assay title', None),
+                'biosample_name': get('biosample_name', None),
+                'biosample_type': get('biosample_type', None),
+                'transcription_factor': get('transcription_factor', None),
+                'histone_mark': get('histone_mark', None),
+            }
+        )
+    if not rows and num_tracks is not None:
+        rows = [{'name': f'track_{i}', 'strand': '.'} for i in range(num_tracks)]
+    df = pd.DataFrame(rows)
+    if df.empty:
+        df = pd.DataFrame(columns=['name', 'strand'])
+    if num_tracks is not None:
+        if len(df) < num_tracks:
+            for i in range(len(df), num_tracks):
+                df.loc[i] = {'name': f'track_{i}', 'strand': '.'}
+        elif len(df) > num_tracks:
+            df = df.iloc[:num_tracks].copy()
+    df = df.reset_index(drop=True)
+    if 'name' not in df.columns:
+        df['name'] = [f'track_{i}' for i in range(len(df))]
+    if 'strand' not in df.columns:
+        df['strand'] = '.'
+    return df
+
+
+def _pt_metadata_to_junction_df(
+    metadata: Sequence[PTTrackMetadata],
+    num_tracks: int | None = None,
+) -> pd.DataFrame:
+    rows = []
+    for i, meta in enumerate(metadata):
+        extras_get = getattr(meta, 'get', None)
+        get = extras_get if callable(extras_get) else lambda name, default=None: getattr(meta, name, default)
+        track_name = getattr(meta, 'track_name', None) or get('name', None)
+        rows.append(
+            {
+                'name': track_name or f'track_{i}',
+                'ontology_curie': get('ontology_curie', None),
+                'gtex_tissue': get('gtex_tissue', None),
+                'Assay title': get('assay_title', None) or get('Assay title', None),
+                'biosample_name': get('biosample_name', None),
+                'biosample_type': get('biosample_type', None),
+            }
+        )
+    if not rows and num_tracks is not None:
+        rows = [{'name': f'track_{i}'} for i in range(num_tracks)]
+    df = pd.DataFrame(rows)
+    if df.empty:
+        df = pd.DataFrame(columns=['name'])
+    if num_tracks is not None:
+        if len(df) < num_tracks:
+            for i in range(len(df), num_tracks):
+                df.loc[i] = {'name': f'track_{i}'}
+        elif len(df) > num_tracks:
+            df = df.iloc[:num_tracks].copy()
+    return df.reset_index(drop=True)
+
+
 class LocalDnaModelAdapter:
     """Notebook-compatible local model adapter.
 
@@ -205,11 +280,14 @@ class LocalDnaModelAdapter:
     `output_metadata`.
     """
 
-    supports_variant_scoring = False
-    supports_attribution = True
-
-    def __init__(self, runtime: AlphaGenomePredictionRuntime):
+    def __init__(
+        self,
+        runtime: AlphaGenomePredictionRuntime,
+        *,
+        scorer: 'VariantScorer | None' = None,
+    ):
         self.runtime = runtime
+        self.scorer = scorer
 
     def predict_sequence(
         self,
@@ -296,19 +374,22 @@ class LocalDnaModelAdapter:
 
     def score_interval(self, *args, **kwargs):
         del args, kwargs  # Unused for the local serving MVP.
-        raise NotImplementedError('score_interval is not implemented in LocalDnaModelAdapter.')
+        raise NotImplementedError('score_interval is not implemented.')
 
     def score_variant(self, *args, **kwargs):
-        del args, kwargs
-        raise NotImplementedError('Variant scoring not available for this model.')
+        if self.scorer is None:
+            raise NotImplementedError('Variant scoring not available for this model.')
+        return self.scorer.score_variant(*args, **kwargs)
 
     def score_variants(self, *args, **kwargs):
-        del args, kwargs
-        raise NotImplementedError('Variant scoring not available for this model.')
+        if self.scorer is None:
+            raise NotImplementedError('Variant scoring not available for this model.')
+        return self.scorer.score_variants(*args, **kwargs)
 
     def score_ism_variants(self, *args, **kwargs):
-        del args, kwargs
-        raise NotImplementedError('Variant scoring not available for this model.')
+        if self.scorer is None:
+            raise NotImplementedError('Variant scoring not available for this model.')
+        return self.scorer.score_ism_variants(*args, **kwargs)
 
     def explain_interval(
         self,
@@ -634,75 +715,14 @@ class LocalDnaModelAdapter:
         metadata: Sequence[PTTrackMetadata],
         num_tracks: int | None = None,
     ) -> pd.DataFrame:
-        rows = []
-        for i, meta in enumerate(metadata):
-            extras_get = getattr(meta, 'get', None)
-            get = extras_get if callable(extras_get) else lambda name, default=None: getattr(meta, name, default)
-            track_name = getattr(meta, 'track_name', None) or get('name', None)
-            track_strand = getattr(meta, 'track_strand', None) or get('strand', '.')
-            rows.append(
-                {
-                    'name': track_name or f'track_{i}',
-                    'strand': track_strand or '.',
-                    'ontology_curie': get('ontology_curie', None),
-                    'gtex_tissue': get('gtex_tissue', None),
-                    'Assay title': get('assay_title', None) or get('Assay title', None),
-                    'biosample_name': get('biosample_name', None),
-                    'biosample_type': get('biosample_type', None),
-                    'transcription_factor': get('transcription_factor', None),
-                    'histone_mark': get('histone_mark', None),
-                }
-            )
-        if not rows and num_tracks is not None:
-            rows = [{'name': f'track_{i}', 'strand': '.'} for i in range(num_tracks)]
-        df = pd.DataFrame(rows)
-        if df.empty:
-            df = pd.DataFrame(columns=['name', 'strand'])
-        if num_tracks is not None:
-            if len(df) < num_tracks:
-                for i in range(len(df), num_tracks):
-                    df.loc[i] = {'name': f'track_{i}', 'strand': '.'}
-            elif len(df) > num_tracks:
-                df = df.iloc[:num_tracks].copy()
-        df = df.reset_index(drop=True)
-        if 'name' not in df.columns:
-            df['name'] = [f'track_{i}' for i in range(len(df))]
-        if 'strand' not in df.columns:
-            df['strand'] = '.'
-        return df
+        return _pt_metadata_to_track_df(metadata, num_tracks=num_tracks)
 
     def _pt_metadata_to_junction_df(
         self,
         metadata: Sequence[PTTrackMetadata],
         num_tracks: int | None = None,
     ) -> pd.DataFrame:
-        rows = []
-        for i, meta in enumerate(metadata):
-            extras_get = getattr(meta, 'get', None)
-            get = extras_get if callable(extras_get) else lambda name, default=None: getattr(meta, name, default)
-            track_name = getattr(meta, 'track_name', None) or get('name', None)
-            rows.append(
-                {
-                    'name': track_name or f'track_{i}',
-                    'ontology_curie': get('ontology_curie', None),
-                    'gtex_tissue': get('gtex_tissue', None),
-                    'Assay title': get('assay_title', None) or get('Assay title', None),
-                    'biosample_name': get('biosample_name', None),
-                    'biosample_type': get('biosample_type', None),
-                }
-            )
-        if not rows and num_tracks is not None:
-            rows = [{'name': f'track_{i}'} for i in range(num_tracks)]
-        df = pd.DataFrame(rows)
-        if df.empty:
-            df = pd.DataFrame(columns=['name'])
-        if num_tracks is not None:
-            if len(df) < num_tracks:
-                for i in range(len(df), num_tracks):
-                    df.loc[i] = {'name': f'track_{i}'}
-            elif len(df) > num_tracks:
-                df = df.iloc[:num_tracks].copy()
-        return df.reset_index(drop=True)
+        return _pt_metadata_to_junction_df(metadata, num_tracks=num_tracks)
 
     @staticmethod
     def _squeeze_batch(values: np.ndarray) -> np.ndarray:

--- a/src/alphagenome_pytorch/extensions/serving/adapter.py
+++ b/src/alphagenome_pytorch/extensions/serving/adapter.py
@@ -419,11 +419,14 @@ class LocalDnaModelAdapter:
             target_interval: Sub-interval to attribute over — must be contained
                 in ``interval``.
             organism: Organism identifier (proto enum, string, or int).
-            requested_output: Head name, e.g. ``"dnase"``.
+            requested_output: Output/head identifier. Accepts the same forms as
+                the predict path: a head name (``"dnase"``), the upper-case or
+                ``OUTPUT_TYPE_``-prefixed enum name, the proto/PT ``OutputType``
+                enum, or its int value.
             resolution: Output resolution in bp (1 or 128).
             track_indices: Which tracks to attribute.
             method: ``"input_x_gradient"`` or ``"saturation_ism"``.
-            reduction: Window reduction (``"sum"``, ``"mean"``, ``"peak"``).
+            reduction: Window reduction (``"sum"``, ``"mean"``, ``"max"``).
             include_raw_gradient: Return full ``(W, 4, T)`` gradient tensor
                 (only valid for gradient-based methods).
             strand_averaged: Average forward and reverse-complement attributions.
@@ -463,6 +466,18 @@ class LocalDnaModelAdapter:
         if not track_indices:
             raise ValueError("track_indices must be non-empty.")
 
+        # Normalize the requested output to the model's head key, accepting the
+        # same forms as the predict path (``"dnase"``, ``"DNASE"``,
+        # ``"OUTPUT_TYPE_DNASE"``, the proto/PT enum, or its int value). The
+        # official enum maps to a PT output whose ``.value`` is the head key.
+        official_output = _normalize_output_type(requested_output)
+        pt_output = _OFFICIAL_TO_PT_OUTPUT.get(official_output)
+        if pt_output is None:
+            raise ValueError(
+                f"Output {requested_output!r} is not supported for attribution."
+            )
+        output_type = pt_output.value
+
         # --- sequence → one-hot -----------------------------------------
         organism_index = self.runtime.resolve_organism_index(organism)
         sequence = self.runtime.get_sequence(interval)
@@ -498,7 +513,7 @@ class LocalDnaModelAdapter:
         kwargs: dict[str, Any] = dict(
             onehot=onehot,
             organism_index=organism_index,
-            output_type=requested_output,
+            output_type=output_type,
             resolution=resolution,
             target_slice=target_slice,
             track_indices=track_indices,

--- a/src/alphagenome_pytorch/extensions/serving/cli.py
+++ b/src/alphagenome_pytorch/extensions/serving/cli.py
@@ -8,6 +8,7 @@ user actually invokes the ``serve`` subcommand.
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import time
 from pathlib import Path
@@ -15,11 +16,15 @@ from pathlib import Path
 import torch
 
 from alphagenome_pytorch import AlphaGenome
+from alphagenome_pytorch.config import DtypePolicy
+from alphagenome_pytorch.named_outputs import TrackMetadataCatalog
+from alphagenome_pytorch.prediction import AlphaGenomePredictionRuntime
 from alphagenome_pytorch.variant_scoring.inference import VariantScoringModel
 
 from .adapter import LocalDnaModelAdapter
 from .grpc_service import serve_grpc
 from .rest_service import serve_rest
+from .variant_scoring_adapter import VariantScoringAdapter
 
 LOGGER = logging.getLogger(__name__)
 
@@ -61,34 +66,61 @@ def _resolve_bundled_metadata_paths() -> list[Path]:
     return paths
 
 
-def run(args: argparse.Namespace) -> int:
-    """Start the serving process based on parsed *args*."""
-    logging.basicConfig(
-        level=getattr(logging, args.log_level),
-        format='%(asctime)s %(levelname)s %(name)s - %(message)s',
+def _build_checkpoint_adapter(args: argparse.Namespace) -> LocalDnaModelAdapter:
+    """Construct a prediction-only adapter from a fine-tuned checkpoint."""
+    from alphagenome_pytorch.extensions.finetuning.checkpointing import (
+        load_finetuned_model,
+    )
+    from alphagenome_pytorch.extensions.finetuning.transfer import (
+        transfer_config_from_dict,
     )
 
+    transfer_config = None
+    if args.transfer_config:
+        with open(args.transfer_config) as f:
+            transfer_config = transfer_config_from_dict(json.load(f))
+
+    model, meta = load_finetuned_model(
+        checkpoint_path=args.checkpoint,
+        pretrained_weights=args.weights,
+        device=args.device,
+        dtype_policy=DtypePolicy.default(),
+        transfer_config=transfer_config,
+        merge=not args.no_merge_adapters,
+    )
+    runtime = AlphaGenomePredictionRuntime(
+        model=model,
+        fasta_path=args.fasta,
+        track_names=meta.get('track_names'),
+        device=args.device,
+    )
+    LOGGER.info(
+        'Loaded fine-tuned checkpoint %s; variant scoring routes disabled.',
+        args.checkpoint,
+    )
+    return LocalDnaModelAdapter(runtime)
+
+
+def _build_weights_adapter(args: argparse.Namespace) -> VariantScoringAdapter:
+    """Construct a variant-scoring adapter from a pretrained weights file."""
     model = AlphaGenome(num_organisms=2)
     state_dict = torch.load(args.weights, map_location=args.device, weights_only=True)
     model.load_state_dict(state_dict, strict=False)
     model.to(args.device)
     model.eval()
 
-    scoring_model = VariantScoringModel(
-        model=model,
-        fasta_path=args.fasta,
-        gtf_path=args.gtf,
-        polya_path=args.polya,
-        device=args.device,
-    )
+    # Load track metadata via the canonical catalog path.
+    metadata_catalog = None
     if args.track_metadata:
-        scoring_model.load_all_metadata(args.track_metadata)
+        metadata_catalog = TrackMetadataCatalog.from_file(args.track_metadata)
         LOGGER.info('Loaded track metadata from %s', args.track_metadata)
     else:
         bundled_paths = _resolve_bundled_metadata_paths()
         if bundled_paths:
-            for path in bundled_paths:
-                scoring_model.load_all_metadata(path)
+            metadata_catalog = TrackMetadataCatalog.from_file(bundled_paths[0])
+            for path in bundled_paths[1:]:
+                extra = TrackMetadataCatalog.from_file(path)
+                metadata_catalog._tracks_by_organism.update(extra._tracks_by_organism)
             LOGGER.info(
                 'Loaded built-in track metadata: %s',
                 ', '.join(p.name for p in bundled_paths),
@@ -100,7 +132,75 @@ def run(args: argparse.Namespace) -> int:
                 'bundled parquets ship under alphagenome_pytorch/data/.'
             )
 
-    adapter = LocalDnaModelAdapter(scoring_model)
+    # Construct the runtime directly — no VariantScoringModel bridge.
+    runtime = AlphaGenomePredictionRuntime(
+        model=model,
+        fasta_path=args.fasta,
+        metadata_catalog=metadata_catalog,
+        device=args.device,
+    )
+
+    # VariantScoringModel is only needed for variant scoring routes.
+    scoring_model = VariantScoringModel(
+        model=model,
+        fasta_path=args.fasta,
+        gtf_path=args.gtf,
+        polya_path=args.polya,
+        device=args.device,
+    )
+    if metadata_catalog is not None:
+        # Sync legacy track metadata into scoring_model for scorer compatibility.
+        from alphagenome_pytorch.variant_scoring.types import (
+            OutputType as PTOutputType,
+            TrackMetadata as PTTrackMetadata,
+        )
+        for org_idx in metadata_catalog.organisms:
+            for output_name in metadata_catalog.outputs(organism=org_idx):
+                tracks = metadata_catalog.get_tracks(output_name, organism=org_idx)
+                try:
+                    pt_output = PTOutputType(output_name)
+                except ValueError:
+                    continue
+                legacy_tracks = [
+                    PTTrackMetadata(
+                        track_index=t.track_index,
+                        track_name=t.track_name,
+                        track_strand=t.get('strand', t.get('track_strand', '.')),
+                        output_type=pt_output,
+                        ontology_curie=t.get('ontology_curie'),
+                        gtex_tissue=t.get('gtex_tissue'),
+                        assay_title=t.get('assay_title'),
+                        biosample_name=t.get('biosample_name'),
+                        biosample_type=t.get('biosample_type'),
+                        transcription_factor=t.get('transcription_factor'),
+                        histone_mark=t.get('histone_mark'),
+                    )
+                    for t in tracks
+                ]
+                scoring_model.set_track_metadata(pt_output, legacy_tracks, organism=org_idx)
+
+    return VariantScoringAdapter(runtime, scoring_model)
+
+
+def _build_adapter(args: argparse.Namespace) -> LocalDnaModelAdapter:
+    """Pick the right adapter construction path based on CLI args.
+
+    * ``--checkpoint`` → fine-tuned, prediction-only ``LocalDnaModelAdapter``
+    * ``--weights``   → pretrained, variant-scoring-capable ``VariantScoringAdapter``
+    """
+    if args.checkpoint:
+        return _build_checkpoint_adapter(args)
+    return _build_weights_adapter(args)
+
+
+def run(args: argparse.Namespace) -> int:
+    """Start the serving process based on parsed *args*."""
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format='%(asctime)s %(levelname)s %(name)s - %(message)s',
+    )
+
+    adapter = _build_adapter(args)
 
     grpc_server = None
     if not args.disable_grpc:

--- a/src/alphagenome_pytorch/extensions/serving/cli.py
+++ b/src/alphagenome_pytorch/extensions/serving/cli.py
@@ -24,7 +24,7 @@ from alphagenome_pytorch.variant_scoring.inference import VariantScoringModel
 from .adapter import LocalDnaModelAdapter
 from .grpc_service import serve_grpc
 from .rest_service import serve_rest
-from .variant_scoring_adapter import VariantScoringAdapter
+from .scorer import VariantScorer
 
 LOGGER = logging.getLogger(__name__)
 
@@ -66,8 +66,108 @@ def _resolve_bundled_metadata_paths() -> list[Path]:
     return paths
 
 
+def _load_metadata_catalog(
+    args: argparse.Namespace,
+    *,
+    include_bundled: bool,
+) -> TrackMetadataCatalog | None:
+    """Load optional track metadata for serving.
+
+    Pretrained weights can safely fall back to bundled metadata. Fine-tuned
+    checkpoints may have custom/replaced heads, so their construction path only
+    uses metadata explicitly provided by the user and otherwise relies on
+    checkpoint ``track_names``.
+    """
+    if args.track_metadata:
+        metadata_catalog = TrackMetadataCatalog.from_file(args.track_metadata)
+        LOGGER.info('Loaded track metadata from %s', args.track_metadata)
+        return metadata_catalog
+
+    if not include_bundled:
+        return None
+
+    bundled_paths = _resolve_bundled_metadata_paths()
+    if bundled_paths:
+        metadata_catalog = TrackMetadataCatalog.from_file(bundled_paths[0])
+        for path in bundled_paths[1:]:
+            extra = TrackMetadataCatalog.from_file(path)
+            metadata_catalog._tracks_by_organism.update(extra._tracks_by_organism)
+        LOGGER.info(
+            'Loaded built-in track metadata: %s',
+            ', '.join(p.name for p in bundled_paths),
+        )
+        return metadata_catalog
+
+    LOGGER.warning(
+        'No track metadata available; /v1/output_metadata will be '
+        'empty. Pass --track-metadata or reinstall the package so the '
+        'bundled parquets ship under alphagenome_pytorch/data/.'
+    )
+    return None
+
+
+def _sync_metadata_catalog_to_scoring_model(
+    scoring_model: VariantScoringModel,
+    metadata_catalog: TrackMetadataCatalog | None,
+) -> None:
+    """Copy runtime/catalog metadata into ``VariantScoringModel`` compatibility storage."""
+    if metadata_catalog is None:
+        return
+
+    from alphagenome_pytorch.variant_scoring.types import (
+        OutputType as PTOutputType,
+        TrackMetadata as PTTrackMetadata,
+    )
+
+    for org_idx in metadata_catalog.organisms:
+        for output_name in metadata_catalog.outputs(organism=org_idx):
+            tracks = metadata_catalog.get_tracks(output_name, organism=org_idx)
+            try:
+                pt_output = PTOutputType(output_name)
+            except ValueError:
+                continue
+            legacy_tracks = [
+                PTTrackMetadata(
+                    track_index=t.track_index,
+                    track_name=t.track_name,
+                    track_strand=t.get('strand', t.get('track_strand', '.')),
+                    output_type=pt_output,
+                    ontology_curie=t.get('ontology_curie'),
+                    gtex_tissue=t.get('gtex_tissue'),
+                    assay_title=t.get('assay_title'),
+                    biosample_name=t.get('biosample_name'),
+                    biosample_type=t.get('biosample_type'),
+                    transcription_factor=t.get('transcription_factor'),
+                    histone_mark=t.get('histone_mark'),
+                )
+                for t in tracks
+            ]
+            scoring_model.set_track_metadata(
+                pt_output, legacy_tracks, organism=org_idx,
+            )
+
+
+def _make_variant_scorer(
+    *,
+    runtime: AlphaGenomePredictionRuntime,
+    model: torch.nn.Module,
+    args: argparse.Namespace,
+    metadata_catalog: TrackMetadataCatalog | None,
+) -> VariantScorer:
+    """Build the optional variant-scoring capability for any AlphaGenome model."""
+    scoring_model = VariantScoringModel(
+        model=model,
+        fasta_path=args.fasta,
+        gtf_path=args.gtf,
+        polya_path=args.polya,
+        device=args.device,
+    )
+    _sync_metadata_catalog_to_scoring_model(scoring_model, metadata_catalog)
+    return VariantScorer(runtime, scoring_model)
+
+
 def _build_checkpoint_adapter(args: argparse.Namespace) -> LocalDnaModelAdapter:
-    """Construct a prediction-only adapter from a fine-tuned checkpoint."""
+    """Construct a serving adapter from a fine-tuned checkpoint."""
     from alphagenome_pytorch.extensions.finetuning.checkpointing import (
         load_finetuned_model,
     )
@@ -88,20 +188,29 @@ def _build_checkpoint_adapter(args: argparse.Namespace) -> LocalDnaModelAdapter:
         transfer_config=transfer_config,
         merge=not args.no_merge_adapters,
     )
+    metadata_catalog = _load_metadata_catalog(args, include_bundled=False)
     runtime = AlphaGenomePredictionRuntime(
         model=model,
         fasta_path=args.fasta,
+        metadata_catalog=metadata_catalog,
         track_names=meta.get('track_names'),
         device=args.device,
     )
+    scorer = _make_variant_scorer(
+        runtime=runtime,
+        model=model,
+        args=args,
+        metadata_catalog=metadata_catalog,
+    )
     LOGGER.info(
-        'Loaded fine-tuned checkpoint %s; variant scoring routes disabled.',
+        'Loaded fine-tuned checkpoint %s; variant scoring routes enabled '
+        'for heads supported by the checkpoint.',
         args.checkpoint,
     )
-    return LocalDnaModelAdapter(runtime)
+    return LocalDnaModelAdapter(runtime, scorer=scorer)
 
 
-def _build_weights_adapter(args: argparse.Namespace) -> VariantScoringAdapter:
+def _build_weights_adapter(args: argparse.Namespace) -> LocalDnaModelAdapter:
     """Construct a variant-scoring adapter from a pretrained weights file."""
     model = AlphaGenome(num_organisms=2)
     state_dict = torch.load(args.weights, map_location=args.device, weights_only=True)
@@ -110,27 +219,7 @@ def _build_weights_adapter(args: argparse.Namespace) -> VariantScoringAdapter:
     model.eval()
 
     # Load track metadata via the canonical catalog path.
-    metadata_catalog = None
-    if args.track_metadata:
-        metadata_catalog = TrackMetadataCatalog.from_file(args.track_metadata)
-        LOGGER.info('Loaded track metadata from %s', args.track_metadata)
-    else:
-        bundled_paths = _resolve_bundled_metadata_paths()
-        if bundled_paths:
-            metadata_catalog = TrackMetadataCatalog.from_file(bundled_paths[0])
-            for path in bundled_paths[1:]:
-                extra = TrackMetadataCatalog.from_file(path)
-                metadata_catalog._tracks_by_organism.update(extra._tracks_by_organism)
-            LOGGER.info(
-                'Loaded built-in track metadata: %s',
-                ', '.join(p.name for p in bundled_paths),
-            )
-        else:
-            LOGGER.warning(
-                'No track metadata available; /v1/output_metadata will be '
-                'empty. Pass --track-metadata or reinstall the package so the '
-                'bundled parquets ship under alphagenome_pytorch/data/.'
-            )
+    metadata_catalog = _load_metadata_catalog(args, include_bundled=True)
 
     # Construct the runtime directly — no VariantScoringModel bridge.
     runtime = AlphaGenomePredictionRuntime(
@@ -140,53 +229,20 @@ def _build_weights_adapter(args: argparse.Namespace) -> VariantScoringAdapter:
         device=args.device,
     )
 
-    # VariantScoringModel is only needed for variant scoring routes.
-    scoring_model = VariantScoringModel(
+    scorer = _make_variant_scorer(
+        runtime=runtime,
         model=model,
-        fasta_path=args.fasta,
-        gtf_path=args.gtf,
-        polya_path=args.polya,
-        device=args.device,
+        args=args,
+        metadata_catalog=metadata_catalog,
     )
-    if metadata_catalog is not None:
-        # Sync legacy track metadata into scoring_model for scorer compatibility.
-        from alphagenome_pytorch.variant_scoring.types import (
-            OutputType as PTOutputType,
-            TrackMetadata as PTTrackMetadata,
-        )
-        for org_idx in metadata_catalog.organisms:
-            for output_name in metadata_catalog.outputs(organism=org_idx):
-                tracks = metadata_catalog.get_tracks(output_name, organism=org_idx)
-                try:
-                    pt_output = PTOutputType(output_name)
-                except ValueError:
-                    continue
-                legacy_tracks = [
-                    PTTrackMetadata(
-                        track_index=t.track_index,
-                        track_name=t.track_name,
-                        track_strand=t.get('strand', t.get('track_strand', '.')),
-                        output_type=pt_output,
-                        ontology_curie=t.get('ontology_curie'),
-                        gtex_tissue=t.get('gtex_tissue'),
-                        assay_title=t.get('assay_title'),
-                        biosample_name=t.get('biosample_name'),
-                        biosample_type=t.get('biosample_type'),
-                        transcription_factor=t.get('transcription_factor'),
-                        histone_mark=t.get('histone_mark'),
-                    )
-                    for t in tracks
-                ]
-                scoring_model.set_track_metadata(pt_output, legacy_tracks, organism=org_idx)
-
-    return VariantScoringAdapter(runtime, scoring_model)
+    return LocalDnaModelAdapter(runtime, scorer=scorer)
 
 
 def _build_adapter(args: argparse.Namespace) -> LocalDnaModelAdapter:
     """Pick the right adapter construction path based on CLI args.
 
-    * ``--checkpoint`` → fine-tuned, prediction-only ``LocalDnaModelAdapter``
-    * ``--weights``   → pretrained, variant-scoring-capable ``VariantScoringAdapter``
+    * ``--checkpoint`` → fine-tuned adapter with a configured ``VariantScorer``
+    * ``--weights``   → pretrained adapter with a configured ``VariantScorer``
     """
     if args.checkpoint:
         return _build_checkpoint_adapter(args)

--- a/src/alphagenome_pytorch/extensions/serving/grpc_service.py
+++ b/src/alphagenome_pytorch/extensions/serving/grpc_service.py
@@ -317,8 +317,6 @@ class LocalDnaModelService(dna_model_service_pb2_grpc.DnaModelServiceServicer):
 
     def ScoreVariant(self, request_iterator, context):
         try:
-            if not getattr(self.adapter, 'supports_variant_scoring', False):
-                raise NotImplementedError('Variant scoring not available for this model.')
             request = _first_request(request_iterator, 'ScoreVariant')
             interval = genome.Interval.from_proto(request.interval)
             variant = genome.Variant.from_proto(request.variant)
@@ -342,8 +340,6 @@ class LocalDnaModelService(dna_model_service_pb2_grpc.DnaModelServiceServicer):
 
     def ScoreIsmVariant(self, request_iterator, context):
         try:
-            if not getattr(self.adapter, 'supports_variant_scoring', False):
-                raise NotImplementedError('Variant scoring not available for this model.')
             request = _first_request(request_iterator, 'ScoreIsmVariant')
             interval = genome.Interval.from_proto(request.interval)
             ism_interval = genome.Interval.from_proto(request.ism_interval)

--- a/src/alphagenome_pytorch/extensions/serving/grpc_service.py
+++ b/src/alphagenome_pytorch/extensions/serving/grpc_service.py
@@ -317,6 +317,8 @@ class LocalDnaModelService(dna_model_service_pb2_grpc.DnaModelServiceServicer):
 
     def ScoreVariant(self, request_iterator, context):
         try:
+            if not getattr(self.adapter, 'supports_variant_scoring', False):
+                raise NotImplementedError('Variant scoring not available for this model.')
             request = _first_request(request_iterator, 'ScoreVariant')
             interval = genome.Interval.from_proto(request.interval)
             variant = genome.Variant.from_proto(request.variant)
@@ -340,6 +342,8 @@ class LocalDnaModelService(dna_model_service_pb2_grpc.DnaModelServiceServicer):
 
     def ScoreIsmVariant(self, request_iterator, context):
         try:
+            if not getattr(self.adapter, 'supports_variant_scoring', False):
+                raise NotImplementedError('Variant scoring not available for this model.')
             request = _first_request(request_iterator, 'ScoreIsmVariant')
             interval = genome.Interval.from_proto(request.interval)
             ism_interval = genome.Interval.from_proto(request.ism_interval)

--- a/src/alphagenome_pytorch/extensions/serving/rest_service.py
+++ b/src/alphagenome_pytorch/extensions/serving/rest_service.py
@@ -22,6 +22,7 @@ from alphagenome.models import dna_output
 from alphagenome_pytorch.variant_scoring.types import OutputType as PTOutputType
 
 from .adapter import LocalDnaModelAdapter, _OFFICIAL_TO_PT_OUTPUT, _normalize_output_type
+from alphagenome_pytorch.extensions.attribution import UnsupportedMethodError
 
 # NOTE: variant-scoring scorer classes (``CenterMaskScorer`` etc.) and
 # ``GeneMaskMode`` / ``AggregationType`` are deliberately *not* imported at
@@ -348,6 +349,49 @@ def _serialize_output_metadata(metadata: dna_output.OutputMetadata) -> dict[str,
     }
 
 
+def _nan_to_none(arr: np.ndarray) -> list:
+    """Convert a numpy array to a nested list with NaN replaced by None.
+
+    ``ndarray.tolist()`` maps NaN to ``float('nan')``, which ``json.dumps``
+    serializes as the non-standard ``NaN`` token.  We want ``null`` instead,
+    so we replace NaN values with ``None`` in a Python object array first.
+    """
+    if not np.issubdtype(arr.dtype, np.floating):
+        return arr.tolist()
+    mask = np.isnan(arr)
+    if not mask.any():
+        return arr.tolist()
+    obj = arr.astype(object)
+    obj[mask] = None
+    return obj.tolist()
+
+
+def _serialize_attribution(result: 'AttributionResult') -> dict[str, Any]:
+    """Convert an :class:`AttributionResult` to a JSON-serializable dict.
+
+    NaN values in the numpy arrays are mapped to ``null`` via
+    :func:`_nan_to_none`.
+    """
+    payload: dict[str, Any] = {
+        'method': result.method,
+        'kind': result.kind,
+        'bases': list(result.bases),
+        'values': _nan_to_none(result.values),
+        'sequence': result.sequence,
+        'target_start': result.target_start,
+        'target_end': result.target_end,
+        'resolution': result.resolution,
+        'track_indices': list(result.track_indices),
+        'reduction': result.reduction,
+        'metadata': result.metadata,
+    }
+    if result.raw_gradient is not None:
+        payload['raw_gradient'] = _nan_to_none(result.raw_gradient)
+    else:
+        payload['raw_gradient'] = None
+    return payload
+
+
 class _ServingHandler(BaseHTTPRequestHandler):
     adapter: LocalDnaModelAdapter
 
@@ -478,6 +522,27 @@ class _ServingHandler(BaseHTTPRequestHandler):
                 self._write_json(
                     {'scores': [[_serialize_anndata(s) for s in group] for group in scores]}
                 )
+                return
+
+            if path == '/v1/explain_interval':
+                try:
+                    result = self.adapter.explain_interval(
+                        interval=_interval_from_payload(body['interval']),
+                        target_interval=_interval_from_payload(body['target_interval']),
+                        organism=body.get('organism', 'HOMO_SAPIENS'),
+                        requested_output=body['requested_output'],
+                        resolution=int(body.get('resolution', 128)),
+                        track_indices=[int(i) for i in body['track_indices']],
+                        method=body['method'],
+                        reduction=body.get('reduction', 'sum'),
+                        include_raw_gradient=bool(body.get('include_raw_gradient', False)),
+                        strand_averaged=bool(body.get('strand_averaged', False)),
+                        batch_size=int(body.get('batch_size', 8)),
+                    )
+                except UnsupportedMethodError as exc:
+                    self._write_json({'error': str(exc)}, status=HTTPStatus.BAD_REQUEST)
+                    return
+                self._write_json({'attribution': _serialize_attribution(result)})
                 return
 
             self._write_json({'error': 'Not found'}, status=HTTPStatus.NOT_FOUND)

--- a/src/alphagenome_pytorch/extensions/serving/rest_service.py
+++ b/src/alphagenome_pytorch/extensions/serving/rest_service.py
@@ -19,23 +19,25 @@ from alphagenome.data import junction_data as ag_junction_data
 from alphagenome.data import track_data as ag_track_data
 from alphagenome.models import dna_output
 
-from alphagenome_pytorch.variant_scoring.scorers import (
-    BaseVariantScorer as PTBaseVariantScorer,
-    CenterMaskScorer as PTCenterMaskScorer,
-    ContactMapScorer as PTContactMapScorer,
-    GeneMaskActiveScorer as PTGeneMaskActiveScorer,
-    GeneMaskLFCScorer as PTGeneMaskLFCScorer,
-    GeneMaskSplicingScorer as PTGeneMaskSplicingScorer,
-    PolyadenylationScorer as PTPolyadenylationScorer,
-    SpliceJunctionScorer as PTSpliceJunctionScorer,
-)
-from alphagenome_pytorch.variant_scoring.scorers.gene_mask import GeneMaskMode
-from alphagenome_pytorch.variant_scoring.types import (
-    AggregationType as PTAggregationType,
-    OutputType as PTOutputType,
-)
+from alphagenome_pytorch.variant_scoring.types import OutputType as PTOutputType
 
 from .adapter import LocalDnaModelAdapter, _OFFICIAL_TO_PT_OUTPUT, _normalize_output_type
+
+# NOTE: variant-scoring scorer classes (``CenterMaskScorer`` etc.) and
+# ``GeneMaskMode`` / ``AggregationType`` are deliberately *not* imported at
+# module load time. They live in ``alphagenome_pytorch.variant_scoring.scorers``
+# which is heavyweight (gene-mask, polyadenylation, splice-junction machinery).
+# The ``--checkpoint`` (fine-tuned) serving path doesn't need any of that, so
+# this module loads them on demand via :py:func:`_get_scorer_builders`.
+#
+# Caveat: ``alphagenome_pytorch.variant_scoring.__init__`` currently re-exports
+# the scorers eagerly, which means importing *any* ``variant_scoring`` submodule
+# (including ``variant_scoring.types`` below, used by the adapter) still pulls
+# the scorers into ``sys.modules`` today. Fully decoupling rest_service from
+# the scoring stack requires making that package init lazy too — out of scope
+# for this PR. The lazy import here is still worthwhile: it establishes the
+# boundary at this layer and benefits automatically once the package init is
+# refactored.
 
 LOGGER = logging.getLogger(__name__)
 
@@ -136,72 +138,95 @@ def _scorer_enum(
     raise ValueError(f'Field "{field}" must be a string naming a {enum_cls.__name__} member.')
 
 
-def _center_mask_from_json(payload: dict[str, Any]) -> PTCenterMaskScorer:
-    width = payload.get('width')
-    return PTCenterMaskScorer(
-        requested_output=_scorer_pt_output(payload),
-        width=int(width) if width is not None else None,
-        aggregation_type=_scorer_enum(payload, 'aggregation_type', PTAggregationType),
+_SCORER_BUILDERS_CACHE: dict[str, Callable[[dict[str, Any]], Any]] | None = None
+
+
+def _get_scorer_builders() -> dict[str, Callable[[dict[str, Any]], Any]]:
+    """Lazily import variant-scoring classes and return the JSON→scorer dispatch table.
+
+    Defers ``alphagenome_pytorch.variant_scoring.scorers`` (and the
+    gene-mask / polyadenylation / splice-junction sub-modules it transitively
+    pulls in) until a scoring request actually arrives. The fine-tuned
+    serving path (``--checkpoint``) never enters this code, so its process
+    avoids loading the scoring stack entirely.
+    """
+    global _SCORER_BUILDERS_CACHE
+    if _SCORER_BUILDERS_CACHE is not None:
+        return _SCORER_BUILDERS_CACHE
+
+    from alphagenome_pytorch.variant_scoring.scorers import (
+        CenterMaskScorer as PTCenterMaskScorer,
+        ContactMapScorer as PTContactMapScorer,
+        GeneMaskActiveScorer as PTGeneMaskActiveScorer,
+        GeneMaskLFCScorer as PTGeneMaskLFCScorer,
+        GeneMaskSplicingScorer as PTGeneMaskSplicingScorer,
+        PolyadenylationScorer as PTPolyadenylationScorer,
+        SpliceJunctionScorer as PTSpliceJunctionScorer,
     )
+    from alphagenome_pytorch.variant_scoring.scorers.gene_mask import GeneMaskMode
+    from alphagenome_pytorch.variant_scoring.types import AggregationType as PTAggregationType
+
+    def _center_mask_from_json(payload: dict[str, Any]):
+        width = payload.get('width')
+        return PTCenterMaskScorer(
+            requested_output=_scorer_pt_output(payload),
+            width=int(width) if width is not None else None,
+            aggregation_type=_scorer_enum(payload, 'aggregation_type', PTAggregationType),
+        )
+
+    def _contact_map_from_json(payload: dict[str, Any]):
+        del payload
+        return PTContactMapScorer()
+
+    def _gene_mask_lfc_from_json(payload: dict[str, Any]):
+        return PTGeneMaskLFCScorer(
+            requested_output=_scorer_pt_output(payload),
+            mask_mode=_scorer_enum(payload, 'mask_mode', GeneMaskMode, default=GeneMaskMode.EXONS),
+        )
+
+    def _gene_mask_active_from_json(payload: dict[str, Any]):
+        return PTGeneMaskActiveScorer(
+            requested_output=_scorer_pt_output(payload),
+            mask_mode=_scorer_enum(payload, 'mask_mode', GeneMaskMode, default=GeneMaskMode.EXONS),
+        )
+
+    def _gene_mask_splicing_from_json(payload: dict[str, Any]):
+        width = payload.get('width')
+        return PTGeneMaskSplicingScorer(
+            requested_output=_scorer_pt_output(payload),
+            width=int(width) if width is not None else None,
+        )
+
+    def _polyadenylation_from_json(payload: dict[str, Any]):
+        return PTPolyadenylationScorer(
+            min_pas_count=int(payload.get('min_pas_count', 2)),
+            min_pas_coverage=float(payload.get('min_pas_coverage', 0.8)),
+        )
+
+    def _splice_junction_from_json(payload: dict[str, Any]):
+        return PTSpliceJunctionScorer(
+            filter_protein_coding=bool(payload.get('filter_protein_coding', True)),
+        )
+
+    _SCORER_BUILDERS_CACHE = {
+        'center_mask': _center_mask_from_json,
+        'contact_map': _contact_map_from_json,
+        'gene_mask_lfc': _gene_mask_lfc_from_json,
+        'gene_mask_active': _gene_mask_active_from_json,
+        'gene_mask_splicing': _gene_mask_splicing_from_json,
+        'polyadenylation': _polyadenylation_from_json,
+        'splice_junction': _splice_junction_from_json,
+    }
+    return _SCORER_BUILDERS_CACHE
 
 
-def _contact_map_from_json(payload: dict[str, Any]) -> PTContactMapScorer:
-    del payload
-    return PTContactMapScorer()
-
-
-def _gene_mask_lfc_from_json(payload: dict[str, Any]) -> PTGeneMaskLFCScorer:
-    return PTGeneMaskLFCScorer(
-        requested_output=_scorer_pt_output(payload),
-        mask_mode=_scorer_enum(payload, 'mask_mode', GeneMaskMode, default=GeneMaskMode.EXONS),
-    )
-
-
-def _gene_mask_active_from_json(payload: dict[str, Any]) -> PTGeneMaskActiveScorer:
-    return PTGeneMaskActiveScorer(
-        requested_output=_scorer_pt_output(payload),
-        mask_mode=_scorer_enum(payload, 'mask_mode', GeneMaskMode, default=GeneMaskMode.EXONS),
-    )
-
-
-def _gene_mask_splicing_from_json(payload: dict[str, Any]) -> PTGeneMaskSplicingScorer:
-    width = payload.get('width')
-    return PTGeneMaskSplicingScorer(
-        requested_output=_scorer_pt_output(payload),
-        width=int(width) if width is not None else None,
-    )
-
-
-def _polyadenylation_from_json(payload: dict[str, Any]) -> PTPolyadenylationScorer:
-    return PTPolyadenylationScorer(
-        min_pas_count=int(payload.get('min_pas_count', 2)),
-        min_pas_coverage=float(payload.get('min_pas_coverage', 0.8)),
-    )
-
-
-def _splice_junction_from_json(payload: dict[str, Any]) -> PTSpliceJunctionScorer:
-    return PTSpliceJunctionScorer(
-        filter_protein_coding=bool(payload.get('filter_protein_coding', True)),
-    )
-
-
-_SCORER_BUILDERS: dict[str, Callable[[dict[str, Any]], PTBaseVariantScorer]] = {
-    'center_mask': _center_mask_from_json,
-    'contact_map': _contact_map_from_json,
-    'gene_mask_lfc': _gene_mask_lfc_from_json,
-    'gene_mask_active': _gene_mask_active_from_json,
-    'gene_mask_splicing': _gene_mask_splicing_from_json,
-    'polyadenylation': _polyadenylation_from_json,
-    'splice_junction': _splice_junction_from_json,
-}
-
-
-def _parse_variant_scorers(raw: Any) -> list[PTBaseVariantScorer]:
+def _parse_variant_scorers(raw: Any) -> list[Any]:
     if raw is None:
         return []
     if not isinstance(raw, list):
         raise ValueError('"variant_scorers" must be a JSON list of scorer objects.')
-    scorers: list[PTBaseVariantScorer] = []
+    builders = _get_scorer_builders()
+    scorers: list[Any] = []
     for index, item in enumerate(raw):
         if not isinstance(item, dict):
             raise ValueError(
@@ -211,13 +236,13 @@ def _parse_variant_scorers(raw: Any) -> list[PTBaseVariantScorer]:
         if not isinstance(scorer_type, str):
             raise ValueError(
                 f'variant_scorers[{index}] missing required string field "type". '
-                f'Supported types: {", ".join(sorted(_SCORER_BUILDERS))}.'
+                f'Supported types: {", ".join(sorted(builders))}.'
             )
-        builder = _SCORER_BUILDERS.get(scorer_type)
+        builder = builders.get(scorer_type)
         if builder is None:
             raise ValueError(
                 f'Unknown variant scorer type "{scorer_type}" at variant_scorers[{index}]. '
-                f'Supported: {", ".join(sorted(_SCORER_BUILDERS))}.'
+                f'Supported: {", ".join(sorted(builders))}.'
             )
         scorers.append(builder(item))
     return scorers
@@ -389,6 +414,12 @@ class _ServingHandler(BaseHTTPRequestHandler):
                 return
 
             if path == '/v1/score_variant':
+                if not getattr(self.adapter, 'supports_variant_scoring', False):
+                    self._write_json(
+                        {'error': 'Variant scoring not available for this model.'},
+                        status=HTTPStatus.NOT_IMPLEMENTED,
+                    )
+                    return
                 scores = self.adapter.score_variant(
                     interval=_interval_from_payload(body['interval']),
                     variant=_variant_from_payload(body['variant']),
@@ -399,6 +430,12 @@ class _ServingHandler(BaseHTTPRequestHandler):
                 return
 
             if path == '/v1/score_variants':
+                if not getattr(self.adapter, 'supports_variant_scoring', False):
+                    self._write_json(
+                        {'error': 'Variant scoring not available for this model.'},
+                        status=HTTPStatus.NOT_IMPLEMENTED,
+                    )
+                    return
                 intervals_payload = body['intervals']
                 variants_payload = body['variants']
                 if isinstance(intervals_payload, dict):
@@ -420,6 +457,12 @@ class _ServingHandler(BaseHTTPRequestHandler):
                 return
 
             if path == '/v1/score_ism_variants':
+                if not getattr(self.adapter, 'supports_variant_scoring', False):
+                    self._write_json(
+                        {'error': 'Variant scoring not available for this model.'},
+                        status=HTTPStatus.NOT_IMPLEMENTED,
+                    )
+                    return
                 interval_variant_payload = body.get('interval_variant')
                 scores = self.adapter.score_ism_variants(
                     interval=_interval_from_payload(body['interval']),

--- a/src/alphagenome_pytorch/extensions/serving/rest_service.py
+++ b/src/alphagenome_pytorch/extensions/serving/rest_service.py
@@ -458,12 +458,6 @@ class _ServingHandler(BaseHTTPRequestHandler):
                 return
 
             if path == '/v1/score_variant':
-                if not getattr(self.adapter, 'supports_variant_scoring', False):
-                    self._write_json(
-                        {'error': 'Variant scoring not available for this model.'},
-                        status=HTTPStatus.NOT_IMPLEMENTED,
-                    )
-                    return
                 scores = self.adapter.score_variant(
                     interval=_interval_from_payload(body['interval']),
                     variant=_variant_from_payload(body['variant']),
@@ -474,12 +468,6 @@ class _ServingHandler(BaseHTTPRequestHandler):
                 return
 
             if path == '/v1/score_variants':
-                if not getattr(self.adapter, 'supports_variant_scoring', False):
-                    self._write_json(
-                        {'error': 'Variant scoring not available for this model.'},
-                        status=HTTPStatus.NOT_IMPLEMENTED,
-                    )
-                    return
                 intervals_payload = body['intervals']
                 variants_payload = body['variants']
                 if isinstance(intervals_payload, dict):
@@ -501,12 +489,6 @@ class _ServingHandler(BaseHTTPRequestHandler):
                 return
 
             if path == '/v1/score_ism_variants':
-                if not getattr(self.adapter, 'supports_variant_scoring', False):
-                    self._write_json(
-                        {'error': 'Variant scoring not available for this model.'},
-                        status=HTTPStatus.NOT_IMPLEMENTED,
-                    )
-                    return
                 interval_variant_payload = body.get('interval_variant')
                 scores = self.adapter.score_ism_variants(
                     interval=_interval_from_payload(body['interval']),
@@ -546,6 +528,8 @@ class _ServingHandler(BaseHTTPRequestHandler):
                 return
 
             self._write_json({'error': 'Not found'}, status=HTTPStatus.NOT_FOUND)
+        except NotImplementedError as exc:
+            self._write_json({'error': str(exc)}, status=HTTPStatus.NOT_IMPLEMENTED)
         except Exception as exc:  # pragma: no cover - exercised in integration.
             self._write_json({'error': str(exc)}, status=HTTPStatus.BAD_REQUEST)
 

--- a/src/alphagenome_pytorch/extensions/serving/scorer.py
+++ b/src/alphagenome_pytorch/extensions/serving/scorer.py
@@ -1,0 +1,413 @@
+"""Variant scoring as a composable capability.
+
+Holds the scoring-specific state (a :class:`VariantScoringModel` plus the
+scorer-conversion logic) so the serving adapter doesn't need a subclass to
+opt in. ``LocalDnaModelAdapter`` takes a :class:`VariantScorer` instance and
+delegates ``score_*`` calls to it; if no scorer is configured, those calls
+raise ``NotImplementedError``, which the REST layer maps to HTTP 501.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import importlib
+import itertools
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from alphagenome.data import genome
+from alphagenome.models import dna_output
+from alphagenome.protos import dna_model_pb2
+
+from alphagenome_pytorch.prediction import AlphaGenomePredictionRuntime
+from alphagenome_pytorch.variant_scoring.inference import (
+    VariantScoringModel,
+    get_recommended_scorers,
+)
+from alphagenome_pytorch.variant_scoring.scorers import (
+    BaseVariantScorer as PTBaseVariantScorer,
+    CenterMaskScorer as PTCenterMaskScorer,
+    ContactMapScorer as PTContactMapScorer,
+    GeneMaskActiveScorer as PTGeneMaskActiveScorer,
+    GeneMaskLFCScorer as PTGeneMaskLFCScorer,
+    GeneMaskSplicingScorer as PTGeneMaskSplicingScorer,
+    PolyadenylationScorer as PTPolyadenylationScorer,
+    SpliceJunctionScorer as PTSpliceJunctionScorer,
+)
+from alphagenome_pytorch.variant_scoring.types import (
+    AggregationType as PTAggregationType,
+    OutputType as PTOutputType,
+    VariantScore,
+)
+
+from .adapter import (
+    DEFAULT_MAX_WORKERS,
+    MAX_VARIANT_SCORERS_PER_REQUEST,
+    _OFFICIAL_TO_PT_OUTPUT,
+    _as_numpy,
+    _interval_to_pt,
+    _normalize_output_type,
+    _pt_metadata_to_track_df,
+    _validate_sequence_length,
+    _variant_to_pt,
+)
+
+ISM_NUCLEOTIDES = "ACGT"
+_PT_AGGREGATION_BY_NAME = {a.name: a for a in PTAggregationType}
+
+
+def _import_anndata_module():
+    return importlib.import_module("anndata")
+
+
+class VariantScorer:
+    """Bundles a :class:`VariantScoringModel` with conversion helpers.
+
+    Construct one and pass it as ``scorer=`` to :class:`LocalDnaModelAdapter`
+    to enable variant-scoring routes. Without it, the adapter raises
+    ``NotImplementedError`` from ``score_*`` calls.
+
+    Holds a reference to the same ``runtime`` the adapter uses — both objects
+    rely on it for sequence access and track metadata.
+    """
+
+    def __init__(
+        self,
+        runtime: AlphaGenomePredictionRuntime,
+        scoring_model: VariantScoringModel,
+    ):
+        self.runtime = runtime
+        self.scoring_model = scoring_model
+
+    def score_variant(
+        self,
+        interval: genome.Interval,
+        variant: genome.Variant,
+        variant_scorers: Sequence[Any] = (),
+        *,
+        organism: Any = dna_model_pb2.ORGANISM_HOMO_SAPIENS,
+    ) -> list[Any]:
+        _validate_sequence_length(interval.width)
+        organism_index = self.runtime.resolve_organism_index(organism)
+
+        if not variant_scorers:
+            organism_name = "human" if organism_index == 0 else "mouse"
+            variant_scorers = list(get_recommended_scorers(organism_name))
+
+        if len(variant_scorers) > MAX_VARIANT_SCORERS_PER_REQUEST:
+            raise ValueError(
+                f"Too many variant scorers requested: {len(variant_scorers)} "
+                f"(max {MAX_VARIANT_SCORERS_PER_REQUEST})."
+            )
+        if len(variant_scorers) != len(set(map(str, variant_scorers))):
+            raise ValueError(f"Duplicate variant scorers requested: {variant_scorers}.")
+
+        local_scorers = [self._to_local_variant_scorer(vs) for vs in variant_scorers]
+        scorer_results = self.scoring_model.score_variant(
+            interval=_interval_to_pt(interval),
+            variant=_variant_to_pt(variant),
+            scorers=local_scorers,
+            organism=organism_index,
+        )
+
+        return [
+            self._scores_to_anndata(
+                scores=local_result,
+                organism_index=organism_index,
+                fallback_variant_scorer=original_scorer,
+                interval=interval,
+                variant=variant,
+            )
+            for original_scorer, local_result in zip(
+                variant_scorers, scorer_results, strict=True
+            )
+        ]
+
+    def score_variants(
+        self,
+        intervals: genome.Interval | Sequence[genome.Interval],
+        variants: Sequence[genome.Variant],
+        variant_scorers: Sequence[Any] = (),
+        *,
+        organism: Any = dna_model_pb2.ORGANISM_HOMO_SAPIENS,
+        progress_bar: bool = True,
+        max_workers: int = DEFAULT_MAX_WORKERS,
+    ) -> list[list[Any]]:
+        if not isinstance(intervals, Sequence):
+            intervals = [intervals] * len(variants)
+        if len(intervals) != len(variants):
+            raise ValueError(
+                "Intervals and variants must have the same length. "
+                f"Got {len(intervals)} intervals and {len(variants)} variants."
+            )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = [
+                executor.submit(
+                    self.score_variant,
+                    interval=interval,
+                    variant=variant,
+                    variant_scorers=variant_scorers,
+                    organism=organism,
+                )
+                for interval, variant in zip(intervals, variants, strict=True)
+            ]
+
+            iterator: Iterable[Any]
+            if progress_bar:
+                try:
+                    import tqdm.auto
+
+                    iterator = tqdm.auto.tqdm(
+                        concurrent.futures.as_completed(futures),
+                        total=len(futures),
+                        desc="Scoring variants",
+                    )
+                except ImportError:
+                    iterator = concurrent.futures.as_completed(futures)
+            else:
+                iterator = concurrent.futures.as_completed(futures)
+
+            for future in iterator:
+                if (exc := future.exception()) is not None:
+                    executor.shutdown(wait=False, cancel_futures=True)
+                    raise exc
+
+            return [future.result() for future in futures]
+
+    def score_ism_variants(
+        self,
+        interval: genome.Interval,
+        ism_interval: genome.Interval,
+        variant_scorers: Sequence[Any] = (),
+        *,
+        organism: Any = dna_model_pb2.ORGANISM_HOMO_SAPIENS,
+        interval_variant: genome.Variant | None = None,
+        progress_bar: bool = True,
+        max_workers: int = DEFAULT_MAX_WORKERS,
+    ) -> list[list[Any]]:
+        _validate_sequence_length(interval.width)
+        if ism_interval.negative_strand:
+            raise ValueError("ISM interval must be on the positive strand.")
+        if ism_interval.chromosome != interval.chromosome:
+            raise ValueError("ISM interval chromosome must match interval chromosome.")
+        if ism_interval.start < interval.start or ism_interval.end > interval.end:
+            raise ValueError("ISM interval must be contained within interval.")
+
+        sequence = self.runtime.get_sequence(interval, variant=interval_variant)
+
+        variants: list[genome.Variant] = []
+        for genomic_pos_0b in range(ism_interval.start, ism_interval.end):
+            rel = genomic_pos_0b - interval.start
+            if rel < 0 or rel >= len(sequence):
+                continue
+            ref_base = sequence[rel].upper()
+            if ref_base not in ISM_NUCLEOTIDES:
+                continue
+            for alt_base in ISM_NUCLEOTIDES:
+                if alt_base == ref_base:
+                    continue
+                variants.append(
+                    genome.Variant(
+                        chromosome=interval.chromosome,
+                        position=genomic_pos_0b + 1,
+                        reference_bases=ref_base,
+                        alternate_bases=alt_base,
+                    )
+                )
+
+        if not variants:
+            return []
+
+        return self.score_variants(
+            intervals=interval,
+            variants=variants,
+            variant_scorers=variant_scorers,
+            organism=organism,
+            progress_bar=progress_bar,
+            max_workers=max_workers,
+        )
+
+    def _to_local_variant_scorer(self, scorer: Any) -> PTBaseVariantScorer:
+        if isinstance(scorer, PTBaseVariantScorer):
+            return scorer
+
+        base = getattr(scorer, "base_variant_scorer", None)
+        base_name = getattr(base, "name", None)
+        class_name = scorer.__class__.__name__
+        scorer_kind = (base_name or class_name or "").upper()
+        requested_output = getattr(scorer, "requested_output", None)
+
+        if scorer_kind in {"CENTER_MASK", "CENTERMASKSCORER"}:
+            aggregation = getattr(scorer, "aggregation_type", None)
+            aggregation_name = getattr(aggregation, "name", None)
+            if aggregation_name is None:
+                raise ValueError(f"Unsupported center-mask scorer: {scorer}")
+            return PTCenterMaskScorer(
+                requested_output=_OFFICIAL_TO_PT_OUTPUT[_normalize_output_type(requested_output)],
+                width=getattr(scorer, "width", None),
+                aggregation_type=_PT_AGGREGATION_BY_NAME[aggregation_name],
+            )
+        if scorer_kind in {"CONTACT_MAP", "CONTACTMAPSCORER"}:
+            return PTContactMapScorer()
+        if scorer_kind in {"GENE_MASK_LFC", "GENEMASKLFCSCORER"}:
+            return PTGeneMaskLFCScorer(
+                requested_output=_OFFICIAL_TO_PT_OUTPUT[_normalize_output_type(requested_output)],
+                resolution=1,
+            )
+        if scorer_kind in {"GENE_MASK_ACTIVE", "GENEMASKACTIVESCORER"}:
+            return PTGeneMaskActiveScorer(
+                requested_output=_OFFICIAL_TO_PT_OUTPUT[_normalize_output_type(requested_output)],
+                resolution=1,
+            )
+        if scorer_kind in {"GENE_MASK_SPLICING", "GENEMASKSPLICINGSCORER"}:
+            return PTGeneMaskSplicingScorer(
+                requested_output=_OFFICIAL_TO_PT_OUTPUT[_normalize_output_type(requested_output)],
+                width=getattr(scorer, "width", None),
+            )
+        if scorer_kind in {"PA_QTL", "POLYADENYLATIONSCORER"}:
+            return PTPolyadenylationScorer()
+        if scorer_kind in {"SPLICE_JUNCTION", "SPLICEJUNCTIONSCORER"}:
+            return PTSpliceJunctionScorer()
+
+        which = getattr(scorer, "WhichOneof", None)
+        if callable(which):
+            field = scorer.WhichOneof("scorer")
+            if field == "center_mask":
+                center = scorer.center_mask
+                return PTCenterMaskScorer(
+                    requested_output=_OFFICIAL_TO_PT_OUTPUT[
+                        dna_output.OutputType(center.requested_output)
+                    ],
+                    width=center.width if center.HasField("width") else None,
+                    aggregation_type=_PT_AGGREGATION_BY_NAME[
+                        dna_model_pb2.AggregationType.Name(center.aggregation_type)
+                        .removeprefix("AGGREGATION_TYPE_")
+                    ],
+                )
+            if field == "contact_map":
+                return PTContactMapScorer()
+            if field == "gene_mask":
+                return PTGeneMaskLFCScorer(
+                    requested_output=_OFFICIAL_TO_PT_OUTPUT[
+                        dna_output.OutputType(scorer.gene_mask.requested_output)
+                    ],
+                    resolution=1,
+                )
+            if field == "gene_mask_active":
+                return PTGeneMaskActiveScorer(
+                    requested_output=_OFFICIAL_TO_PT_OUTPUT[
+                        dna_output.OutputType(scorer.gene_mask_active.requested_output)
+                    ],
+                    resolution=1,
+                )
+            if field == "gene_mask_splicing":
+                return PTGeneMaskSplicingScorer(
+                    requested_output=_OFFICIAL_TO_PT_OUTPUT[
+                        dna_output.OutputType(scorer.gene_mask_splicing.requested_output)
+                    ],
+                    width=scorer.gene_mask_splicing.width
+                    if scorer.gene_mask_splicing.HasField("width")
+                    else None,
+                )
+            if field == "pa_qtl":
+                return PTPolyadenylationScorer()
+            if field == "splice_junction":
+                return PTSpliceJunctionScorer()
+
+        raise ValueError(f"Unsupported variant scorer type: {scorer!r}")
+
+    def _scores_to_anndata(
+        self,
+        *,
+        scores: VariantScore | list[VariantScore],
+        organism_index: int,
+        fallback_variant_scorer: Any,
+        interval: genome.Interval,
+        variant: genome.Variant,
+    ):
+        anndata = _import_anndata_module()
+
+        score_list = scores if isinstance(scores, list) else [scores]
+        if not score_list:
+            return anndata.AnnData(
+                X=np.zeros((0, 0), dtype=np.float32),
+                obs=pd.DataFrame(),
+                var=pd.DataFrame(columns=["name", "strand"]),
+                uns={
+                    "interval": interval,
+                    "variant": variant,
+                    "variant_scorer": fallback_variant_scorer,
+                },
+            )
+
+        x_rows = []
+        obs_rows = []
+        has_gene_metadata = False
+        for score in score_list:
+            values = _as_numpy(score.scores).astype(np.float32, copy=False)
+            if values.ndim != 1:
+                values = values.reshape(-1)
+            x_rows.append(values)
+
+            row = {
+                "gene_id": score.gene_id,
+                "gene_name": score.gene_name,
+                "gene_type": score.gene_type,
+                "strand": score.gene_strand,
+                "junction_Start": score.junction_start,
+                "junction_End": score.junction_end,
+            }
+            if any(v is not None for v in row.values()):
+                has_gene_metadata = True
+            obs_rows.append(row)
+
+        X = np.stack(x_rows, axis=0).astype(np.float32, copy=False)
+        n_tracks = X.shape[1] if X.ndim == 2 else 0
+
+        scorer_for_output = score_list[0].scorer if score_list else None
+        requested_output = getattr(scorer_for_output, "requested_output", None)
+        if isinstance(requested_output, PTOutputType):
+            pt_output = requested_output
+        else:
+            pt_output = _OFFICIAL_TO_PT_OUTPUT.get(
+                _normalize_output_type(
+                    getattr(
+                        fallback_variant_scorer,
+                        "requested_output",
+                        dna_output.OutputType.RNA_SEQ,
+                    )
+                ),
+                PTOutputType.RNA_SEQ,
+            )
+        track_metadata = self.runtime.get_track_metadata(
+            organism_index,
+            output_name=pt_output.value,
+        )
+        var_df = _pt_metadata_to_track_df(track_metadata, num_tracks=n_tracks)
+
+        if has_gene_metadata:
+            obs_df = pd.DataFrame(obs_rows)
+            obs_df.index = obs_df.index.map(str)
+        else:
+            obs_df = pd.DataFrame(index=[str(i) for i in range(X.shape[0])])
+
+        var_df = var_df.reset_index(drop=True)
+        var_df.index = var_df.index.map(str)
+
+        return anndata.AnnData(
+            X=X,
+            obs=obs_df,
+            var=var_df,
+            uns={
+                "interval": interval,
+                "variant": variant,
+                "variant_scorer": fallback_variant_scorer,
+            },
+        )
+
+
+__all__ = ["VariantScorer"]

--- a/src/alphagenome_pytorch/genome.py
+++ b/src/alphagenome_pytorch/genome.py
@@ -1,0 +1,410 @@
+"""Genome-coordinate types and FASTA-backed sequence access."""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from enum import IntEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Union
+
+import numpy as np
+import torch
+
+from alphagenome_pytorch.utils.sequence import (
+    onehot_tensor_to_sequence,
+    sequence_to_onehot,
+    sequence_to_onehot_tensor,
+)
+
+if TYPE_CHECKING:
+    import pyfaidx
+
+
+class Width(IntEnum):
+    """Supported AlphaGenome interval widths.
+
+    IntEnum so it works anywhere a raw base-pair integer is expected.
+    """
+
+    W_2KB = 2 * 1024
+    W_4KB = 4 * 1024
+    W_8KB = 8 * 1024
+    W_16KB = 16 * 1024
+    W_100KB = 128 * 1024
+    W_300KB = 256 * 1024
+    W_500KB = 512 * 1024
+    W_1MB = 1024 * 1024
+
+    @classmethod
+    def normalize(cls, value: Union["Width", int, str]) -> int:
+        names = {
+            "2KB": cls.W_2KB,
+            "4KB": cls.W_4KB,
+            "8KB": cls.W_8KB,
+            "16KB": cls.W_16KB,
+            "100KB": cls.W_100KB,
+            "300KB": cls.W_300KB,
+            "500KB": cls.W_500KB,
+            "1MB": cls.W_1MB,
+        }
+        if isinstance(value, int):
+            if value in [int(v) for v in names.values()]:
+                return int(value)
+            raise ValueError(
+                f"{value} is not a supported width. "
+                f"Choose from: {', '.join(names)}"
+            )
+        if isinstance(value, str):
+            key = value.strip().upper()
+            if key in names:
+                return int(names[key])
+            prefixed = key.removeprefix("W_")
+            if prefixed in names:
+                return int(names[prefixed])
+            raise ValueError(
+                f"Invalid width {value!r}. Choose from: {', '.join(names)}"
+            )
+        raise TypeError(f"Unsupported width type: {type(value)}")
+
+
+@dataclass(frozen=True)
+class Interval:
+    """Genomic interval using 0-based, half-open coordinates."""
+
+    chromosome: str
+    start: int
+    end: int
+    strand: str = "."
+    name: str = ""
+
+    def __post_init__(self) -> None:
+        if self.start < 0:
+            raise ValueError(f"Start position must be non-negative, got {self.start}")
+        if self.end <= self.start:
+            raise ValueError(f"End ({self.end}) must be greater than start ({self.start})")
+        if self.strand not in ("+", "-", "."):
+            raise ValueError(f"Strand must be '+', '-', or '.', got {self.strand!r}")
+
+    @property
+    def width(self) -> int:
+        return self.end - self.start
+
+    @property
+    def center(self) -> int:
+        return (self.start + self.end) // 2
+
+    def contains(self, position: int) -> bool:
+        return self.start <= position < self.end
+
+    def __str__(self) -> str:
+        if self.strand == ".":
+            return f"{self.chromosome}:{self.start}-{self.end}"
+        return f"{self.chromosome}:{self.start}-{self.end}:{self.strand}"
+
+    @classmethod
+    def from_str(cls, value: str) -> "Interval":
+        match = re.match(r"^([^:]+):(\d+)-(\d+):([+\-.])$", value)
+        if match:
+            return cls(match.group(1), int(match.group(2)), int(match.group(3)), match.group(4))
+        match = re.match(r"^([^:]+):(\d+)-(\d+)$", value)
+        if match:
+            return cls(match.group(1), int(match.group(2)), int(match.group(3)))
+        raise ValueError(f"Could not parse interval string: {value!r}")
+
+    @classmethod
+    def centered_on(
+        cls,
+        chromosome: str,
+        position: int,
+        width: Union[Width, int, str] = Width.W_100KB,
+    ) -> "Interval":
+        normalized = Width.normalize(width)
+        half_width = normalized // 2
+        return cls(
+            chromosome=chromosome,
+            start=max(0, position - half_width),
+            end=position + half_width + (normalized % 2),
+        )
+
+
+@dataclass(frozen=True)
+class Variant:
+    """Genomic variant using VCF-style 1-based position."""
+
+    chromosome: str
+    position: int
+    reference_bases: str
+    alternate_bases: str
+    name: str = ""
+
+    def __post_init__(self) -> None:
+        if self.position < 1:
+            raise ValueError(f"Position must be >= 1 (VCF convention), got {self.position}")
+        if not self.reference_bases:
+            raise ValueError("Reference bases cannot be empty")
+        if not self.alternate_bases:
+            raise ValueError("Alternate bases cannot be empty")
+        object.__setattr__(self, "reference_bases", self.reference_bases.upper())
+        object.__setattr__(self, "alternate_bases", self.alternate_bases.upper())
+
+    @property
+    def start(self) -> int:
+        return self.position - 1
+
+    @property
+    def end(self) -> int:
+        return self.start + len(self.reference_bases)
+
+    @property
+    def is_snv(self) -> bool:
+        return len(self.reference_bases) == 1 and len(self.alternate_bases) == 1
+
+    @property
+    def is_insertion(self) -> bool:
+        return len(self.alternate_bases) > len(self.reference_bases)
+
+    @property
+    def is_deletion(self) -> bool:
+        return len(self.alternate_bases) < len(self.reference_bases)
+
+    @property
+    def is_indel(self) -> bool:
+        return self.is_insertion or self.is_deletion
+
+    def __str__(self) -> str:
+        return f"{self.chromosome}:{self.position}:{self.reference_bases}>{self.alternate_bases}"
+
+    @classmethod
+    def from_str(cls, value: str, format: str = "default") -> "Variant":
+        if format == "default":
+            match = re.match(r"^([^:]+):(\d+):([ACGTN]+)>([ACGTN]+)$", value, re.IGNORECASE)
+            if match:
+                return cls(
+                    chromosome=match.group(1),
+                    position=int(match.group(2)),
+                    reference_bases=match.group(3),
+                    alternate_bases=match.group(4),
+                )
+            raise ValueError(f"Could not parse variant string: {value!r}")
+        if format == "gtex":
+            parts = value.split("_")
+            if len(parts) >= 4:
+                return cls(parts[0], int(parts[1]), parts[2], parts[3])
+            raise ValueError(f"Could not parse GTEx variant string: {value!r}")
+        if format == "gnomad":
+            parts = value.split("-")
+            if len(parts) >= 4:
+                return cls(parts[0], int(parts[1]), parts[2], parts[3])
+            raise ValueError(f"Could not parse gnomAD variant string: {value!r}")
+        raise ValueError(f"Unknown format: {format!r}")
+
+
+def _coerce_interval(interval: object) -> Interval:
+    return Interval(
+        chromosome=getattr(interval, "chromosome"),
+        start=int(getattr(interval, "start")),
+        end=int(getattr(interval, "end")),
+        strand=getattr(interval, "strand", "."),
+        name=getattr(interval, "name", ""),
+    )
+
+
+def _coerce_variant(variant: object) -> Variant:
+    return Variant(
+        chromosome=getattr(variant, "chromosome"),
+        position=int(getattr(variant, "position")),
+        reference_bases=getattr(variant, "reference_bases"),
+        alternate_bases=getattr(variant, "alternate_bases"),
+        name=getattr(variant, "name", ""),
+    )
+
+
+def apply_variant_to_sequence(sequence: str, variant: object, interval: object) -> str:
+    """Apply a variant to a reference sequence."""
+    v = _coerce_variant(variant)
+    i = _coerce_interval(interval)
+    if v.chromosome != i.chromosome:
+        raise ValueError(
+            f"Variant chromosome ({v.chromosome}) doesn't match interval chromosome ({i.chromosome})"
+        )
+
+    var_start = v.start - i.start
+    var_end = var_start + len(v.reference_bases)
+    if var_start < 0 or var_end > len(sequence):
+        raise ValueError(
+            f"Variant position {v.position} (ref length {len(v.reference_bases)}) "
+            f"is outside interval {i}"
+        )
+
+    seq_ref = sequence[var_start:var_end].upper()
+    if seq_ref != v.reference_bases:
+        raise ValueError(
+            f"Reference allele mismatch at {v.chromosome}:{v.position}. "
+            f"Expected {v.reference_bases!r}, found {seq_ref!r} in sequence"
+        )
+    return sequence[:var_start] + v.alternate_bases + sequence[var_end:]
+
+
+def apply_variant_to_onehot(onehot: torch.Tensor, variant: object, interval: object) -> torch.Tensor:
+    """Apply a variant to a one-hot encoded sequence."""
+    v = _coerce_variant(variant)
+    i = _coerce_interval(interval)
+    if v.is_snv:
+        base_to_idx = {"A": 0, "C": 1, "G": 2, "T": 3}
+        var_pos = v.start - i.start
+        if var_pos < 0 or var_pos >= onehot.shape[0]:
+            raise ValueError(f"Variant position {v.position} is outside interval {i}")
+        alt_onehot = onehot.clone()
+        alt_onehot[var_pos] = 0.0
+        alt_onehot[var_pos, base_to_idx[v.alternate_bases]] = 1.0
+        return alt_onehot
+
+    ref_seq = onehot_tensor_to_sequence(onehot)
+    alt_seq = apply_variant_to_sequence(ref_seq, v, i)
+    return sequence_to_onehot_tensor(alt_seq, dtype=onehot.dtype, device=onehot.device)
+
+
+class GenomeSequenceSource:
+    """FASTA-backed sequence source with optional chromosome-level cache."""
+
+    def __init__(
+        self,
+        fasta_path: str | Path,
+        *,
+        chromosomes: set[str] | None = None,
+        cache: bool = False,
+        ambiguous: str = "zero",
+        verbose: bool = False,
+    ):
+        try:
+            import pyfaidx
+        except ImportError as exc:
+            raise ImportError(
+                "pyfaidx is required for FASTA extraction. Install with: pip install pyfaidx"
+            ) from exc
+
+        self.fasta_path = str(fasta_path)
+        self.ambiguous = ambiguous
+        self._pyfaidx = pyfaidx
+        self._fasta: pyfaidx.Fasta | None = None
+        self._owner_pid: int | None = None
+        self._cache: dict[str, np.ndarray] = {}
+        self.chrom_sizes: dict[str, int] = {}
+
+        fasta = pyfaidx.Fasta(self.fasta_path)
+        try:
+            for ref in fasta.keys():
+                self.chrom_sizes[ref] = len(fasta[ref])
+            if cache:
+                refs_to_load = chromosomes if chromosomes else set(fasta.keys())
+                for ref in refs_to_load:
+                    if ref in self.chrom_sizes:
+                        self._cache[ref] = sequence_to_onehot(
+                            str(fasta[ref][:]), ambiguous=ambiguous
+                        )
+        finally:
+            fasta.close()
+
+        if verbose and cache:
+            cached_mb = sum(arr.nbytes for arr in self._cache.values()) / 1e6
+            print(f"Cached genome: loaded {len(self._cache)} chromosomes ({cached_mb:.1f} MB)")
+
+    @property
+    def fasta(self) -> "pyfaidx.Fasta":
+        current_pid = os.getpid()
+        if self._fasta is None or self._owner_pid != current_pid:
+            if self._fasta is not None:
+                try:
+                    self._fasta.close()
+                except Exception:
+                    pass
+            self._fasta = self._pyfaidx.Fasta(self.fasta_path)
+            self._owner_pid = current_pid
+        return self._fasta
+
+    def _resolve_chrom(self, chrom: str) -> str:
+        if chrom in self.chrom_sizes:
+            return chrom
+        alt = chrom[3:] if chrom.startswith("chr") else f"chr{chrom}"
+        if alt in self.chrom_sizes:
+            return alt
+        raise ValueError(f"Chromosome {chrom} not found in FASTA file")
+
+    def fetch_sequence(self, interval: object, *, variant: object | None = None) -> str:
+        i = _coerce_interval(interval)
+        chrom = self._resolve_chrom(i.chromosome)
+        seq = str(self.fasta[chrom][i.start:i.end]).upper()
+        if variant is not None:
+            seq = apply_variant_to_sequence(seq, variant, i)
+        return seq
+
+    def fetch_onehot(
+        self,
+        chrom: str,
+        start: int,
+        end: int,
+        *,
+        ambiguous: str | None = None,
+        pad: bool = False,
+        copy: bool = True,
+    ) -> np.ndarray:
+        policy = ambiguous or self.ambiguous
+        seq_len = end - start
+        resolved = self._resolve_chrom(chrom)
+        chrom_len = self.chrom_sizes[resolved]
+
+        if start >= 0 and end <= chrom_len:
+            if resolved in self._cache:
+                view = self._cache[resolved][start:end]
+                return view.copy() if copy else view
+            return sequence_to_onehot(
+                str(self.fasta[resolved][start:end]), ambiguous=policy
+            )
+
+        if not pad:
+            raise ValueError(f"Requested interval {chrom}:{start}-{end} is out of bounds")
+
+        result = np.full((seq_len, 4), 0.25, dtype=np.float32)
+        valid_start = max(0, start)
+        valid_end = min(chrom_len, end)
+        if valid_start < valid_end:
+            if resolved in self._cache:
+                seq = self._cache[resolved][valid_start:valid_end]
+            else:
+                seq = sequence_to_onehot(
+                    str(self.fasta[resolved][valid_start:valid_end]),
+                    ambiguous=policy,
+                )
+            dest_start = valid_start - start
+            result[dest_start:dest_start + (valid_end - valid_start)] = seq
+        return result
+
+    def close(self) -> None:
+        if self._fasta is not None:
+            self._fasta.close()
+            self._fasta = None
+            self._owner_pid = None
+
+    def __enter__(self) -> "GenomeSequenceSource":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
+
+def extract_sequence_from_fasta(fasta_path: str | Path, interval: object) -> str:
+    with GenomeSequenceSource(fasta_path) as source:
+        return source.fetch_sequence(interval)
+
+
+__all__ = [
+    "Width",
+    "Interval",
+    "Variant",
+    "GenomeSequenceSource",
+    "apply_variant_to_sequence",
+    "apply_variant_to_onehot",
+    "extract_sequence_from_fasta",
+]

--- a/src/alphagenome_pytorch/genome.py
+++ b/src/alphagenome_pytorch/genome.py
@@ -275,7 +275,6 @@ class GenomeSequenceSource:
         *,
         chromosomes: set[str] | None = None,
         cache: bool = False,
-        ambiguous: str = "zero",
         verbose: bool = False,
     ):
         try:
@@ -286,7 +285,6 @@ class GenomeSequenceSource:
             ) from exc
 
         self.fasta_path = str(fasta_path)
-        self.ambiguous = ambiguous
         self._pyfaidx = pyfaidx
         self._fasta: pyfaidx.Fasta | None = None
         self._owner_pid: int | None = None
@@ -302,7 +300,7 @@ class GenomeSequenceSource:
                 for ref in refs_to_load:
                     if ref in self.chrom_sizes:
                         self._cache[ref] = sequence_to_onehot(
-                            str(fasta[ref][:]), ambiguous=ambiguous
+                            str(fasta[ref][:])
                         )
         finally:
             fasta.close()
@@ -346,37 +344,33 @@ class GenomeSequenceSource:
         start: int,
         end: int,
         *,
-        ambiguous: str | None = None,
         pad: bool = False,
         copy: bool = True,
     ) -> np.ndarray:
-        policy = ambiguous or self.ambiguous
         seq_len = end - start
         resolved = self._resolve_chrom(chrom)
         chrom_len = self.chrom_sizes[resolved]
 
+        cached = resolved in self._cache
+
+        def _encode(lo: int, hi: int) -> np.ndarray:
+            if cached:
+                return self._cache[resolved][lo:hi]
+            return sequence_to_onehot(str(self.fasta[resolved][lo:hi]))
+
         if start >= 0 and end <= chrom_len:
-            if resolved in self._cache:
-                view = self._cache[resolved][start:end]
-                return view.copy() if copy else view
-            return sequence_to_onehot(
-                str(self.fasta[resolved][start:end]), ambiguous=policy
-            )
+            seq = _encode(start, end)
+            return seq.copy() if (copy and cached) else seq
 
         if not pad:
             raise ValueError(f"Requested interval {chrom}:{start}-{end} is out of bounds")
 
-        result = np.full((seq_len, 4), 0.25, dtype=np.float32)
+        # Padding is zeros (same as unknown-base encoding).
+        result = np.zeros((seq_len, 4), dtype=np.uint8)
         valid_start = max(0, start)
         valid_end = min(chrom_len, end)
         if valid_start < valid_end:
-            if resolved in self._cache:
-                seq = self._cache[resolved][valid_start:valid_end]
-            else:
-                seq = sequence_to_onehot(
-                    str(self.fasta[resolved][valid_start:valid_end]),
-                    ambiguous=policy,
-                )
+            seq = _encode(valid_start, valid_end)
             dest_start = valid_start - start
             result[dest_start:dest_start + (valid_end - valid_start)] = seq
         return result

--- a/src/alphagenome_pytorch/prediction.py
+++ b/src/alphagenome_pytorch/prediction.py
@@ -1,0 +1,250 @@
+"""Shared raw prediction runtime for AlphaGenome models."""
+
+from __future__ import annotations
+
+import gc
+from pathlib import Path
+from typing import Any, Mapping
+
+import torch
+
+from alphagenome_pytorch.genome import (
+    GenomeSequenceSource,
+    Interval,
+    apply_variant_to_sequence,
+)
+from alphagenome_pytorch.named_outputs import TrackMetadata, TrackMetadataCatalog
+from alphagenome_pytorch.utils.sequence import sequence_to_onehot_tensor
+
+
+class AlphaGenomePredictionRuntime:
+    """Own model/device/FASTA plumbing for raw prediction calls.
+
+    This is intentionally independent from variant scoring. Scoring can compose
+    this runtime, but raw serving and attribution should not need to construct a
+    ``VariantScoringModel``.
+    """
+
+    organism_map = {
+        "human": 0,
+        "homo_sapiens": 0,
+        "mouse": 1,
+        "mus_musculus": 1,
+        "HOMO_SAPIENS": 0,
+        "MUS_MUSCULUS": 1,
+        # NCBI taxonomy IDs — these are the values of the
+        # ``dna_model_pb2.ORGANISM_*`` proto enum constants, so the runtime can
+        # accept them transparently without importing alphagenome.protos.
+        9606: 0,
+        10090: 1,
+    }
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        *,
+        fasta_path: str | Path | None = None,
+        sequence_source: GenomeSequenceSource | None = None,
+        metadata_catalog: TrackMetadataCatalog | None = None,
+        track_metadata: Mapping[int, Mapping[Any, list[Any]]] | None = None,
+        track_names: Mapping[str, list[str]] | list[str] | None = None,
+        device: str | torch.device | None = None,
+        default_organism: str | int | None = "human",
+    ):
+        if sequence_source is None and fasta_path is not None:
+            sequence_source = GenomeSequenceSource(fasta_path)
+        self.sequence_source = sequence_source
+        self.metadata_catalog = metadata_catalog
+        self._legacy_track_metadata = track_metadata or {}
+        self._track_names = track_names
+
+        if device is None:
+            try:
+                device = next(model.parameters()).device
+            except StopIteration:
+                device = torch.device("cpu")
+        self.device = torch.device(device)
+        self.model = model.to(self.device)
+        self.model.eval()
+        self.num_organisms = getattr(model, "num_organisms", 2)
+        self.default_organism_index = (
+            self.resolve_organism_index(default_organism)
+            if default_organism is not None
+            else None
+        )
+
+    def resolve_organism_index(self, organism: Any = None) -> int:
+        """Map an organism specifier to the runtime's internal organism index.
+
+        Accepts:
+
+        * ``None`` — returns ``self.default_organism_index`` (or 0 if unset).
+        * Strings: ``"human"``, ``"mouse"``, ``"homo_sapiens"``, ``"HOMO_SAPIENS"``,
+          ``"ORGANISM_HOMO_SAPIENS"`` (proto enum name), etc.
+        * Integers: NCBI taxonomy IDs 9606 / 10090 (the values of the
+          ``dna_model_pb2.ORGANISM_*`` proto enum constants), or raw 0/1
+          internal indices via the ``__index__`` fallback.
+        * Enum-like objects exposing ``.value`` or ``.name``.
+
+        Raw integers fall through to a bounds check against
+        ``self.num_organisms``.
+        """
+        if organism is None:
+            return self.default_organism_index if self.default_organism_index is not None else 0
+        if hasattr(organism, "value"):
+            candidate = getattr(organism, "value")
+            if candidate in self.organism_map:
+                return self.organism_map[candidate]
+        if hasattr(organism, "name"):
+            candidate = getattr(organism, "name")
+            if candidate in self.organism_map:
+                return self.organism_map[candidate]
+            if isinstance(candidate, str):
+                stripped = candidate.removeprefix("ORGANISM_")
+                if stripped in self.organism_map:
+                    return self.organism_map[stripped]
+        if organism in self.organism_map:
+            return self.organism_map[organism]
+        if hasattr(organism, "__index__"):
+            idx = int(organism)
+        elif isinstance(organism, str):
+            normalized = organism.upper().removeprefix("ORGANISM_")
+            if normalized in self.organism_map:
+                idx = self.organism_map[normalized]
+            else:
+                lower = organism.lower()
+                if lower in self.organism_map:
+                    idx = self.organism_map[lower]
+                else:
+                    idx = int(organism)
+        else:
+            raise ValueError(f"Invalid organism type: {type(organism)}")
+        if idx < 0 or idx >= self.num_organisms:
+            raise ValueError(
+                f"Organism index {idx} out of range for model with {self.num_organisms} organisms"
+            )
+        return idx
+
+    def get_sequence(self, interval: Any, variant: Any | None = None) -> str:
+        if self.sequence_source is None:
+            raise ValueError("FASTA path not provided. Cannot extract interval sequence.")
+        return self.sequence_source.fetch_sequence(interval, variant=variant)
+
+    @torch.no_grad()
+    def predict(
+        self,
+        sequence: str | torch.Tensor,
+        organism: Any = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        organism_index = self.resolve_organism_index(organism)
+        if isinstance(sequence, str):
+            dtype = getattr(self.model, "dtype_policy", None)
+            dtype = getattr(dtype, "compute_dtype", torch.float32)
+            onehot = sequence_to_onehot_tensor(
+                sequence,
+                dtype=dtype,
+                device=self.device,
+                ambiguous="zero",
+            )
+        else:
+            dtype = getattr(self.model, "dtype_policy", None)
+            dtype = getattr(dtype, "compute_dtype", sequence.dtype)
+            onehot = sequence.to(dtype=dtype, device=self.device)
+        if onehot.dim() == 2:
+            onehot = onehot.unsqueeze(0)
+        org_idx = torch.full(
+            (onehot.shape[0],),
+            organism_index,
+            dtype=torch.long,
+            device=self.device,
+        )
+        return self.model(onehot, org_idx, **kwargs)
+
+    @torch.no_grad()
+    def predict_variant(
+        self,
+        interval: Any,
+        variant: Any,
+        organism: Any = None,
+        *,
+        to_cpu: bool = False,
+        unified_splicing: bool = False,
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        if unified_splicing:
+            raise NotImplementedError(
+                "Unified splicing prediction remains part of variant scoring."
+            )
+        interval_length = int(getattr(interval, "width", getattr(interval, "end") - getattr(interval, "start")))
+        deletion_extension = max(
+            0,
+            len(getattr(variant, "reference_bases")) - len(getattr(variant, "alternate_bases")),
+        )
+        if deletion_extension > 0:
+            extraction_interval = Interval(
+                getattr(interval, "chromosome"),
+                int(getattr(interval, "start")),
+                int(getattr(interval, "end")) + deletion_extension,
+                getattr(interval, "strand", "."),
+                getattr(interval, "name", ""),
+            )
+        else:
+            extraction_interval = interval
+
+        base_seq = self.get_sequence(extraction_interval)
+        ref_seq = base_seq[:interval_length]
+        alt_seq = apply_variant_to_sequence(base_seq, variant, extraction_interval)[:interval_length]
+        ref_outputs = self.predict(ref_seq, organism)
+        alt_outputs = self.predict(alt_seq, organism)
+        if to_cpu:
+            ref_outputs = self._outputs_to_cpu(ref_outputs)
+            alt_outputs = self._outputs_to_cpu(alt_outputs)
+            gc.collect()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        return ref_outputs, alt_outputs
+
+    def get_track_metadata(self, organism: Any = None, output_name: str | None = None) -> list[Any] | dict[Any, list[Any]]:
+        organism_index = self.resolve_organism_index(organism)
+        if output_name is not None and self.metadata_catalog is not None:
+            return list(self.metadata_catalog.get_tracks(output_name, organism=organism_index))
+        legacy = self._legacy_track_metadata.get(organism_index, {})
+        if output_name is None:
+            return legacy
+        for key, value in legacy.items():
+            key_name = getattr(key, "value", str(key))
+            if key_name == output_name:
+                return value
+        names = self._track_names_for_output(output_name)
+        if names:
+            return [
+                TrackMetadata(
+                    track_index=i,
+                    output_name=output_name,
+                    organism=organism_index,
+                    track_name=name,
+                )
+                for i, name in enumerate(names)
+            ]
+        return []
+
+    def _track_names_for_output(self, output_name: str) -> list[str] | None:
+        if self._track_names is None:
+            return None
+        if isinstance(self._track_names, Mapping):
+            return self._track_names.get(output_name)
+        return self._track_names
+
+    def _outputs_to_cpu(self, outputs: Any) -> Any:
+        if torch.is_tensor(outputs):
+            return outputs.cpu()
+        if isinstance(outputs, dict):
+            return {k: self._outputs_to_cpu(v) for k, v in outputs.items()}
+        if isinstance(outputs, list):
+            return [self._outputs_to_cpu(v) for v in outputs]
+        if isinstance(outputs, tuple):
+            return tuple(self._outputs_to_cpu(v) for v in outputs)
+        return outputs
+
+
+__all__ = ["AlphaGenomePredictionRuntime"]

--- a/src/alphagenome_pytorch/prediction.py
+++ b/src/alphagenome_pytorch/prediction.py
@@ -145,7 +145,6 @@ class AlphaGenomePredictionRuntime:
                 sequence,
                 dtype=dtype,
                 device=self.device,
-                ambiguous="zero",
             )
         else:
             dtype = getattr(self.model, "dtype_policy", None)

--- a/src/alphagenome_pytorch/utils/sequence.py
+++ b/src/alphagenome_pytorch/utils/sequence.py
@@ -32,38 +32,25 @@ for _i, _ch in enumerate(_BASES):
     _ENCODE_LOOKUP[ord(_ch.lower())] = _i
 
 
-def sequence_to_onehot(sequence: str, *, ambiguous: str = "zero") -> np.ndarray:
+def sequence_to_onehot(sequence: str) -> np.ndarray:
     """Convert a DNA sequence string to a one-hot encoded numpy array.
 
     Handles both upper- and lower-case nucleotides.
-    Ambiguous / unknown bases (e.g. ``N``) are encoded according to
-    ``ambiguous``.
+    Ambiguous / unknown bases (e.g. ``N``) are encoded as all-zeros,
+    matching the JAX reference.
 
     Args:
         sequence: DNA sequence string (``ACGTN``).
-        ambiguous: Encoding for ambiguous / unknown bases. ``"zero"`` uses
-            all-zeros, matching the JAX reference for model inputs. ``"uniform"``
-            uses ``[0.25, 0.25, 0.25, 0.25]``, matching the existing tiling
-            padding convention.
 
     Returns:
-        One-hot encoded array of shape ``(len(sequence), 4)``.
+        One-hot encoded ``uint8`` array of shape ``(len(sequence), 4)``.
     """
     seq_bytes = np.frombuffer(sequence.encode("ascii"), dtype=np.uint8)
-    if ambiguous == "zero":
-        onehot = np.zeros((len(seq_bytes), 4), dtype=np.uint8)
-    elif ambiguous == "uniform":
-        onehot = np.full((len(seq_bytes), 4), 0.25, dtype=np.float32)
-    else:
-        raise ValueError(
-            f"Unknown ambiguous policy {ambiguous!r}. Expected 'zero' or 'uniform'."
-        )
+    onehot = np.zeros((len(seq_bytes), 4), dtype=np.uint8)
     # clip(0, 127) prevents crash on non-ASCII if present
     indices = _ENCODE_LOOKUP[seq_bytes.clip(0, 127)]
     mask = indices >= 0
     valid_rows = np.where(mask)[0]
-    if ambiguous == "uniform":
-        onehot[valid_rows] = 0.0
     onehot[valid_rows, indices[mask]] = 1
     return onehot
 
@@ -99,8 +86,6 @@ def sequence_to_onehot_tensor(
     sequence: str,
     dtype: "torch.dtype | None" = None,
     device: "torch.device | str | None" = None,
-    *,
-    ambiguous: str = "zero",
 ) -> "torch.Tensor":
     """Convert DNA sequence string to a one-hot encoded torch tensor.
 
@@ -111,15 +96,13 @@ def sequence_to_onehot_tensor(
         sequence: DNA sequence string (``ACGTN``).
         dtype: Output tensor dtype. Defaults to ``torch.float32``.
         device: Output tensor device.
-        ambiguous: Encoding for ambiguous / unknown bases. See
-            :func:`sequence_to_onehot`.
 
     Returns:
         One-hot encoded tensor of shape ``(len(sequence), 4)``.
     """
     import torch as _torch
 
-    np_onehot = sequence_to_onehot(sequence, ambiguous=ambiguous)
+    np_onehot = sequence_to_onehot(sequence)
     tensor = _torch.from_numpy(np_onehot.astype(np.float32))
     if dtype is not None:
         tensor = tensor.to(dtype=dtype)

--- a/src/alphagenome_pytorch/utils/sequence.py
+++ b/src/alphagenome_pytorch/utils/sequence.py
@@ -32,7 +32,9 @@ for _i, _ch in enumerate(_BASES):
     _ENCODE_LOOKUP[ord(_ch.lower())] = _i
 
 
-def sequence_to_onehot(sequence: str) -> np.ndarray:
+def sequence_to_onehot(
+    sequence: str, dtype: "np.dtype | type" = np.uint8
+) -> np.ndarray:
     """Convert a DNA sequence string to a one-hot encoded numpy array.
 
     Handles both upper- and lower-case nucleotides.
@@ -41,12 +43,17 @@ def sequence_to_onehot(sequence: str) -> np.ndarray:
 
     Args:
         sequence: DNA sequence string (``ACGTN``).
+        dtype: Output array dtype. Defaults to ``np.uint8`` (compact; the
+            model casts to its compute dtype at the forward boundary). Pass
+            ``np.float32`` if a downstream consumer needs float arithmetic on
+            the one-hot before it reaches the model.
 
     Returns:
-        One-hot encoded ``uint8`` array of shape ``(len(sequence), 4)``.
+        One-hot encoded array of shape ``(len(sequence), 4)`` and dtype
+        ``dtype``.
     """
     seq_bytes = np.frombuffer(sequence.encode("ascii"), dtype=np.uint8)
-    onehot = np.zeros((len(seq_bytes), 4), dtype=np.uint8)
+    onehot = np.zeros((len(seq_bytes), 4), dtype=dtype)
     # clip(0, 127) prevents crash on non-ASCII if present
     indices = _ENCODE_LOOKUP[seq_bytes.clip(0, 127)]
     mask = indices >= 0

--- a/src/alphagenome_pytorch/utils/sequence.py
+++ b/src/alphagenome_pytorch/utils/sequence.py
@@ -32,24 +32,39 @@ for _i, _ch in enumerate(_BASES):
     _ENCODE_LOOKUP[ord(_ch.lower())] = _i
 
 
-def sequence_to_onehot(sequence: str) -> np.ndarray:
+def sequence_to_onehot(sequence: str, *, ambiguous: str = "zero") -> np.ndarray:
     """Convert a DNA sequence string to a one-hot encoded numpy array.
 
     Handles both upper- and lower-case nucleotides.
-    Ambiguous / unknown bases (e.g. ``N``) are encoded as all-zeros.
+    Ambiguous / unknown bases (e.g. ``N``) are encoded according to
+    ``ambiguous``.
 
     Args:
         sequence: DNA sequence string (``ACGTN``).
+        ambiguous: Encoding for ambiguous / unknown bases. ``"zero"`` uses
+            all-zeros, matching the JAX reference for model inputs. ``"uniform"``
+            uses ``[0.25, 0.25, 0.25, 0.25]``, matching the existing tiling
+            padding convention.
 
     Returns:
-        One-hot encoded ``uint8`` array of shape ``(len(sequence), 4)``.
+        One-hot encoded array of shape ``(len(sequence), 4)``.
     """
     seq_bytes = np.frombuffer(sequence.encode("ascii"), dtype=np.uint8)
-    onehot = np.zeros((len(seq_bytes), 4), dtype=np.uint8)
+    if ambiguous == "zero":
+        onehot = np.zeros((len(seq_bytes), 4), dtype=np.uint8)
+    elif ambiguous == "uniform":
+        onehot = np.full((len(seq_bytes), 4), 0.25, dtype=np.float32)
+    else:
+        raise ValueError(
+            f"Unknown ambiguous policy {ambiguous!r}. Expected 'zero' or 'uniform'."
+        )
     # clip(0, 127) prevents crash on non-ASCII if present
     indices = _ENCODE_LOOKUP[seq_bytes.clip(0, 127)]
     mask = indices >= 0
-    onehot[np.where(mask)[0], indices[mask]] = 1
+    valid_rows = np.where(mask)[0]
+    if ambiguous == "uniform":
+        onehot[valid_rows] = 0.0
+    onehot[valid_rows, indices[mask]] = 1
     return onehot
 
 
@@ -84,6 +99,8 @@ def sequence_to_onehot_tensor(
     sequence: str,
     dtype: "torch.dtype | None" = None,
     device: "torch.device | str | None" = None,
+    *,
+    ambiguous: str = "zero",
 ) -> "torch.Tensor":
     """Convert DNA sequence string to a one-hot encoded torch tensor.
 
@@ -94,13 +111,15 @@ def sequence_to_onehot_tensor(
         sequence: DNA sequence string (``ACGTN``).
         dtype: Output tensor dtype. Defaults to ``torch.float32``.
         device: Output tensor device.
+        ambiguous: Encoding for ambiguous / unknown bases. See
+            :func:`sequence_to_onehot`.
 
     Returns:
         One-hot encoded tensor of shape ``(len(sequence), 4)``.
     """
     import torch as _torch
 
-    np_onehot = sequence_to_onehot(sequence)
+    np_onehot = sequence_to_onehot(sequence, ambiguous=ambiguous)
     tensor = _torch.from_numpy(np_onehot.astype(np.float32))
     if dtype is not None:
         tensor = tensor.to(dtype=dtype)

--- a/src/alphagenome_pytorch/variant_scoring/inference.py
+++ b/src/alphagenome_pytorch/variant_scoring/inference.py
@@ -357,6 +357,7 @@ class VariantScoringModel:
         to_cpu: bool = False,
         unified_splicing: bool = False,
         heads: tuple[str, ...] | None = None,
+        ref_outputs: dict[str, Any] | None = None,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Get reference and alternate predictions for a variant.
 
@@ -370,6 +371,13 @@ class VariantScoringModel:
                 sites between Ref and Alt predictions. Required for SpliceJunctionScorer.
             heads: Optional tuple of head names to compute. If None, all heads
                 run. Forwarded to the model forward pass to skip unused heads.
+            ref_outputs: Optional precomputed first-pass reference outputs. When
+                supplied (e.g. by ISM scoring over a shared reference), the
+                reference forward pass is skipped and this cache is reused. It
+                must have been computed with the same ``heads``/``unified_splicing``
+                settings. The cache is shallow-copied before any per-variant
+                mutation (junction second pass, embedding cleanup) so it stays
+                valid across variants.
 
         Returns:
             Tuple of (ref_outputs, alt_outputs) dictionaries.
@@ -415,7 +423,14 @@ class VariantScoringModel:
         predict_kwargs: dict[str, Any] = {'return_embeddings': return_embeddings}
         if heads is not None:
             predict_kwargs['heads'] = heads
-        ref_outputs = self.predict(ref_seq, organism, **predict_kwargs)
+        if ref_outputs is None:
+            ref_outputs = self.predict(ref_seq, organism, **predict_kwargs)
+        else:
+            # Reuse a shared reference cache (ISM). Shallow-copy so the
+            # unified-splicing second pass (which sets 'splice_junctions' and
+            # pops embeddings) mutates only this variant's view, leaving the
+            # cache intact for subsequent variants.
+            ref_outputs = dict(ref_outputs)
         alt_outputs = self.predict(alt_seq, organism, **predict_kwargs)
 
         if unified_splicing:
@@ -510,6 +525,27 @@ class VariantScoringModel:
             return tuple(self._outputs_to_cpu(v) for v in outputs)
         return outputs
 
+    def _resolve_scorer_passes(
+        self, scorers: list[BaseVariantScorer]
+    ) -> tuple[bool, tuple[str, ...] | None]:
+        """Resolve forward-pass settings shared by a set of scorers.
+
+        Returns ``(unified_splicing, heads_arg)``:
+
+        - ``unified_splicing``: whether any scorer needs the splice-junction
+          alignment second pass. Checked by class-name string to avoid a
+          circular import of ``SpliceJunctionScorer``.
+        - ``heads_arg``: the union of heads the scorers require, so the model
+          forward pass can skip unused heads. ``None`` (run all heads) when no
+          scorer declares requirements.
+        """
+        unified_splicing = any(s.name == "SpliceJunctionScorer()" for s in scorers)
+        required_heads: set[str] = set()
+        for s in scorers:
+            required_heads.update(s.required_heads)
+        heads_arg = tuple(sorted(required_heads)) if required_heads else None
+        return unified_splicing, heads_arg
+
     def score_variant(
         self,
         interval: Interval,
@@ -518,6 +554,7 @@ class VariantScoringModel:
         organism: str | int | None = None,
         gene_annotation: GeneAnnotation | None = None,
         to_cpu: bool = False,
+        ref_outputs: dict[str, Any] | None = None,
     ) -> list[VariantScore | list[VariantScore]]:
         """Score a single variant with multiple scorers.
 
@@ -528,31 +565,24 @@ class VariantScoringModel:
             organism: 'human', 'mouse', or index. Uses default_organism if None.
             gene_annotation: Optional GeneAnnotation.
             to_cpu: If True, move scores to CPU and clear GPU cache.
+            ref_outputs: Optional precomputed first-pass reference outputs to
+                reuse instead of recomputing the reference forward pass. Must
+                have been produced for the same ``interval``/``organism`` with
+                the same scorer set (see ``_predict_reference_outputs``).
 
         Returns:
             List of VariantScore objects
         """
         organism_index = self._resolve_organism_index(organism)
 
-        # Check if we need unified splicing pass
-        unified_splicing = any(s.name == "SpliceJunctionScorer()" for s in scorers)
-        # Note: checking by class name string is fragile but avoids circular imports
-        # Alternative: isinstance(s, SpliceJunctionScorer) if imported
-        # Let's check typical string representation
-
-        # Build the union of heads required by the active scorers so the model
-        # forward pass can skip unused heads. Empty union means no scorers
-        # declared requirements; in that case fall back to running all heads.
-        required_heads: set[str] = set()
-        for s in scorers:
-            required_heads.update(s.required_heads)
-        heads_arg = tuple(sorted(required_heads)) if required_heads else None
+        unified_splicing, heads_arg = self._resolve_scorer_passes(scorers)
 
         # Get predictions
         ref_outputs, alt_outputs = self.predict_variant(
             interval, variant, organism,
             unified_splicing=unified_splicing,
             heads=heads_arg,
+            ref_outputs=ref_outputs,
         )
 
         # Use instance gene annotation if not provided
@@ -722,16 +752,57 @@ class VariantScoringModel:
                             alternate_bases=alt_base.upper(),
                         ))
 
-        # Score all variants
-        return self.score_variants(
-            intervals=interval,
-            variants=variants,
-            scorers=scorers,
-            organism=organism,
-            gene_annotation=gene_annotation,
-            to_cpu=to_cpu,
-            progress=progress,
-        )
+        # All SNVs in the window share the same reference sequence, so the
+        # reference forward pass is computed once and reused across variants.
+        ref_outputs = self._predict_reference_outputs(interval, scorers, organism)
+
+        if gene_annotation is None:
+            gene_annotation = self._gene_annotation
+
+        # Set up progress bar
+        if progress:
+            try:
+                from tqdm import tqdm
+                iterator = tqdm(variants, desc="Scoring ISM variants")
+            except ImportError:
+                iterator = variants
+        else:
+            iterator = variants
+
+        results = []
+        for variant in iterator:
+            results.append(self.score_variant(
+                interval=interval,
+                variant=variant,
+                scorers=scorers,
+                organism=organism,
+                gene_annotation=gene_annotation,
+                to_cpu=to_cpu,
+                ref_outputs=ref_outputs,
+            ))
+
+        return results
+
+    def _predict_reference_outputs(
+        self,
+        interval: Interval,
+        scorers: list[BaseVariantScorer],
+        organism: str | int | None = None,
+    ) -> dict[str, Any]:
+        """Compute first-pass reference outputs once for a shared interval.
+
+        Used by ISM scoring so the reference forward pass is not repeated for
+        every SNV in the window. Returns the un-mutated first-pass outputs
+        (including ``embeddings_1bp`` when splice-junction scoring is active);
+        the per-variant junction second pass operates on shallow copies of this
+        cache (see ``predict_variant``).
+        """
+        unified_splicing, heads_arg = self._resolve_scorer_passes(scorers)
+        ref_seq = self.fasta.extract(interval)[:interval.width]
+        predict_kwargs: dict[str, Any] = {'return_embeddings': unified_splicing}
+        if heads_arg is not None:
+            predict_kwargs['heads'] = heads_arg
+        return self.predict(ref_seq, organism, **predict_kwargs)
 
     def tidy_scores(
         self,

--- a/src/alphagenome_pytorch/variant_scoring/sequence.py
+++ b/src/alphagenome_pytorch/variant_scoring/sequence.py
@@ -4,122 +4,25 @@ This module provides functions for:
 - Converting DNA sequences to one-hot encoding
 - Applying variants to sequences
 - Extracting sequences from FASTA files
+
+The generic implementations now live in :mod:`alphagenome_pytorch.genome`.
+This module remains as a compatibility layer for existing imports.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-import torch
-
+from pathlib import Path
 from alphagenome_pytorch.utils.sequence import (
     sequence_to_onehot_tensor as sequence_to_onehot,
     onehot_tensor_to_sequence as onehot_to_sequence,
 )
+from alphagenome_pytorch.genome import (
+    GenomeSequenceSource,
+    apply_variant_to_onehot,
+    apply_variant_to_sequence,
+    extract_sequence_from_fasta,
+)
 from .types import Interval, Variant
-
-# DNA nucleotide to index mapping (used by apply_variant_to_onehot for SNVs)
-_NUCLEOTIDE_TO_INDEX = {'A': 0, 'C': 1, 'G': 2, 'T': 3}
-
-if TYPE_CHECKING:
-    import pyfaidx
-
-
-def apply_variant_to_sequence(
-    sequence: str,
-    variant: Variant,
-    interval: Interval,
-) -> str:
-    """Apply a variant to a DNA sequence.
-
-    Args:
-        sequence: Reference DNA sequence string
-        variant: Variant to apply
-        interval: The genomic interval that the sequence corresponds to
-
-    Returns:
-        Alternate sequence with the variant applied
-
-    Raises:
-        ValueError: If variant position is outside the interval, or if
-            the reference allele doesn't match the sequence
-
-    Example:
-        >>> seq = 'AAACCCGGG'
-        >>> interval = Interval('chr1', 0, 9)
-        >>> variant = Variant('chr1', 4, 'C', 'T')  # Position 4 (1-based) = index 3
-        >>> apply_variant_to_sequence(seq, variant, interval)
-        'AAATCCGGG'
-    """
-    # Validate variant is within interval
-    if variant.chromosome != interval.chromosome:
-        raise ValueError(
-            f"Variant chromosome ({variant.chromosome}) doesn't match "
-            f"interval chromosome ({interval.chromosome})"
-        )
-
-    # Convert variant position to sequence coordinates (0-based)
-    var_start = variant.start - interval.start  # variant.start is already 0-based
-    var_end = var_start + len(variant.reference_bases)
-
-    if var_start < 0 or var_end > len(sequence):
-        raise ValueError(
-            f"Variant position {variant.position} (ref length {len(variant.reference_bases)}) "
-            f"is outside interval {interval}"
-        )
-
-    # Verify reference matches
-    seq_ref = sequence[var_start:var_end].upper()
-    if seq_ref != variant.reference_bases.upper():
-        raise ValueError(
-            f"Reference allele mismatch at {variant.chromosome}:{variant.position}. "
-            f"Expected '{variant.reference_bases}', found '{seq_ref}' in sequence"
-        )
-
-    # Apply the variant
-    alt_sequence = sequence[:var_start] + variant.alternate_bases + sequence[var_end:]
-
-    return alt_sequence
-
-
-def apply_variant_to_onehot(
-    onehot: torch.Tensor,
-    variant: Variant,
-    interval: Interval,
-) -> torch.Tensor:
-    """Apply a variant to a one-hot encoded sequence.
-
-    For SNVs, this is efficient and doesn't require converting to/from string.
-    For indels, the sequence is converted to string, modified, and re-encoded.
-
-    Args:
-        onehot: One-hot encoded reference sequence of shape (L, 4)
-        variant: Variant to apply
-        interval: The genomic interval that the sequence corresponds to
-
-    Returns:
-        One-hot encoded alternate sequence. For SNVs, shape is (L, 4).
-        For indels, shape may differ due to insertion/deletion.
-    """
-    if variant.is_snv:
-        # Efficient in-place modification for SNVs
-        var_pos = variant.start - interval.start  # 0-based position in sequence
-
-        if var_pos < 0 or var_pos >= onehot.shape[0]:
-            raise ValueError(
-                f"Variant position {variant.position} is outside interval {interval}"
-            )
-
-        alt_onehot = onehot.clone()
-        alt_onehot[var_pos] = 0.0
-        alt_onehot[var_pos, _NUCLEOTIDE_TO_INDEX[variant.alternate_bases.upper()]] = 1.0
-
-        return alt_onehot
-    else:
-        # For indels, convert to string, apply, and re-encode
-        ref_seq = onehot_to_sequence(onehot)
-        alt_seq = apply_variant_to_sequence(ref_seq, variant, interval)
-        return sequence_to_onehot(alt_seq, dtype=onehot.dtype, device=onehot.device)
 
 
 class FastaExtractor:
@@ -135,30 +38,19 @@ class FastaExtractor:
         131072
     """
 
-    def __init__(self, fasta_path: str):
+    def __init__(self, fasta_path: str | Path):
         """Initialize with path to FASTA file.
 
         Args:
             fasta_path: Path to FASTA file. Will create .fai index if not present.
         """
-        try:
-            import pyfaidx
-        except ImportError:
-            raise ImportError(
-                "pyfaidx is required for FASTA extraction. "
-                "Install with: pip install pyfaidx"
-            )
-
-        self.fasta_path = fasta_path
-        self._fasta: pyfaidx.Fasta | None = None
+        self.source = GenomeSequenceSource(fasta_path)
+        self.fasta_path = str(fasta_path)
 
     @property
-    def fasta(self) -> 'pyfaidx.Fasta':
+    def fasta(self):
         """Lazy-loaded FASTA file handle."""
-        if self._fasta is None:
-            import pyfaidx
-            self._fasta = pyfaidx.Fasta(self.fasta_path)
-        return self._fasta
+        return self.source.fasta
 
     def extract(self, interval: Interval) -> str:
         """Extract sequence for a genomic interval.
@@ -169,21 +61,7 @@ class FastaExtractor:
         Returns:
             DNA sequence string (uppercase)
         """
-        chrom = interval.chromosome
-        if chrom not in self.fasta:
-            # Try with/without 'chr' prefix
-            if chrom.startswith('chr'):
-                chrom = chrom[3:]
-            else:
-                chrom = 'chr' + chrom
-
-            if chrom not in self.fasta:
-                raise ValueError(
-                    f"Chromosome {interval.chromosome} not found in FASTA file"
-                )
-
-        seq = str(self.fasta[chrom][interval.start:interval.end])
-        return seq.upper()
+        return self.source.fetch_sequence(interval)
 
     def extract_with_variant(
         self,
@@ -205,29 +83,10 @@ class FastaExtractor:
 
     def close(self):
         """Close the FASTA file handle."""
-        if self._fasta is not None:
-            self._fasta.close()
-            self._fasta = None
+        self.source.close()
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
-
-
-def extract_sequence_from_fasta(
-    fasta_path: str,
-    interval: Interval,
-) -> str:
-    """Convenience function to extract a sequence from a FASTA file.
-
-    Args:
-        fasta_path: Path to FASTA file
-        interval: Genomic interval to extract
-
-    Returns:
-        DNA sequence string (uppercase)
-    """
-    with FastaExtractor(fasta_path) as extractor:
-        return extractor.extract(interval)

--- a/tests/unit/serving_fakes.py
+++ b/tests/unit/serving_fakes.py
@@ -1,0 +1,218 @@
+"""Shared test fakes for serving-adapter tests.
+
+Centralises the mocks that were previously duplicated across
+``test_serving_adapter.py``, ``test_serving_rest.py`` and
+``test_serving_grpc.py``.
+
+Keep these fakes minimal: they expose just enough surface for the adapter
+layer to call them. The real behaviours under test live in the adapter,
+runtime and REST/gRPC layers.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import torch
+from torch import nn
+
+from alphagenome_pytorch.extensions.serving.adapter import SEQUENCE_LENGTH_16KB
+from alphagenome_pytorch.variant_scoring.types import (
+    Interval as PTInterval,
+    OutputType as PTOutputType,
+    TrackMetadata as PTTrackMetadata,
+    Variant as PTVariant,
+    VariantScore,
+)
+
+
+class FakeAnndataModule:
+    """Stand-in for the ``anndata`` module so tests don't need it installed."""
+
+    class AnnData:
+        def __init__(self, X, obs=None, var=None, uns=None, layers=None):
+            self.X = X
+            self.obs = obs if obs is not None else pd.DataFrame()
+            self.var = var if var is not None else pd.DataFrame()
+            self.uns = uns if uns is not None else {}
+            self.layers = layers if layers is not None else {}
+
+
+def _default_metadata():
+    """Two DNase tracks with distinct ontology curies and strands.
+
+    ``track_b`` uses ``'-'`` so adapter tests can exercise
+    ``filter_to_negative_strand``; the REST/gRPC tests don't depend on the
+    strand value.
+    """
+    return {
+        0: {
+            PTOutputType.DNASE: [
+                PTTrackMetadata(
+                    track_index=0,
+                    track_name='track_a',
+                    track_strand='.',
+                    output_type=PTOutputType.DNASE,
+                    ontology_curie='CL:0001',
+                ),
+                PTTrackMetadata(
+                    track_index=1,
+                    track_name='track_b',
+                    track_strand='-',
+                    output_type=PTOutputType.DNASE,
+                    ontology_curie='CL:0002',
+                ),
+            ]
+        }
+    }
+
+
+class FakeScoringModel:
+    """Mimics ``VariantScoringModel`` for the scoring code path."""
+
+    def __init__(self):
+        self._metadata = _default_metadata()
+
+    def get_track_metadata(self, organism: int | None = None):
+        idx = 0 if organism is None else int(organism)
+        return self._metadata.get(idx, {})
+
+    def predict(self, sequence: str, organism: int | None = None, **kwargs):
+        del organism, kwargs
+        seq_len = len(sequence)
+        values = np.zeros((1, seq_len, 2), dtype=np.float32)
+        values[0, :, 0] = 1.0
+        values[0, :, 1] = 2.0
+        return {'dnase': {1: values}}
+
+    def get_sequence(self, interval: PTInterval, variant: PTVariant | None = None) -> str:
+        seq = list('A' * interval.width)
+        if variant is not None:
+            rel = variant.start - interval.start
+            if 0 <= rel < len(seq):
+                seq[rel] = variant.alternate_bases
+        return ''.join(seq)
+
+    def predict_variant(self, interval: PTInterval, variant: PTVariant, organism: int | None = None):
+        del variant, organism
+        ref = self.predict('A' * interval.width)
+        alt = self.predict('A' * interval.width)
+        alt['dnase'][1] = alt['dnase'][1] + 1.0
+        return ref, alt
+
+    def score_variant(
+        self,
+        interval: PTInterval,
+        variant: PTVariant,
+        scorers,
+        organism: int | None = None,
+    ):
+        del interval, variant, organism
+        outputs = []
+        for scorer in scorers:
+            outputs.append(
+                VariantScore(
+                    variant=PTVariant('chr1', 10, 'A', 'C'),
+                    interval=PTInterval('chr1', 0, SEQUENCE_LENGTH_16KB),
+                    scorer=scorer,
+                    scores=torch.tensor([0.25, -0.5]),
+                    gene_id='ENSG000001',
+                    gene_name='GENE1',
+                    gene_strand='+',
+                )
+            )
+        return outputs
+
+
+class TinyAttributionModel(nn.Module):
+    """Minimal differentiable model for attribution tests.
+
+    Returns ``weight * sum_channels(input)`` as a single-track output for the
+    ``dnase`` head at resolution 1. Just enough surface for
+    ``explain_interval`` / gradient×input / saturation ISM to run.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.weight = nn.Parameter(torch.tensor([1.0]))
+
+    def forward(
+        self,
+        dna_sequence,
+        organism_index,
+        *,
+        heads=None,
+        resolutions=None,
+        channels_last=True,
+        return_scaled_predictions=False,
+        **kwargs,
+    ):
+        del organism_index, heads, resolutions, channels_last
+        del return_scaled_predictions, kwargs
+        val = self.weight * dna_sequence.sum(dim=-1, keepdim=True)
+        return {'dnase': {1: val}}
+
+
+class FakeRuntime:
+    """Mimics ``AlphaGenomePredictionRuntime`` for prediction-only paths."""
+
+    def __init__(self):
+        self._metadata = _default_metadata()
+        # Mirrors the real runtime's catalog/legacy split; tests can opt in by
+        # assigning a catalog instance after construction.
+        self.metadata_catalog = None
+        self.default_organism_index = 0
+        # Carry a tiny differentiable model + device so adapter tests that
+        # exercise attribution can dispatch through the runtime without
+        # building a separate fixture.
+        self.model = TinyAttributionModel()
+        self.device = torch.device('cpu')
+
+    def resolve_organism_index(self, organism=None):
+        """Match :py:meth:`AlphaGenomePredictionRuntime.resolve_organism_index`.
+
+        Tests pass values like ``9606`` (proto enum value), ``'HOMO_SAPIENS'``,
+        or ``'human'``; they should all map to internal index 0. Anything else
+        falls through via ``int(organism)``.
+        """
+        if organism is None:
+            return self.default_organism_index
+        # Proto-enum NCBI taxonomy IDs.
+        if organism == 9606 or organism == 'HOMO_SAPIENS' or organism == 'human':
+            return 0
+        if organism == 10090 or organism == 'MUS_MUSCULUS' or organism == 'mouse':
+            return 1
+        return int(organism)
+
+    def predict(self, sequence: str, organism=None, **kwargs):
+        del organism, kwargs
+        seq_len = len(sequence)
+        values = np.zeros((1, seq_len, 2), dtype=np.float32)
+        values[0, :, 0] = 1.0
+        values[0, :, 1] = 2.0
+        return {'dnase': {1: values}}
+
+    def get_sequence(self, interval, variant=None):
+        seq = list('A' * interval.width)
+        if variant is not None:
+            rel = variant.start - interval.start
+            if 0 <= rel < len(seq):
+                seq[rel] = variant.alternate_bases
+        return ''.join(seq)
+
+    def predict_variant(self, interval, variant, organism=None):
+        del variant, organism
+        ref = self.predict('A' * interval.width)
+        alt = self.predict('A' * interval.width)
+        alt['dnase'][1] = alt['dnase'][1] + 1.0
+        return ref, alt
+
+    def get_track_metadata(self, organism=None, output_name=None):
+        idx = 0 if organism is None else int(organism)
+        metadata = self._metadata.get(idx, {})
+        if output_name is None:
+            return metadata
+        for key, value in metadata.items():
+            if key.value == output_name:
+                return value
+        return []

--- a/tests/unit/test_attribution_gradient.py
+++ b/tests/unit/test_attribution_gradient.py
@@ -11,7 +11,10 @@ import torch
 from torch import nn
 
 from alphagenome_pytorch.extensions.attribution.gradient import gradient_x_input
-from alphagenome_pytorch.extensions.attribution.heads import HeadSelector
+from alphagenome_pytorch.extensions.attribution.heads import (
+    HeadSelector,
+    default_head_selector,
+)
 from alphagenome_pytorch.extensions.attribution.types import AttributionResult
 
 
@@ -89,6 +92,32 @@ def _asymmetric_head(
     pos = torch.arange(L, dtype=onehot.dtype, device=onehot.device)
     weighted = onehot.sum(-1) * pos  # (B, L)
     return weighted.unsqueeze(-1)  # (B, L, 1) — single track
+
+
+class _AlphaGenomeLikeAdapterModel(nn.Module):
+    """Fake adapter-backed/fine-tuned model with the public AlphaGenome contract."""
+
+    def __init__(self):
+        super().__init__()
+        self.adapter_weight = nn.Parameter(torch.tensor([2.0]))
+
+    def forward(
+        self,
+        onehot,
+        organism_index,
+        *,
+        heads=None,
+        resolutions=None,
+        channels_last=True,
+        return_scaled_predictions=False,
+    ):
+        assert heads == ("custom_dnase",)
+        assert resolutions == (1,)
+        assert channels_last is True
+        assert return_scaled_predictions is False
+        assert organism_index.shape == (onehot.shape[0],)
+        values = onehot.sum(dim=-1, keepdim=True) * self.adapter_weight
+        return {"custom_dnase": {1: values}}
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +208,40 @@ class TestGradientXInput:
         )
         assert result.raw_gradient is not None
         assert result.raw_gradient.shape == (W, 4, 1)
+
+    def test_default_selector_uses_alphagenome_forward_contract(self):
+        """Adapter-backed/fine-tuned models should not need a special selector."""
+        model = _AlphaGenomeLikeAdapterModel()
+        onehot = _make_onehot("ACGTACGT")
+
+        selected = default_head_selector(
+            model,
+            onehot,
+            torch.zeros(1, dtype=torch.long),
+            output_type="custom_dnase",
+            resolution=1,
+        )
+
+        assert selected.shape == (1, 8, 1)
+        np.testing.assert_allclose(
+            selected.detach().numpy(),
+            np.full((1, 8, 1), 2.0, dtype=np.float32),
+        )
+
+        result = gradient_x_input(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="custom_dnase",
+            resolution=1,
+            target_slice=slice(0, 8),
+            track_indices=[0],
+        )
+        finite_values = result.values[np.isfinite(result.values)]
+        np.testing.assert_allclose(
+            finite_values,
+            np.full_like(finite_values, 2.0),
+        )
 
     def test_raw_gradient_not_returned_by_default(self):
         model = _LinearFakeModel(n_tracks=1)

--- a/tests/unit/test_attribution_gradient.py
+++ b/tests/unit/test_attribution_gradient.py
@@ -1,0 +1,281 @@
+"""Unit tests for gradient x input attribution.
+
+Uses a tiny differentiable fake model with known linear relationships so the
+analytic answer is trivially verifiable.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from alphagenome_pytorch.extensions.attribution.gradient import gradient_x_input
+from alphagenome_pytorch.extensions.attribution.heads import HeadSelector
+from alphagenome_pytorch.extensions.attribution.types import AttributionResult
+
+
+# ---------------------------------------------------------------------------
+# Fake model whose per-track output is a known linear function of the input.
+# ---------------------------------------------------------------------------
+
+
+class _LinearFakeModel(nn.Module):
+    """A dummy model whose output is a per-track linear projection of the input.
+
+    For track `t`, the output at resolution-bin `b` is:
+        output[b, t] = weight[t] * input[b, :].sum()
+
+    This means gradient w.r.t. input[b, c] is exactly `weight[t]` for every
+    channel `c`, making the analytic gradient x input trivially:
+        (grad * input)[b] = weight[t] * (input one-hot value at b)
+    summed over channels = weight[t] * 1.0 = weight[t].
+    """
+
+    def __init__(self, n_tracks: int = 3, weights: list[float] | None = None):
+        super().__init__()
+        if weights is None:
+            weights = list(range(1, n_tracks + 1))
+        self._w = nn.Parameter(torch.tensor(weights, dtype=torch.float32))
+
+    @property
+    def n_tracks(self) -> int:
+        return len(self._w)
+
+
+def _fake_head_selector(
+    model: nn.Module,
+    onehot: torch.Tensor,
+    organism_index: torch.Tensor,
+    *,
+    output_type: str,
+    resolution: int,
+) -> torch.Tensor:
+    """HeadSelector for ``_LinearFakeModel``."""
+    assert isinstance(model, _LinearFakeModel)
+    # onehot: (B, L, 4)
+    x = onehot.sum(dim=-1)  # (B, L) — effectively 1 at each position for a valid one-hot
+    # (B, L, T)
+    return x.unsqueeze(-1) * model._w.unsqueeze(0).unsqueeze(0)
+
+
+# ---------------------------------------------------------------------------
+# Asymmetric model for strand-averaging tests
+# ---------------------------------------------------------------------------
+
+
+class _AsymmetricModel(nn.Module):
+    """Model whose output is position-dependent so forward != RC."""
+
+    def __init__(self):
+        super().__init__()
+        self._dummy = nn.Parameter(torch.zeros(1))
+
+    def forward(self, onehot, org):
+        raise NotImplementedError
+
+
+def _asymmetric_head(
+    model: nn.Module,
+    onehot: torch.Tensor,
+    organism_index: torch.Tensor,
+    *,
+    output_type: str,
+    resolution: int,
+) -> torch.Tensor:
+    # Output is a weighted sum with position-dependent weights.
+    # (B, L, 4) → (B, L, 1) with weight = position index.
+    B, L, _ = onehot.shape
+    pos = torch.arange(L, dtype=onehot.dtype, device=onehot.device)
+    weighted = onehot.sum(-1) * pos  # (B, L)
+    return weighted.unsqueeze(-1)  # (B, L, 1) — single track
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _make_onehot(seq: str, device: str = "cpu") -> torch.Tensor:
+    base_to_idx = {"A": 0, "C": 1, "G": 2, "T": 3, "N": -1}
+    L = len(seq)
+    oh = torch.zeros(1, L, 4, dtype=torch.float32, device=device)
+    for i, ch in enumerate(seq):
+        idx = base_to_idx[ch]
+        if idx >= 0:
+            oh[0, i, idx] = 1.0
+    return oh
+
+
+class TestGradientXInput:
+    """Core gradient x input tests."""
+
+    def test_analytic_answer(self):
+        """For a linear model the gradient projection equals the weight."""
+        model = _LinearFakeModel(n_tracks=2, weights=[3.0, 5.0])
+        seq = "ACGT" * 4  # 16 bp
+        onehot = _make_onehot(seq)
+        target_slice = slice(4, 12)  # middle 8 bp
+        W = (target_slice.stop - target_slice.start)
+
+        result = gradient_x_input(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="dnase",
+            resolution=1,
+            target_slice=target_slice,
+            track_indices=[0, 1],
+            reduction="sum",
+            head_selector=_fake_head_selector,
+        )
+
+        assert isinstance(result, AttributionResult)
+        assert result.method == "input_x_gradient"
+        assert result.kind == "base_matrix"
+        assert result.values.shape == (W, 4, 2)
+
+        # For each position, only the reference-base cell should be filled.
+        # The projected value = weight[t] * 1.0 * W_bins (sum reduction sums
+        # W_bins bins, each contributing weight[t]).
+        # Actually: gradient of sum over window w.r.t. input at position p
+        # equals weight[t] regardless of the other positions.
+        # So grad * input at position p, channel c:
+        #   weight[t] * onehot[p, c]
+        # Projection = sum over c → weight[t] * 1.0 = weight[t].
+        for w in range(W):
+            ref_base = onehot[0, target_slice.start + w].argmax().item()
+            for b in range(4):
+                if b == ref_base:
+                    np.testing.assert_allclose(
+                        result.values[w, b, 0], 3.0, atol=1e-5,
+                        err_msg=f"Track 0 mismatch at w={w}, base={b}",
+                    )
+                    np.testing.assert_allclose(
+                        result.values[w, b, 1], 5.0, atol=1e-5,
+                        err_msg=f"Track 1 mismatch at w={w}, base={b}",
+                    )
+                else:
+                    assert np.isnan(result.values[w, b, 0])
+                    assert np.isnan(result.values[w, b, 1])
+
+    def test_include_raw_gradient_shape(self):
+        model = _LinearFakeModel(n_tracks=1, weights=[2.0])
+        onehot = _make_onehot("ACGTACGT")
+        target_slice = slice(2, 6)
+        W = 4
+
+        result = gradient_x_input(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="x",
+            resolution=1,
+            target_slice=target_slice,
+            track_indices=[0],
+            reduction="sum",
+            include_raw_gradient=True,
+            head_selector=_fake_head_selector,
+        )
+        assert result.raw_gradient is not None
+        assert result.raw_gradient.shape == (W, 4, 1)
+
+    def test_raw_gradient_not_returned_by_default(self):
+        model = _LinearFakeModel(n_tracks=1)
+        onehot = _make_onehot("ACGT")
+        result = gradient_x_input(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="x",
+            resolution=1,
+            target_slice=slice(0, 4),
+            track_indices=[0],
+            head_selector=_fake_head_selector,
+        )
+        assert result.raw_gradient is None
+
+    def test_n_positions_are_nan(self):
+        model = _LinearFakeModel(n_tracks=1, weights=[1.0])
+        onehot = _make_onehot("ANNC")
+        result = gradient_x_input(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="x",
+            resolution=1,
+            target_slice=slice(0, 4),
+            track_indices=[0],
+            head_selector=_fake_head_selector,
+        )
+        # Positions 1 and 2 are N → all four base cells should be NaN.
+        for w in [1, 2]:
+            assert np.all(np.isnan(result.values[w, :, 0])), (
+                f"N position w={w} should be all NaN"
+            )
+
+    def test_strand_averaged_differs_from_forward_only(self):
+        """With an asymmetric model, strand-averaging must differ from fwd-only."""
+        model = _AsymmetricModel()
+        onehot = _make_onehot("ACGTACGT")
+        target_slice = slice(2, 6)
+
+        fwd = gradient_x_input(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="x",
+            resolution=1,
+            target_slice=target_slice,
+            track_indices=[0],
+            reduction="sum",
+            strand_averaged=False,
+            head_selector=_asymmetric_head,
+        )
+        avg = gradient_x_input(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="x",
+            resolution=1,
+            target_slice=target_slice,
+            track_indices=[0],
+            reduction="sum",
+            strand_averaged=True,
+            head_selector=_asymmetric_head,
+        )
+        # They should NOT be identical because the model is asymmetric.
+        assert not np.allclose(
+            np.nan_to_num(fwd.values), np.nan_to_num(avg.values)
+        ), "Strand-averaged should differ from forward-only for an asymmetric model."
+
+    def test_invalid_onehot_shape_raises(self):
+        model = _LinearFakeModel(n_tracks=1)
+        bad = torch.zeros(2, 8, 4)  # batch != 1
+        with pytest.raises(ValueError, match="shape"):
+            gradient_x_input(
+                model,
+                onehot=bad,
+                organism_index=0,
+                output_type="x",
+                resolution=1,
+                target_slice=slice(0, 4),
+                track_indices=[0],
+                head_selector=_fake_head_selector,
+            )
+
+    def test_invalid_reduction_raises(self):
+        model = _LinearFakeModel(n_tracks=1)
+        onehot = _make_onehot("ACGT")
+        with pytest.raises(ValueError, match="reduction"):
+            gradient_x_input(
+                model,
+                onehot=onehot,
+                organism_index=0,
+                output_type="x",
+                resolution=1,
+                target_slice=slice(0, 4),
+                track_indices=[0],
+                reduction="max",
+                head_selector=_fake_head_selector,
+            )

--- a/tests/unit/test_attribution_gradient.py
+++ b/tests/unit/test_attribution_gradient.py
@@ -339,6 +339,6 @@ class TestGradientXInput:
                 resolution=1,
                 target_slice=slice(0, 4),
                 track_indices=[0],
-                reduction="max",
+                reduction="bogus",
                 head_selector=_fake_head_selector,
             )

--- a/tests/unit/test_attribution_ism.py
+++ b/tests/unit/test_attribution_ism.py
@@ -1,0 +1,247 @@
+"""Unit tests for saturation ISM attribution.
+
+Uses a tiny fake model where mutating position ``p`` to base ``b`` changes the
+score by a known delta, so we can verify values, NaN placement, N-position
+handling, and batching.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from alphagenome_pytorch.extensions.attribution.ism import saturation_ism
+from alphagenome_pytorch.extensions.attribution.types import AttributionResult
+
+
+# ---------------------------------------------------------------------------
+# Fake model where output = sum_over_L(onehot * base_weights)
+# ---------------------------------------------------------------------------
+
+
+class _BaseWeightedModel(nn.Module):
+    """Model whose output at each bin is ``(onehot * base_weights).sum()``.
+
+    ``base_weights`` = [1, 2, 3, 4] for A, C, G, T.  Mutating position p
+    from ref to alt changes the single-position contribution by
+    ``base_weights[alt] - base_weights[ref]``. With ``reduction='sum'``
+    over the target window the delta is the same magnitude because only one
+    position is flipped at a time.
+    """
+
+    BASE_WEIGHTS = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+    def __init__(self):
+        super().__init__()
+        self._dummy = nn.Parameter(torch.zeros(1))
+
+
+def _base_weighted_head(
+    model: nn.Module,
+    onehot: torch.Tensor,
+    organism_index: torch.Tensor,
+    *,
+    output_type: str,
+    resolution: int,
+) -> torch.Tensor:
+    """HeadSelector for ``_BaseWeightedModel``: 1 track, 1:1 resolution."""
+    assert isinstance(model, _BaseWeightedModel)
+    bw = _BaseWeightedModel.BASE_WEIGHTS.to(device=onehot.device)
+    # (B, L, 4) * (4,) → sum → (B, L)
+    val = (onehot * bw).sum(dim=-1)  # (B, L)
+    return val.unsqueeze(-1)  # (B, L, 1) — single track
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_onehot(seq: str, device: str = "cpu") -> torch.Tensor:
+    base_to_idx = {"A": 0, "C": 1, "G": 2, "T": 3, "N": -1}
+    L = len(seq)
+    oh = torch.zeros(1, L, 4, dtype=torch.float32, device=device)
+    for i, ch in enumerate(seq):
+        idx = base_to_idx[ch]
+        if idx >= 0:
+            oh[0, i, idx] = 1.0
+    return oh
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSaturationISM:
+    """Saturation ISM unit tests."""
+
+    def test_known_delta(self):
+        """Mutating A(=1) → C(=2) at any position should give delta = +1."""
+        model = _BaseWeightedModel()
+        seq = "AAAA"
+        onehot = _make_onehot(seq)
+        target_slice = slice(0, 4)
+
+        result = saturation_ism(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="x",
+            resolution=1,
+            target_slice=target_slice,
+            track_indices=[0],
+            reduction="sum",
+            batch_size=8,
+            head_selector=_base_weighted_head,
+        )
+
+        assert isinstance(result, AttributionResult)
+        assert result.method == "saturation_ism"
+        assert result.kind == "base_matrix"
+        assert result.values.shape == (4, 4, 1)
+
+        bw = _BaseWeightedModel.BASE_WEIGHTS.numpy()
+        for w in range(4):
+            ref_b = 0  # A
+            for b in range(4):
+                if b == ref_b:
+                    # Reference-base column should be NaN.
+                    assert np.isnan(result.values[w, b, 0]), (
+                        f"Reference cell ({w}, {b}) should be NaN"
+                    )
+                else:
+                    expected_delta = bw[b] - bw[ref_b]
+                    np.testing.assert_allclose(
+                        result.values[w, b, 0],
+                        expected_delta,
+                        atol=1e-5,
+                        err_msg=f"Delta mismatch at w={w}, alt={b}",
+                    )
+
+    def test_reference_column_is_nan(self):
+        """The reference-base column must always be NaN."""
+        model = _BaseWeightedModel()
+        onehot = _make_onehot("ACGT")
+        result = saturation_ism(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="x",
+            resolution=1,
+            target_slice=slice(0, 4),
+            track_indices=[0],
+            head_selector=_base_weighted_head,
+        )
+        ref_bases = [0, 1, 2, 3]  # A, C, G, T
+        for w, ref_b in enumerate(ref_bases):
+            assert np.isnan(result.values[w, ref_b, 0]), (
+                f"Ref cell ({w}, {ref_b}) should be NaN"
+            )
+
+    def test_n_positions_all_nan(self):
+        """Positions with N should have all-NaN rows."""
+        model = _BaseWeightedModel()
+        onehot = _make_onehot("ANNG")
+        result = saturation_ism(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="x",
+            resolution=1,
+            target_slice=slice(0, 4),
+            track_indices=[0],
+            head_selector=_base_weighted_head,
+        )
+        # Positions 1 and 2 are N → entire row should be NaN.
+        for w in [1, 2]:
+            assert np.all(np.isnan(result.values[w, :, 0])), (
+                f"N position w={w} should be all NaN"
+            )
+
+    def test_batching_matches_unbatched(self):
+        """batch_size=2 over 8 positions must give same result as batch_size=100."""
+        model = _BaseWeightedModel()
+        seq = "ACGTACGT"
+        onehot = _make_onehot(seq)
+        target_slice = slice(0, 8)
+
+        r_small = saturation_ism(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="x",
+            resolution=1,
+            target_slice=target_slice,
+            track_indices=[0],
+            batch_size=2,
+            head_selector=_base_weighted_head,
+        )
+        r_big = saturation_ism(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="x",
+            resolution=1,
+            target_slice=target_slice,
+            track_indices=[0],
+            batch_size=100,
+            head_selector=_base_weighted_head,
+        )
+        np.testing.assert_allclose(
+            np.nan_to_num(r_small.values),
+            np.nan_to_num(r_big.values),
+            atol=1e-5,
+        )
+
+    def test_strand_averaged(self):
+        """Strand averaging should produce a finite result without crashing."""
+        model = _BaseWeightedModel()
+        onehot = _make_onehot("ACGT")
+        result = saturation_ism(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="x",
+            resolution=1,
+            target_slice=slice(0, 4),
+            track_indices=[0],
+            strand_averaged=True,
+            head_selector=_base_weighted_head,
+        )
+        # Should succeed and return the same shape.
+        assert result.values.shape == (4, 4, 1)
+        assert result.metadata.get("strand_averaged") is True
+
+    def test_raw_gradient_is_none(self):
+        """ISM results never include raw_gradient."""
+        model = _BaseWeightedModel()
+        onehot = _make_onehot("ACGT")
+        result = saturation_ism(
+            model,
+            onehot=onehot,
+            organism_index=0,
+            output_type="x",
+            resolution=1,
+            target_slice=slice(0, 4),
+            track_indices=[0],
+            head_selector=_base_weighted_head,
+        )
+        assert result.raw_gradient is None
+
+    def test_invalid_batch_size_raises(self):
+        model = _BaseWeightedModel()
+        onehot = _make_onehot("ACGT")
+        with pytest.raises(ValueError, match="batch_size"):
+            saturation_ism(
+                model,
+                onehot=onehot,
+                organism_index=0,
+                output_type="x",
+                resolution=1,
+                target_slice=slice(0, 4),
+                track_indices=[0],
+                batch_size=0,
+                head_selector=_base_weighted_head,
+            )

--- a/tests/unit/test_full_chromosome.py
+++ b/tests/unit/test_full_chromosome.py
@@ -258,6 +258,40 @@ class TestStitchingWithMockModel:
         onehot[:, 0] = 1.0  # All A's for simplicity
         return onehot
 
+    def _build_in_memory_provider(self, GenomeSequenceProvider, chrom_len):
+        """Construct a ``GenomeSequenceProvider`` backed by an in-memory genome.
+
+        Bypasses ``__init__`` (which requires a real FASTA) by injecting a
+        fake source object that mirrors the
+        :class:`~alphagenome_pytorch.genome.GenomeSequenceSource` API the
+        provider delegates to: ``fetch_onehot(chrom, start, end, ...)`` plus
+        a ``chrom_sizes`` dict.
+        """
+        genome_array = self._make_genome_array(chrom_len)
+
+        class _FakeSource:
+            chrom_sizes = {'chr1': chrom_len}
+
+            def fetch_onehot(self, chrom, start, end, *, pad=True, ambiguous='uniform'):
+                del ambiguous
+                length = end - start
+                if pad:
+                    result = np.full((length, 4), 0.25, dtype=np.float32)
+                    valid_start = max(0, start)
+                    valid_end = min(self.chrom_sizes.get(chrom, 0), end)
+                    if valid_start < valid_end:
+                        dest = valid_start - start
+                        result[dest:dest + (valid_end - valid_start)] = (
+                            genome_array[valid_start:valid_end]
+                        )
+                    return result
+                return genome_array[start:end].copy()
+
+        provider = object.__new__(GenomeSequenceProvider)
+        provider._source = _FakeSource()
+        provider.chrom_sizes = provider._source.chrom_sizes
+        return provider
+
     def test_stitching_no_crop_128bp(self):
         """Verify stitching without cropping recovers full chromosome predictions."""
         from alphagenome_pytorch.extensions.inference.full_chromosome import (
@@ -269,12 +303,7 @@ class TestStitchingWithMockModel:
         config = TilingConfig(crop_bp=0, resolution=128, batch_size=2)
         model = self._MockModel(resolution=128)
 
-        # Create a mock GenomeSequenceProvider
-        provider = object.__new__(GenomeSequenceProvider)
-        provider.chrom_sizes = {'chr1': chrom_len}
-        provider._cache = {'chr1': self._make_genome_array(chrom_len)}
-        provider._fasta_path = '/dev/null'
-        provider._cache_enabled = True
+        provider = self._build_in_memory_provider(GenomeSequenceProvider, chrom_len)
 
         preds = predict_full_chromosome(
             model, provider, 'chr1', 'atac',
@@ -300,11 +329,7 @@ class TestStitchingWithMockModel:
         config = TilingConfig(crop_bp=32768, resolution=128, batch_size=1)
         model = self._MockModel(resolution=128)
 
-        provider = object.__new__(GenomeSequenceProvider)
-        provider.chrom_sizes = {'chr1': chrom_len}
-        provider._cache = {'chr1': self._make_genome_array(chrom_len)}
-        provider._fasta_path = '/dev/null'
-        provider._cache_enabled = True
+        provider = self._build_in_memory_provider(GenomeSequenceProvider, chrom_len)
 
         preds = predict_full_chromosome(
             model, provider, 'chr1', 'atac',

--- a/tests/unit/test_full_chromosome.py
+++ b/tests/unit/test_full_chromosome.py
@@ -192,9 +192,9 @@ class TestSequenceToOnehot:
         np.testing.assert_array_equal(upper, lower)
 
     def test_n_encoding(self):
-        """N bases should be encoded as uniform [0.25, 0.25, 0.25, 0.25]."""
+        """N bases should be encoded as all-zeros (matching the JAX reference)."""
         onehot = _sequence_to_onehot("N")
-        expected = np.array([[0.25, 0.25, 0.25, 0.25]], dtype=np.float32)
+        expected = np.array([[0, 0, 0, 0]], dtype=np.uint8)
         np.testing.assert_array_equal(onehot, expected)
 
     def test_mixed_sequence(self):
@@ -203,13 +203,13 @@ class TestSequenceToOnehot:
         # A
         np.testing.assert_array_equal(onehot[0], [1, 0, 0, 0])
         # N
-        np.testing.assert_array_equal(onehot[2], [0.25, 0.25, 0.25, 0.25])
+        np.testing.assert_array_equal(onehot[2], [0, 0, 0, 0])
         # T
         np.testing.assert_array_equal(onehot[4], [0, 0, 0, 1])
 
     def test_output_dtype(self):
         onehot = _sequence_to_onehot("ACGT")
-        assert onehot.dtype == np.float32
+        assert onehot.dtype == np.uint8
 
     def test_empty_sequence(self):
         onehot = _sequence_to_onehot("")
@@ -272,11 +272,10 @@ class TestStitchingWithMockModel:
         class _FakeSource:
             chrom_sizes = {'chr1': chrom_len}
 
-            def fetch_onehot(self, chrom, start, end, *, pad=True, ambiguous='uniform'):
-                del ambiguous
+            def fetch_onehot(self, chrom, start, end, *, pad=True):
                 length = end - start
                 if pad:
-                    result = np.full((length, 4), 0.25, dtype=np.float32)
+                    result = np.zeros((length, 4), dtype=genome_array.dtype)
                     valid_start = max(0, start)
                     valid_end = min(self.chrom_sizes.get(chrom, 0), end)
                     if valid_start < valid_end:

--- a/tests/unit/test_genome_sequence_source.py
+++ b/tests/unit/test_genome_sequence_source.py
@@ -38,7 +38,7 @@ def test_genome_sequence_source_reopens_stale_fasta_handle(tmp_path):
     assert source.fetch_sequence(Interval("chr1", 0, 1)) == "A"
 
 
-def test_genome_sequence_source_cached_fetch_and_uniform_padding(tmp_path):
+def test_genome_sequence_source_cached_fetch_and_zero_padding(tmp_path):
     fasta_path = tmp_path / "genome.fa"
     _write_fasta(fasta_path)
 
@@ -46,16 +46,35 @@ def test_genome_sequence_source_cached_fetch_and_uniform_padding(tmp_path):
         fasta_path,
         chromosomes={"chr1"},
         cache=True,
-        ambiguous="uniform",
     )
 
-    values = source.fetch_onehot("chr1", -2, 3, pad=True, ambiguous="uniform")
+    values = source.fetch_onehot("chr1", -2, 3, pad=True)
+    assert values.dtype == np.uint8
     assert values.shape == (5, 4)
-    assert np.allclose(values[0], [0.25, 0.25, 0.25, 0.25])
-    assert np.allclose(values[1], [0.25, 0.25, 0.25, 0.25])
-    assert np.allclose(values[2], [1, 0, 0, 0])
-    assert np.allclose(values[3], [0, 1, 0, 0])
-    assert np.allclose(values[4], [0, 0, 1, 0])
+    # Padding positions: all zeros.
+    np.testing.assert_array_equal(values[0], [0, 0, 0, 0])
+    np.testing.assert_array_equal(values[1], [0, 0, 0, 0])
+    # Valid region: standard one-hot.
+    np.testing.assert_array_equal(values[2], [1, 0, 0, 0])
+    np.testing.assert_array_equal(values[3], [0, 1, 0, 0])
+    np.testing.assert_array_equal(values[4], [0, 0, 1, 0])
+
+
+def test_genome_sequence_source_padding_without_cache(tmp_path):
+    """Padding works correctly even without a cache."""
+    fasta_path = tmp_path / "genome.fa"
+    _write_fasta(fasta_path)
+
+    source = GenomeSequenceSource(fasta_path)
+
+    values = source.fetch_onehot("chr1", -2, 3, pad=True)
+    assert values.dtype == np.uint8
+    assert values.shape == (5, 4)
+    np.testing.assert_array_equal(values[0], [0, 0, 0, 0])
+    np.testing.assert_array_equal(values[1], [0, 0, 0, 0])
+    np.testing.assert_array_equal(values[2], [1, 0, 0, 0])  # A
+    np.testing.assert_array_equal(values[3], [0, 1, 0, 0])  # C
+    np.testing.assert_array_equal(values[4], [0, 0, 1, 0])  # G
 
 
 def test_apply_variant_to_sequence_checks_reference():

--- a/tests/unit/test_genome_sequence_source.py
+++ b/tests/unit/test_genome_sequence_source.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import numpy as np
+
+from alphagenome_pytorch.genome import (
+    GenomeSequenceSource,
+    Interval,
+    Variant,
+    apply_variant_to_sequence,
+)
+
+
+def _write_fasta(path):
+    path.write_text(">chr1\nACGTNN\n>2\nTTAA\n")
+
+
+def test_genome_sequence_source_fetches_sequences_and_chrom_sizes(tmp_path):
+    fasta_path = tmp_path / "genome.fa"
+    _write_fasta(fasta_path)
+
+    source = GenomeSequenceSource(fasta_path)
+
+    assert source.chrom_sizes["chr1"] == 6
+    assert source.fetch_sequence(Interval("chr1", 0, 4)) == "ACGT"
+    assert source.fetch_sequence(Interval("chr2", 1, 3)) == "TA"
+
+
+def test_genome_sequence_source_reopens_stale_fasta_handle(tmp_path):
+    fasta_path = tmp_path / "genome.fa"
+    _write_fasta(fasta_path)
+    source = GenomeSequenceSource(fasta_path)
+
+    first = source.fasta
+    source._owner_pid = -1
+    second = source.fasta
+
+    assert second is not first
+    assert source.fetch_sequence(Interval("chr1", 0, 1)) == "A"
+
+
+def test_genome_sequence_source_cached_fetch_and_uniform_padding(tmp_path):
+    fasta_path = tmp_path / "genome.fa"
+    _write_fasta(fasta_path)
+
+    source = GenomeSequenceSource(
+        fasta_path,
+        chromosomes={"chr1"},
+        cache=True,
+        ambiguous="uniform",
+    )
+
+    values = source.fetch_onehot("chr1", -2, 3, pad=True, ambiguous="uniform")
+    assert values.shape == (5, 4)
+    assert np.allclose(values[0], [0.25, 0.25, 0.25, 0.25])
+    assert np.allclose(values[1], [0.25, 0.25, 0.25, 0.25])
+    assert np.allclose(values[2], [1, 0, 0, 0])
+    assert np.allclose(values[3], [0, 1, 0, 0])
+    assert np.allclose(values[4], [0, 0, 1, 0])
+
+
+def test_apply_variant_to_sequence_checks_reference():
+    interval = Interval("chr1", 0, 6)
+    variant = Variant("chr1", 2, "C", "T")
+
+    assert apply_variant_to_sequence("ACGTNN", variant, interval) == "ATGTNN"

--- a/tests/unit/test_onehot_encoding.py
+++ b/tests/unit/test_onehot_encoding.py
@@ -46,6 +46,14 @@ def test_dtype_and_shape():
     assert oh.shape == (4, 4)
 
 
+def test_dtype_override():
+    """An explicit dtype is honored, with identical values to the default."""
+    oh_u8 = sequence_to_onehot("ACGTN")
+    oh_f32 = sequence_to_onehot("ACGTN", dtype=np.float32)
+    assert oh_f32.dtype == np.float32
+    np.testing.assert_array_equal(oh_f32, oh_u8.astype(np.float32))
+
+
 def test_each_row_sums_to_one_or_zero():
     oh = sequence_to_onehot("ACNGTNA")
     row_sums = oh.sum(axis=1)

--- a/tests/unit/test_onehot_encoding.py
+++ b/tests/unit/test_onehot_encoding.py
@@ -28,13 +28,6 @@ def test_n_encodes_as_zeros_and_decodes_back():
     assert onehot_to_sequence(oh) == "ANGT"
 
 
-def test_n_can_encode_as_uniform_for_padding():
-    oh = sequence_to_onehot("AN", ambiguous="uniform")
-    np.testing.assert_allclose(oh[0], [1, 0, 0, 0])
-    np.testing.assert_allclose(oh[1], [0.25, 0.25, 0.25, 0.25])
-    assert oh.dtype == np.float32
-
-
 def test_all_n():
     oh = sequence_to_onehot("NNN")
     assert oh.sum() == 0

--- a/tests/unit/test_onehot_encoding.py
+++ b/tests/unit/test_onehot_encoding.py
@@ -28,6 +28,13 @@ def test_n_encodes_as_zeros_and_decodes_back():
     assert onehot_to_sequence(oh) == "ANGT"
 
 
+def test_n_can_encode_as_uniform_for_padding():
+    oh = sequence_to_onehot("AN", ambiguous="uniform")
+    np.testing.assert_allclose(oh[0], [1, 0, 0, 0])
+    np.testing.assert_allclose(oh[1], [0.25, 0.25, 0.25, 0.25])
+    assert oh.dtype == np.float32
+
+
 def test_all_n():
     oh = sequence_to_onehot("NNN")
     assert oh.sum() == 0

--- a/tests/unit/test_prediction_runtime.py
+++ b/tests/unit/test_prediction_runtime.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from alphagenome_pytorch.genome import GenomeSequenceSource
+from alphagenome_pytorch.named_outputs import TrackMetadata
+from alphagenome_pytorch.prediction import AlphaGenomePredictionRuntime
+
+
+class _TinyModel(torch.nn.Module):
+    num_organisms = 2
+
+    def __init__(self):
+        super().__init__()
+        self.anchor = torch.nn.Parameter(torch.zeros(()))
+
+    def forward(self, onehot, organism_index, **kwargs):
+        del organism_index, kwargs
+        dnase = onehot[..., :1] + 1.0 + self.anchor
+        return {"dnase": {1: dnase}}
+
+
+def _write_fasta(path):
+    path.write_text(">chr1\nAAAAAA\n")
+
+
+def test_prediction_runtime_predict_sequence():
+    runtime = AlphaGenomePredictionRuntime(_TinyModel())
+
+    outputs = runtime.predict("AAAA", organism="human")
+
+    assert outputs["dnase"][1].shape == (1, 4, 1)
+    assert torch.allclose(outputs["dnase"][1], torch.full((1, 4, 1), 2.0))
+
+
+def test_prediction_runtime_predict_variant(tmp_path):
+    fasta_path = tmp_path / "genome.fa"
+    _write_fasta(fasta_path)
+    runtime = AlphaGenomePredictionRuntime(
+        _TinyModel(),
+        sequence_source=GenomeSequenceSource(fasta_path),
+    )
+
+    from alphagenome.data import genome
+
+    interval = genome.Interval("chr1", 0, 6)
+    variant = genome.Variant("chr1", 2, "A", "C")
+    ref, alt = runtime.predict_variant(interval, variant)
+
+    assert ref["dnase"][1][0, 1, 0].item() == 2.0
+    assert alt["dnase"][1][0, 1, 0].item() == 1.0
+
+
+# --- get_track_metadata dispatch tests --------------------------------------
+#
+# The runtime resolves track metadata through three branches, in order:
+#   1. metadata_catalog.get_tracks(output_name, organism=...)   — if catalog present and output_name given
+#   2. _legacy_track_metadata[organism_index][output_name]      — dict fallback
+#   3. synthesised TrackMetadata from _track_names_for_output() — last-resort placeholder
+# These tests pin each dispatch branch.
+
+
+class _FakeOutputType:
+    """Stand-in for a ``PTOutputType``-like enum entry the legacy dict keys on."""
+
+    def __init__(self, name: str):
+        self.value = name
+
+    def __hash__(self):
+        return hash(self.value)
+
+    def __eq__(self, other):
+        return isinstance(other, _FakeOutputType) and self.value == other.value
+
+
+def test_get_track_metadata_with_catalog_dispatches_to_catalog():
+    catalog = MagicMock()
+    catalog.get_tracks.return_value = ('TRACK_A', 'TRACK_B')
+
+    runtime = AlphaGenomePredictionRuntime(
+        _TinyModel(),
+        metadata_catalog=catalog,
+    )
+
+    result = runtime.get_track_metadata(organism='human', output_name='dnase')
+
+    catalog.get_tracks.assert_called_once_with('dnase', organism=0)
+    assert result == ['TRACK_A', 'TRACK_B']
+
+
+def test_get_track_metadata_legacy_fallback_when_no_catalog():
+    dnase_key = _FakeOutputType('dnase')
+    legacy = {0: {dnase_key: ['legacy_track_0', 'legacy_track_1']}}
+
+    runtime = AlphaGenomePredictionRuntime(
+        _TinyModel(),
+        track_metadata=legacy,
+    )
+
+    by_output_name = runtime.get_track_metadata(organism='human', output_name='dnase')
+    assert by_output_name == ['legacy_track_0', 'legacy_track_1']
+
+    # When ``output_name`` is omitted the whole organism dict is returned.
+    full = runtime.get_track_metadata(organism='human')
+    assert full == {dnase_key: ['legacy_track_0', 'legacy_track_1']}
+
+
+def test_get_track_metadata_synthesises_from_track_names():
+    runtime = AlphaGenomePredictionRuntime(
+        _TinyModel(),
+        track_names={'dnase': ['synthetic_a', 'synthetic_b']},
+    )
+
+    result = runtime.get_track_metadata(organism='human', output_name='dnase')
+
+    assert len(result) == 2
+    assert all(isinstance(t, TrackMetadata) for t in result)
+    assert [t.track_name for t in result] == ['synthetic_a', 'synthetic_b']
+    assert [t.track_index for t in result] == [0, 1]
+    assert all(t.organism == 0 and t.output_name == 'dnase' for t in result)
+
+
+def test_get_track_metadata_returns_empty_when_unknown():
+    runtime = AlphaGenomePredictionRuntime(_TinyModel())
+
+    result = runtime.get_track_metadata(organism='human', output_name='dnase')
+
+    assert result == []

--- a/tests/unit/test_score_variant_head_filtering.py
+++ b/tests/unit/test_score_variant_head_filtering.py
@@ -113,7 +113,7 @@ def test_score_variant_forwards_union_of_required_heads(monkeypatch):
     seq_len = 256
 
     def fake_predict_variant(interval, variant, organism=None, to_cpu=False,
-                             unified_splicing=False, heads=None):
+                             unified_splicing=False, heads=None, ref_outputs=None):
         kwargs = {'return_embeddings': unified_splicing}
         if heads is not None:
             kwargs['heads'] = heads
@@ -152,7 +152,7 @@ def test_score_variant_subset_only_atac():
     seq_len = 256
 
     def fake_predict_variant(interval, variant, organism=None, to_cpu=False,
-                             unified_splicing=False, heads=None):
+                             unified_splicing=False, heads=None, ref_outputs=None):
         kwargs = {'return_embeddings': unified_splicing}
         if heads is not None:
             kwargs['heads'] = heads
@@ -177,7 +177,7 @@ def test_score_variant_empty_scorers_runs_all_heads():
     captured = {}
 
     def fake_predict_variant(interval, variant, organism=None, to_cpu=False,
-                             unified_splicing=False, heads=None):
+                             unified_splicing=False, heads=None, ref_outputs=None):
         captured['heads'] = heads
         # Return minimal outputs (won't be consumed since scorers list is empty)
         return {}, {}

--- a/tests/unit/test_serving_adapter.py
+++ b/tests/unit/test_serving_adapter.py
@@ -1,109 +1,31 @@
 from __future__ import annotations
 
-import types
-
 import numpy as np
-import pandas as pd
 import pytest
-import torch
 
 from alphagenome.data import genome
 from alphagenome.models import dna_output
 from alphagenome.protos import dna_model_pb2
 
 from alphagenome_pytorch.extensions.serving.adapter import LocalDnaModelAdapter, SEQUENCE_LENGTH_16KB
+from alphagenome_pytorch.extensions.serving.variant_scoring_adapter import VariantScoringAdapter
 from alphagenome_pytorch.variant_scoring.scorers import CenterMaskScorer
 from alphagenome_pytorch.variant_scoring.types import (
     AggregationType as PTAggregationType,
-    Interval as PTInterval,
     OutputType as PTOutputType,
-    TrackMetadata as PTTrackMetadata,
-    Variant as PTVariant,
-    VariantScore,
 )
 
-
-class _FakeAnndataModule:
-    class AnnData:
-        def __init__(self, X, obs=None, var=None, uns=None, layers=None):
-            self.X = X
-            self.obs = obs if obs is not None else pd.DataFrame()
-            self.var = var if var is not None else pd.DataFrame()
-            self.uns = uns if uns is not None else {}
-            self.layers = layers if layers is not None else {}
-
-
-class _FakeScoringModel:
-    def __init__(self):
-        self._metadata = {
-            0: {
-                PTOutputType.DNASE: [
-                    PTTrackMetadata(
-                        track_index=0,
-                        track_name='track_a',
-                        track_strand='.',
-                        output_type=PTOutputType.DNASE,
-                        ontology_curie='CL:0001',
-                    ),
-                    PTTrackMetadata(
-                        track_index=1,
-                        track_name='track_b',
-                        track_strand='-',
-                        output_type=PTOutputType.DNASE,
-                        ontology_curie='CL:0002',
-                    ),
-                ]
-            }
-        }
-
-    def get_track_metadata(self, organism: int | None = None):
-        idx = 0 if organism is None else int(organism)
-        return self._metadata.get(idx, {})
-
-    def predict(self, sequence: str, organism: int | None = None, **kwargs):
-        del organism, kwargs
-        seq_len = len(sequence)
-        values = np.zeros((1, seq_len, 2), dtype=np.float32)
-        values[0, :, 0] = 1.0
-        values[0, :, 1] = 2.0
-        return {'dnase': {1: values}}
-
-    def get_sequence(self, interval: PTInterval, variant: PTVariant | None = None) -> str:
-        seq = list('A' * interval.width)
-        if variant is not None:
-            rel = variant.start - interval.start
-            if 0 <= rel < len(seq):
-                seq[rel] = variant.alternate_bases
-        return ''.join(seq)
-
-    def predict_variant(self, interval: PTInterval, variant: PTVariant, organism: int | None = None):
-        del variant, organism
-        ref = self.predict('A' * interval.width)
-        alt = self.predict('A' * interval.width)
-        alt['dnase'][1] = alt['dnase'][1] + 1.0
-        return ref, alt
-
-    def score_variant(self, interval: PTInterval, variant: PTVariant, scorers, organism: int | None = None):
-        del interval, variant, organism
-        outputs = []
-        for scorer in scorers:
-            outputs.append(
-                VariantScore(
-                    variant=PTVariant('chr1', 10, 'A', 'C'),
-                    interval=PTInterval('chr1', 0, SEQUENCE_LENGTH_16KB),
-                    scorer=scorer,
-                    scores=torch.tensor([0.25, -0.5]),
-                    gene_id='ENSG000001',
-                    gene_name='GENE1',
-                    gene_strand='+',
-                )
-            )
-        return outputs
+from .serving_fakes import FakeAnndataModule, FakeRuntime, FakeScoringModel
 
 
 @pytest.fixture
 def adapter():
-    return LocalDnaModelAdapter(_FakeScoringModel())
+    return LocalDnaModelAdapter(FakeRuntime())
+
+
+@pytest.fixture
+def scoring_adapter():
+    return VariantScoringAdapter(FakeRuntime(), FakeScoringModel())
 
 
 def test_predict_sequence_filters_ontology_and_preserves_track_ops(adapter):
@@ -144,8 +66,8 @@ def test_output_metadata_concatenate_has_output_type(adapter):
     assert any(concatenated['output_type'] == dna_output.OutputType.DNASE)
 
 
-def test_score_variant_returns_anndata_compatible_shape(adapter, monkeypatch):
-    monkeypatch.setitem(__import__('sys').modules, 'anndata', _FakeAnndataModule)
+def test_score_variant_returns_anndata_compatible_shape(scoring_adapter, monkeypatch):
+    monkeypatch.setitem(__import__('sys').modules, 'anndata', FakeAnndataModule)
 
     interval = genome.Interval('chr1', 0, SEQUENCE_LENGTH_16KB)
     variant = genome.Variant('chr1', 10, 'A', 'C')
@@ -155,7 +77,7 @@ def test_score_variant_returns_anndata_compatible_shape(adapter, monkeypatch):
         aggregation_type=PTAggregationType.DIFF_SUM,
     )
 
-    scores = adapter.score_variant(
+    scores = scoring_adapter.score_variant(
         interval=interval,
         variant=variant,
         variant_scorers=[scorer],
@@ -167,4 +89,3 @@ def test_score_variant_returns_anndata_compatible_shape(adapter, monkeypatch):
     assert adata.obs.loc['0', 'gene_name'] == 'GENE1'
     assert adata.uns['variant'] == variant
     assert adata.uns['interval'] == interval
-

--- a/tests/unit/test_serving_adapter.py
+++ b/tests/unit/test_serving_adapter.py
@@ -195,3 +195,35 @@ class TestExplainIntervalValidation:
         )
         assert result.method == 'saturation_ism'
         assert result.values.shape == (8, 4, 1)
+
+    def test_requested_output_normalization(self, adapter):
+        """Display-name / enum / prefixed forms resolve like the head key."""
+        interval = genome.Interval('chr1', 0, SEQUENCE_LENGTH_16KB)
+        target = genome.Interval('chr1', 100, 200)
+
+        def run(req):
+            return adapter.explain_interval(
+                interval=interval,
+                target_interval=target,
+                requested_output=req,
+                resolution=1,
+                track_indices=[0],
+                method='input_x_gradient',
+            ).values
+
+        baseline = run('dnase')
+        for alias in ('DNASE', 'OUTPUT_TYPE_DNASE', dna_output.OutputType.DNASE):
+            np.testing.assert_array_equal(run(alias), baseline)
+
+    def test_unknown_requested_output_raises(self, adapter):
+        interval = genome.Interval('chr1', 0, SEQUENCE_LENGTH_16KB)
+        target = genome.Interval('chr1', 100, 200)
+        with pytest.raises(ValueError, match='output type'):
+            adapter.explain_interval(
+                interval=interval,
+                target_interval=target,
+                requested_output='not_a_head',
+                resolution=1,
+                track_indices=[0],
+                method='input_x_gradient',
+            )

--- a/tests/unit/test_serving_adapter.py
+++ b/tests/unit/test_serving_adapter.py
@@ -7,6 +7,7 @@ from alphagenome.data import genome
 from alphagenome.models import dna_output
 from alphagenome.protos import dna_model_pb2
 
+from alphagenome_pytorch.extensions.attribution import UnsupportedMethodError
 from alphagenome_pytorch.extensions.serving.adapter import LocalDnaModelAdapter, SEQUENCE_LENGTH_16KB
 from alphagenome_pytorch.extensions.serving.variant_scoring_adapter import VariantScoringAdapter
 from alphagenome_pytorch.variant_scoring.scorers import CenterMaskScorer
@@ -89,3 +90,107 @@ def test_score_variant_returns_anndata_compatible_shape(scoring_adapter, monkeyp
     assert adata.obs.loc['0', 'gene_name'] == 'GENE1'
     assert adata.uns['variant'] == variant
     assert adata.uns['interval'] == interval
+
+
+# ---------------------------------------------------------------------------
+# explain_interval tests
+# ---------------------------------------------------------------------------
+
+
+class TestExplainIntervalValidation:
+    """explain_interval request-validation tests."""
+
+    def test_target_interval_not_contained_raises(self, adapter):
+        interval = genome.Interval('chr1', 0, SEQUENCE_LENGTH_16KB)
+        target = genome.Interval('chr1', SEQUENCE_LENGTH_16KB - 10, SEQUENCE_LENGTH_16KB + 10)
+        with pytest.raises(ValueError, match='not contained'):
+            adapter.explain_interval(
+                interval=interval,
+                target_interval=target,
+                requested_output='dnase',
+                resolution=1,
+                track_indices=[0],
+                method='input_x_gradient',
+            )
+
+    def test_chromosome_mismatch_raises(self, adapter):
+        interval = genome.Interval('chr1', 0, SEQUENCE_LENGTH_16KB)
+        target = genome.Interval('chr2', 100, 200)
+        with pytest.raises(ValueError, match='chromosome'):
+            adapter.explain_interval(
+                interval=interval,
+                target_interval=target,
+                requested_output='dnase',
+                resolution=1,
+                track_indices=[0],
+                method='input_x_gradient',
+            )
+
+    def test_unknown_method_raises(self, adapter):
+        interval = genome.Interval('chr1', 0, SEQUENCE_LENGTH_16KB)
+        target = genome.Interval('chr1', 100, 200)
+        with pytest.raises(UnsupportedMethodError, match='bogus_method'):
+            adapter.explain_interval(
+                interval=interval,
+                target_interval=target,
+                requested_output='dnase',
+                resolution=1,
+                track_indices=[0],
+                method='bogus_method',
+            )
+
+    def test_include_raw_gradient_rejected_for_ism(self, adapter):
+        interval = genome.Interval('chr1', 0, SEQUENCE_LENGTH_16KB)
+        target = genome.Interval('chr1', 100, 200)
+        with pytest.raises(ValueError, match='include_raw_gradient'):
+            adapter.explain_interval(
+                interval=interval,
+                target_interval=target,
+                requested_output='dnase',
+                resolution=1,
+                track_indices=[0],
+                method='saturation_ism',
+                include_raw_gradient=True,
+            )
+
+    def test_empty_track_indices_raises(self, adapter):
+        interval = genome.Interval('chr1', 0, SEQUENCE_LENGTH_16KB)
+        target = genome.Interval('chr1', 100, 200)
+        with pytest.raises(ValueError, match='track_indices'):
+            adapter.explain_interval(
+                interval=interval,
+                target_interval=target,
+                requested_output='dnase',
+                resolution=1,
+                track_indices=[],
+                method='input_x_gradient',
+            )
+
+    def test_gradient_happy_path(self, adapter):
+        interval = genome.Interval('chr1', 0, SEQUENCE_LENGTH_16KB)
+        target = genome.Interval('chr1', 100, 200)
+        result = adapter.explain_interval(
+            interval=interval,
+            target_interval=target,
+            requested_output='dnase',
+            resolution=1,
+            track_indices=[0],
+            method='input_x_gradient',
+        )
+        assert result.method == 'input_x_gradient'
+        assert result.values.shape == (100, 4, 1)
+
+    def test_ism_happy_path(self, adapter):
+        interval = genome.Interval('chr1', 0, SEQUENCE_LENGTH_16KB)
+        target = genome.Interval('chr1', 100, 108)
+        result = adapter.explain_interval(
+            interval=interval,
+            target_interval=target,
+            requested_output='dnase',
+            resolution=1,
+            track_indices=[0],
+            method='saturation_ism',
+            batch_size=4,
+        )
+        assert result.method == 'saturation_ism'
+        assert result.values.shape == (8, 4, 1)

--- a/tests/unit/test_serving_adapter.py
+++ b/tests/unit/test_serving_adapter.py
@@ -9,7 +9,7 @@ from alphagenome.protos import dna_model_pb2
 
 from alphagenome_pytorch.extensions.attribution import UnsupportedMethodError
 from alphagenome_pytorch.extensions.serving.adapter import LocalDnaModelAdapter, SEQUENCE_LENGTH_16KB
-from alphagenome_pytorch.extensions.serving.variant_scoring_adapter import VariantScoringAdapter
+from alphagenome_pytorch.extensions.serving.scorer import VariantScorer
 from alphagenome_pytorch.variant_scoring.scorers import CenterMaskScorer
 from alphagenome_pytorch.variant_scoring.types import (
     AggregationType as PTAggregationType,
@@ -26,7 +26,8 @@ def adapter():
 
 @pytest.fixture
 def scoring_adapter():
-    return VariantScoringAdapter(FakeRuntime(), FakeScoringModel())
+    runtime = FakeRuntime()
+    return LocalDnaModelAdapter(runtime, scorer=VariantScorer(runtime, FakeScoringModel()))
 
 
 def test_predict_sequence_filters_ontology_and_preserves_track_ops(adapter):

--- a/tests/unit/test_serving_grpc.py
+++ b/tests/unit/test_serving_grpc.py
@@ -12,7 +12,7 @@ from alphagenome.protos import dna_model_pb2, dna_model_service_pb2, dna_model_s
 
 from alphagenome_pytorch.extensions.serving.adapter import LocalDnaModelAdapter, SEQUENCE_LENGTH_16KB
 from alphagenome_pytorch.extensions.serving.grpc_service import LocalDnaModelService
-from alphagenome_pytorch.extensions.serving.variant_scoring_adapter import VariantScoringAdapter
+from alphagenome_pytorch.extensions.serving.scorer import VariantScorer
 
 from .serving_fakes import FakeAnndataModule, FakeRuntime, FakeScoringModel
 
@@ -37,7 +37,10 @@ def _start_grpc(adapter):
 @pytest.fixture
 def grpc_server(monkeypatch):
     monkeypatch.setitem(__import__('sys').modules, 'anndata', FakeAnndataModule)
-    adapter = VariantScoringAdapter(FakeRuntime(), FakeScoringModel())
+    runtime = FakeRuntime()
+    adapter = LocalDnaModelAdapter(
+        runtime, scorer=VariantScorer(runtime, FakeScoringModel()),
+    )
     yield from _start_grpc(adapter)
 
 

--- a/tests/unit/test_serving_grpc.py
+++ b/tests/unit/test_serving_grpc.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 from concurrent import futures
 
 import grpc
-import numpy as np
-import pandas as pd
 import pytest
-import torch
 
 from alphagenome import tensor_utils
 from alphagenome.data import genome
@@ -15,76 +12,12 @@ from alphagenome.protos import dna_model_pb2, dna_model_service_pb2, dna_model_s
 
 from alphagenome_pytorch.extensions.serving.adapter import LocalDnaModelAdapter, SEQUENCE_LENGTH_16KB
 from alphagenome_pytorch.extensions.serving.grpc_service import LocalDnaModelService
-from alphagenome_pytorch.variant_scoring.types import (
-    Interval as PTInterval,
-    OutputType as PTOutputType,
-    TrackMetadata as PTTrackMetadata,
-    Variant as PTVariant,
-    VariantScore,
-)
+from alphagenome_pytorch.extensions.serving.variant_scoring_adapter import VariantScoringAdapter
+
+from .serving_fakes import FakeAnndataModule, FakeRuntime, FakeScoringModel
 
 
-class _FakeAnndataModule:
-    class AnnData:
-        def __init__(self, X, obs=None, var=None, uns=None, layers=None):
-            self.X = X
-            self.obs = obs if obs is not None else pd.DataFrame()
-            self.var = var if var is not None else pd.DataFrame()
-            self.uns = uns if uns is not None else {}
-            self.layers = layers if layers is not None else {}
-
-
-class _FakeScoringModel:
-    def __init__(self):
-        self._metadata = {
-            0: {
-                PTOutputType.DNASE: [
-                    PTTrackMetadata(0, 'track_a', '.', PTOutputType.DNASE, ontology_curie='CL:0001'),
-                    PTTrackMetadata(1, 'track_b', '.', PTOutputType.DNASE, ontology_curie='CL:0002'),
-                ]
-            }
-        }
-
-    def get_track_metadata(self, organism=None):
-        del organism
-        return self._metadata[0]
-
-    def predict(self, sequence, organism=None, **kwargs):
-        del organism, kwargs
-        seq_len = len(sequence)
-        values = np.ones((1, seq_len, 2), dtype=np.float32)
-        return {'dnase': {1: values}}
-
-    def get_sequence(self, interval, variant=None):
-        del variant
-        return 'A' * interval.width
-
-    def predict_variant(self, interval, variant, organism=None):
-        del variant, organism
-        ref = self.predict('A' * interval.width)
-        alt = self.predict('A' * interval.width)
-        alt['dnase'][1] = alt['dnase'][1] + 1.0
-        return ref, alt
-
-    def score_variant(self, interval, variant, scorers, organism=None):
-        del interval, variant, organism
-        result = []
-        for scorer in scorers:
-            result.append(
-                VariantScore(
-                    variant=PTVariant('chr1', 10, 'A', 'C'),
-                    interval=PTInterval('chr1', 0, SEQUENCE_LENGTH_16KB),
-                    scorer=scorer,
-                    scores=torch.tensor([1.0, 2.0]),
-                )
-            )
-        return result
-
-
-@pytest.fixture
-def grpc_server(monkeypatch):
-    monkeypatch.setitem(__import__('sys').modules, 'anndata', _FakeAnndataModule)
-    adapter = LocalDnaModelAdapter(_FakeScoringModel())
+def _start_grpc(adapter):
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=2))
     dna_model_service_pb2_grpc.add_DnaModelServiceServicer_to_server(
         LocalDnaModelService(adapter),
@@ -99,6 +32,20 @@ def grpc_server(monkeypatch):
     finally:
         channel.close()
         server.stop(grace=0.0)
+
+
+@pytest.fixture
+def grpc_server(monkeypatch):
+    monkeypatch.setitem(__import__('sys').modules, 'anndata', FakeAnndataModule)
+    adapter = VariantScoringAdapter(FakeRuntime(), FakeScoringModel())
+    yield from _start_grpc(adapter)
+
+
+@pytest.fixture
+def prediction_only_grpc_server(monkeypatch):
+    monkeypatch.setitem(__import__('sys').modules, 'anndata', FakeAnndataModule)
+    adapter = LocalDnaModelAdapter(FakeRuntime())
+    yield from _start_grpc(adapter)
 
 
 def test_predict_sequence_rpc(grpc_server):
@@ -137,6 +84,17 @@ def test_score_variant_rpc(grpc_server):
     assert responses[0].output.variant_data.metadata.variant.chromosome == 'chr1'
 
 
+def test_score_variant_rpc_prediction_only_unimplemented(prediction_only_grpc_server):
+    request = dna_model_service_pb2.ScoreVariantRequest(
+        interval=genome.Interval('chr1', 0, SEQUENCE_LENGTH_16KB).to_proto(),
+        variant=genome.Variant('chr1', 10, 'A', 'C').to_proto(),
+        organism=dna_model_pb2.ORGANISM_HOMO_SAPIENS,
+    )
+    with pytest.raises(grpc.RpcError) as exc_info:
+        list(prediction_only_grpc_server.ScoreVariant(iter([request])))
+    assert exc_info.value.code() == grpc.StatusCode.UNIMPLEMENTED
+
+
 def test_metadata_rpc(grpc_server):
     request = dna_model_service_pb2.MetadataRequest(
         organism=dna_model_pb2.ORGANISM_HOMO_SAPIENS
@@ -145,4 +103,3 @@ def test_metadata_rpc(grpc_server):
     assert len(responses) == 1
     by_type = {m.output_type for m in responses[0].output_metadata}
     assert dna_output.OutputType.DNASE.to_proto() in by_type
-

--- a/tests/unit/test_serving_rest.py
+++ b/tests/unit/test_serving_rest.py
@@ -10,7 +10,7 @@ from alphagenome.models import dna_output
 
 from alphagenome_pytorch.extensions.serving.adapter import LocalDnaModelAdapter, SEQUENCE_LENGTH_16KB
 from alphagenome_pytorch.extensions.serving.rest_service import serve_rest
-from alphagenome_pytorch.extensions.serving.variant_scoring_adapter import VariantScoringAdapter
+from alphagenome_pytorch.extensions.serving.scorer import VariantScorer
 from alphagenome_pytorch.variant_scoring.scorers import (
     CenterMaskScorer as PTCenterMaskScorer,
     ContactMapScorer as PTContactMapScorer,
@@ -42,7 +42,10 @@ def _start_rest(adapter):
 @pytest.fixture
 def rest_server(monkeypatch):
     monkeypatch.setitem(__import__('sys').modules, 'anndata', FakeAnndataModule)
-    adapter = VariantScoringAdapter(FakeRuntime(), FakeScoringModel())
+    runtime = FakeRuntime()
+    adapter = LocalDnaModelAdapter(
+        runtime, scorer=VariantScorer(runtime, FakeScoringModel()),
+    )
     yield from _start_rest(adapter)
 
 

--- a/tests/unit/test_serving_rest.py
+++ b/tests/unit/test_serving_rest.py
@@ -4,14 +4,13 @@ import http.client
 import json
 
 import numpy as np
-import pandas as pd
 import pytest
-import torch
 
 from alphagenome.models import dna_output
 
 from alphagenome_pytorch.extensions.serving.adapter import LocalDnaModelAdapter, SEQUENCE_LENGTH_16KB
 from alphagenome_pytorch.extensions.serving.rest_service import serve_rest
+from alphagenome_pytorch.extensions.serving.variant_scoring_adapter import VariantScoringAdapter
 from alphagenome_pytorch.variant_scoring.scorers import (
     CenterMaskScorer as PTCenterMaskScorer,
     ContactMapScorer as PTContactMapScorer,
@@ -24,75 +23,13 @@ from alphagenome_pytorch.variant_scoring.scorers import (
 from alphagenome_pytorch.variant_scoring.scorers.gene_mask import GeneMaskMode
 from alphagenome_pytorch.variant_scoring.types import (
     AggregationType as PTAggregationType,
-    Interval as PTInterval,
     OutputType as PTOutputType,
-    TrackMetadata as PTTrackMetadata,
-    Variant as PTVariant,
-    VariantScore,
 )
 
-
-class _FakeAnndataModule:
-    class AnnData:
-        def __init__(self, X, obs=None, var=None, uns=None, layers=None):
-            self.X = X
-            self.obs = obs if obs is not None else pd.DataFrame()
-            self.var = var if var is not None else pd.DataFrame()
-            self.uns = uns if uns is not None else {}
-            self.layers = layers if layers is not None else {}
+from .serving_fakes import FakeAnndataModule, FakeRuntime, FakeScoringModel
 
 
-class _FakeScoringModel:
-    def __init__(self):
-        self._metadata = {
-            0: {
-                PTOutputType.DNASE: [
-                    PTTrackMetadata(0, 'track_a', '.', PTOutputType.DNASE, ontology_curie='CL:0001'),
-                    PTTrackMetadata(1, 'track_b', '.', PTOutputType.DNASE, ontology_curie='CL:0002'),
-                ]
-            }
-        }
-
-    def get_track_metadata(self, organism=None):
-        del organism
-        return self._metadata[0]
-
-    def predict(self, sequence, organism=None, **kwargs):
-        del organism, kwargs
-        seq_len = len(sequence)
-        values = np.ones((1, seq_len, 2), dtype=np.float32)
-        return {'dnase': {1: values}}
-
-    def get_sequence(self, interval, variant=None):
-        del variant
-        return 'A' * interval.width
-
-    def predict_variant(self, interval, variant, organism=None):
-        del variant, organism
-        ref = self.predict('A' * interval.width)
-        alt = self.predict('A' * interval.width)
-        alt['dnase'][1] = alt['dnase'][1] + 1.0
-        return ref, alt
-
-    def score_variant(self, interval, variant, scorers, organism=None):
-        del interval, variant, organism
-        result = []
-        for scorer in scorers:
-            result.append(
-                VariantScore(
-                    variant=PTVariant('chr1', 10, 'A', 'C'),
-                    interval=PTInterval('chr1', 0, SEQUENCE_LENGTH_16KB),
-                    scorer=scorer,
-                    scores=torch.tensor([1.0, 2.0]),
-                )
-            )
-        return result
-
-
-@pytest.fixture
-def rest_server(monkeypatch):
-    monkeypatch.setitem(__import__('sys').modules, 'anndata', _FakeAnndataModule)
-    adapter = LocalDnaModelAdapter(_FakeScoringModel())
+def _start_rest(adapter):
     server = serve_rest(adapter, host='127.0.0.1', port=0, wait=False)
     host, port = server.server_address
     try:
@@ -100,6 +37,20 @@ def rest_server(monkeypatch):
     finally:
         server.shutdown()
         server.server_close()
+
+
+@pytest.fixture
+def rest_server(monkeypatch):
+    monkeypatch.setitem(__import__('sys').modules, 'anndata', FakeAnndataModule)
+    adapter = VariantScoringAdapter(FakeRuntime(), FakeScoringModel())
+    yield from _start_rest(adapter)
+
+
+@pytest.fixture
+def prediction_only_rest_server(monkeypatch):
+    monkeypatch.setitem(__import__('sys').modules, 'anndata', FakeAnndataModule)
+    adapter = LocalDnaModelAdapter(FakeRuntime())
+    yield from _start_rest(adapter)
 
 
 def _post(host: str, port: int, path: str, body: bytes) -> tuple[int, dict]:
@@ -193,6 +144,21 @@ def test_score_variant_missing_required_field(rest_server):
     status, payload = _post(host, port, '/v1/score_variant', body)
     assert status == 400
     assert 'aggregation_type' in payload['error']
+
+
+def test_score_variant_prediction_only_adapter_returns_501(prediction_only_rest_server):
+    host, port = prediction_only_rest_server
+    body = json.dumps({
+        'interval': {'chromosome': 'chr1', 'start': 0, 'end': SEQUENCE_LENGTH_16KB},
+        'variant': {
+            'chromosome': 'chr1', 'position': 10,
+            'reference_bases': 'A', 'alternate_bases': 'C',
+        },
+        'variant_scorers': [],
+    }).encode('utf-8')
+    status, payload = _post(host, port, '/v1/score_variant', body)
+    assert status == 501
+    assert 'Variant scoring not available' in payload['error']
 
 
 def test_parse_variant_scorers_all_types():

--- a/tests/unit/test_serving_rest.py
+++ b/tests/unit/test_serving_rest.py
@@ -208,3 +208,74 @@ def test_parse_variant_scorers_empty_returns_empty_list():
 
     assert _parse_variant_scorers(None) == []
     assert _parse_variant_scorers([]) == []
+
+
+# ---------------------------------------------------------------------------
+# /v1/explain_interval tests
+# ---------------------------------------------------------------------------
+
+
+def test_explain_interval_gradient_round_trip(rest_server):
+    host, port = rest_server
+    body = json.dumps({
+        'interval': {'chromosome': 'chr1', 'start': 0, 'end': SEQUENCE_LENGTH_16KB},
+        'target_interval': {'chromosome': 'chr1', 'start': 100, 'end': 200},
+        'organism': 'HOMO_SAPIENS',
+        'requested_output': 'dnase',
+        'resolution': 1,
+        'track_indices': [0],
+        'method': 'input_x_gradient',
+        'reduction': 'sum',
+    }).encode('utf-8')
+    status, payload = _post(host, port, '/v1/explain_interval', body)
+    assert status == 200
+    assert 'attribution' in payload
+    attr = payload['attribution']
+    assert attr['method'] == 'input_x_gradient'
+    assert attr['kind'] == 'base_matrix'
+    # values shape should be (100, 4, 1) encoded as nested lists
+    values = np.asarray(attr['values'])
+    assert values.shape == (100, 4, 1)
+    assert attr['target_start'] == 100
+    assert attr['target_end'] == 200
+    assert attr['raw_gradient'] is None
+
+
+def test_explain_interval_ism_round_trip(rest_server):
+    host, port = rest_server
+    body = json.dumps({
+        'interval': {'chromosome': 'chr1', 'start': 0, 'end': SEQUENCE_LENGTH_16KB},
+        'target_interval': {'chromosome': 'chr1', 'start': 100, 'end': 108},
+        'requested_output': 'dnase',
+        'resolution': 1,
+        'track_indices': [0],
+        'method': 'saturation_ism',
+        'batch_size': 4,
+    }).encode('utf-8')
+    status, payload = _post(host, port, '/v1/explain_interval', body)
+    assert status == 200
+    attr = payload['attribution']
+    assert attr['method'] == 'saturation_ism'
+    # ISM reference-base cells are NaN → serialized as null
+    values = attr['values']  # nested list
+    # Check that at least one cell is null (the reference base for each position)
+    flat = json.dumps(values)
+    assert 'null' in flat, 'Reference-base cells should serialize as null'
+
+
+def test_explain_interval_unknown_method_400(rest_server):
+    host, port = rest_server
+    body = json.dumps({
+        'interval': {'chromosome': 'chr1', 'start': 0, 'end': SEQUENCE_LENGTH_16KB},
+        'target_interval': {'chromosome': 'chr1', 'start': 100, 'end': 200},
+        'requested_output': 'dnase',
+        'resolution': 1,
+        'track_indices': [0],
+        'method': 'nonexistent_method',
+    }).encode('utf-8')
+    status, payload = _post(host, port, '/v1/explain_interval', body)
+    assert status == 400
+    assert 'nonexistent_method' in payload['error']
+    # Error should list known methods
+    assert 'input_x_gradient' in payload['error']
+    assert 'saturation_ism' in payload['error']


### PR DESCRIPTION
Introduce an attribution endpoint (in `.extensions.serving`) and refactor `LocalDnaModelAdapter` / `VariantScoringAdapter`.

- **Decouple prediction from variant scoring in serving extension** — `LocalDnaModelAdapter` is now prediction-only; scoring layers on via `VariantScoringAdapter`. Adds `AlphaGenomePredictionRuntime` as the canonical construction path and `GenomeSequenceSource` for shared FASTA/encoding policy.
- **Initial draft for serving attributions** — wires up the attribution endpoint (still draft).
- **Fold VariantScoringAdapter into LocalDnaModelAdapter via composable scorer** — replaces the parallel adapter with a `VariantScorer` the prediction adapter optionally holds; pretrained and fine-tuned checkpoints now share one adapter and fine-tuned models gain variant scoring.