### PR TITLE
Fix splice-junction RoPE initialization for from-scratch fine-tuning

### DIFF
--- a/src/alphagenome_pytorch/heads.py
+++ b/src/alphagenome_pytorch/heads.py
@@ -554,9 +554,11 @@ class SpliceSitesJunctionHead(nn.Module):
         )
 
         def make_rope_params():
-            return nn.Parameter(torch.zeros(
+            tensor = torch.empty(
                 self._num_organisms, 2, self._num_tissues, self._hidden_dim
-            ))
+            )
+            nn.init.trunc_normal_(tensor, std=0.1)
+            return nn.Parameter(tensor)
 
         self.rope_params = nn.ParameterDict({
             "pos_donor": make_rope_params(),

--- a/tests/unit/test_heads.py
+++ b/tests/unit/test_heads.py
@@ -486,6 +486,29 @@ class TestSpliceSitesJunctionHead:
         assert bool(mask[0].all())
         assert bool(mask[1].all())
 
+    def test_rope_params_initialized_nonzero(self):
+        # Upstream switched zero-init → trunc-normal so the junction head
+        # converges when fine-tuned from scratch.
+        from alphagenome_pytorch.heads import SpliceSitesJunctionHead
+
+        num_organisms, T, in_channels, hidden_dim = 2, 367, 128, 64
+        head = SpliceSitesJunctionHead(
+            in_channels=in_channels,
+            hidden_dim=hidden_dim,
+            num_tissues=T,
+            num_organisms=num_organisms,
+        )
+
+        expected_shape = (num_organisms, 2, T, hidden_dim)
+        for key in ("pos_donor", "pos_acceptor", "neg_donor", "neg_acceptor"):
+            param = head.rope_params[key]
+            assert param.shape == expected_shape
+            assert torch.isfinite(param).all()
+            assert torch.any(param != 0), f"rope_params[{key!r}] should not be all zeros"
+            assert param.abs().max().item() < 1.0, (
+                f"trunc_normal_(std=0.1) produced unexpectedly large values for {key!r}"
+            )
+
 
 @pytest.mark.unit
 class TestScalingFunctions:

--- a/tests/unit/test_variant_scoring_aggregations.py
+++ b/tests/unit/test_variant_scoring_aggregations.py
@@ -1,0 +1,60 @@
+"""Unit tests for variant scoring aggregations (no JAX dependency)."""
+
+import pytest
+import torch
+
+from alphagenome_pytorch.variant_scoring.aggregations import create_center_mask
+
+
+@pytest.mark.unit
+class TestCreateCenterMask:
+    """Regression tests for the upstream center-mask off-by-one fix.
+
+    Upstream switched from 1-based ``variant.position`` to 0-based
+    ``variant.start`` to center the mask. Our implementation accepts a 1-based
+    VCF ``variant_position`` and immediately converts via ``variant_position - 1``,
+    so the centered bin should match upstream's 0-based behavior.
+    """
+
+    def test_width_one_centers_on_variant_position(self):
+        # variant_position=3 (1-based) → 0-based index 2 → only bin 2 set.
+        mask = create_center_mask(
+            variant_position=3,
+            interval_start=0,
+            width=1,
+            seq_length=5,
+        )
+        expected = torch.tensor([False, False, True, False, False])
+        assert torch.equal(mask, expected)
+
+    def test_width_three_spans_three_bins(self):
+        # width=3 around 0-based center 2 → bins 1, 2, 3.
+        mask = create_center_mask(
+            variant_position=3,
+            interval_start=0,
+            width=3,
+            seq_length=5,
+        )
+        expected = torch.tensor([False, True, True, True, False])
+        assert torch.equal(mask, expected)
+
+    def test_interval_start_offset(self):
+        # interval_start shifts the relative position, so a variant at 1-based
+        # position 13 with interval_start=10 maps to 0-based rel_position 2.
+        mask = create_center_mask(
+            variant_position=13,
+            interval_start=10,
+            width=1,
+            seq_length=5,
+        )
+        expected = torch.tensor([False, False, True, False, False])
+        assert torch.equal(mask, expected)
+
+    def test_none_width_returns_all_true(self):
+        mask = create_center_mask(
+            variant_position=3,
+            interval_start=0,
+            width=None,
+            seq_length=4,
+        )
+        assert torch.equal(mask, torch.ones(4, dtype=torch.bool))


### PR DESCRIPTION
Port two upstream `alphagenome_research` correctness items into this PyTorch fork:

1. **Fix:** splice-junction RoPE parameters now use truncated-normal init instead of zeros, so `SpliceSitesJunctionHead` converges when fine-tuned from scratch.
    - Upstream commit: [google-deepmind/alphagenome_research@e2acbfa](https://github.com/google-deepmind/alphagenome_research/commit/e2acbfaee39dc074d41ca082cab2cad75b84ec9a)
    - Upstream issue: [google-deepmind/alphagenome_research#22](https://github.com/google-deepmind/alphagenome_research/issues/22)

2. **Regression test:** pin `create_center_mask` to the 0-based `variant.start` semantics that upstream landed as a bug fix; our implementation already did this correctly, but had no direct test.
   - Upstream commit: [google-deepmind/alphagenome_research@4550090](https://github.com/google-deepmind/alphagenome_research/commit/455009019acd4c816873d648404ffef2d506606c)
   - Upstream issue: [google-deepmind/alphagenome_research#20](https://github.com/google-deepmind/alphagenome_research/issues/20)

## RoPE init

Upstream switched to `trunc_normal_(std=0.1)` in commit [e2acbfa](https://github.com/google-deepmind/alphagenome_research/commit/e2acbfaee39dc074d41ca082cab2cad75b84ec9a).

We now do the same:

```python
 def make_rope_params():
-    return nn.Parameter(torch.zeros(
-        self._num_organisms, 2, self._num_tissues, self._hidden_dim
-    ))
+    tensor = torch.empty(
+        self._num_organisms, 2, self._num_tissues, self._hidden_dim
+    )
+    nn.init.trunc_normal_(tensor, std=0.1)
+    return nn.Parameter(tensor)
```

Tensor shape and `state_dict` keys are unchanged, so existing checkpoints continue to load bit-identically — only from-scratch init is different.

## Center-mask test

Upstream had an off-by-one bug where masks were centered on 1-based variant.position instead of 0-based variant.start (fixed in [4550090](https://github.com/google-deepmind/alphagenome_research/commit/455009019acd4c816873d648404ffef2d506606c), issue [#20](https://github.com/google-deepmind/alphagenome_research/issues/20)).

In the upstream:

```python
interval = genome.Interval('chr1', 0, 5)
variant  = genome.Variant('chr1', 3, 'A', 'C')

mask = create_center_mask(interval, variant, width=1, resolution=1)
mask.astype(int).reshape((-1)).tolist()
# Expected: [0, 0, 1, 0, 0]
# Pre-fix in upstream:  [0, 0, 0, 1, 0]
```

Our `src/alphagenome_pytorch/variant_scoring/aggregations.py` already converted it correctly:

```python
variant_0based = variant_position - 1     # 1-based VCF → 0-based
rel_position = variant_0based - interval_start
```

so behavior has been correct — but no test pinned it. The new `tests/unit/test_variant_scoring_aggregations.py` mirrors upstream's example:

```python
mask = create_center_mask(
    variant_position=3, interval_start=0, width=1, seq_length=5,
)
# expected: [False, False, True, False, False]
```