### PR TITLE
Variant-scoring changes from upstream

### DIFF
--- a/src/alphagenome_pytorch/variant_scoring/aggregations.py
+++ b/src/alphagenome_pytorch/variant_scoring/aggregations.py
@@ -28,46 +28,56 @@ def align_alternate(
     For deletions: insert zeros at deletion locations.
 
     Args:
-        alt: ALT allele predictions of shape (S, T) where S=sequence, T=tracks.
+        alt: ALT allele tensor. Either ``(S, T)`` or ``(B, S, T)`` — the
+            sequence axis is the second-to-last dim. Used for predictions,
+            splice-site probs, and 1bp embeddings (channels_last NLC).
         variant_start: 0-based start position of the variant in genomic coords.
         ref_length: Length of reference allele.
         alt_length: Length of alternate allele.
         interval_start: 0-based start of the sequence interval.
 
     Returns:
-        Aligned ALT predictions of shape (S, T), matching REF coordinate space.
+        Aligned ALT tensor with the same shape as input, in REF coordinate
+        space. Identity when ``ref_length == alt_length`` (e.g. SNVs).
     """
+    squeeze_back = False
+    if alt.dim() == 2:
+        alt = alt.unsqueeze(0)  # (1, S, T)
+        squeeze_back = True
+    elif alt.dim() != 3:
+        raise ValueError(
+            f"align_alternate expects (S, T) or (B, S, T), got shape {tuple(alt.shape)}"
+        )
+
     insertion_length = alt_length - ref_length
     deletion_length = -insertion_length
     variant_start_in_vector = variant_start - interval_start
     # Assume left-aligned variants; adjustments occur at end of variant
     variant_start_in_vector += min(ref_length, alt_length) - 1
-    original_length = alt.shape[0]
+
+    B, S, C = alt.shape
+    original_length = S
 
     if insertion_length > 0:
         # Summarize insertion by computing max score across alternate bases
-        pool_range = slice(
-            variant_start_in_vector,
-            variant_start_in_vector + insertion_length + 1
-        )
-        pool_alt = alt[pool_range].max(dim=0, keepdim=True)[0]
-        alt = torch.cat([
-            alt[:variant_start_in_vector],
-            pool_alt,
-            alt[variant_start_in_vector + insertion_length + 1:],
-            torch.zeros(insertion_length, alt.shape[1], device=alt.device, dtype=alt.dtype),
-        ], dim=0)
-        # Truncate to original length
-        alt = alt[:original_length]
+        pool_alt = alt[
+            :, variant_start_in_vector:variant_start_in_vector + insertion_length + 1, :
+        ].max(dim=1, keepdim=True)[0]  # (B, 1, C)
+        before = alt[:, :variant_start_in_vector, :]
+        after = alt[:, variant_start_in_vector + insertion_length + 1:, :]
+        pad = torch.zeros(B, insertion_length, C, device=alt.device, dtype=alt.dtype)
+        alt = torch.cat([before, pool_alt, after, pad], dim=1)
+        alt = alt[:, :original_length, :]
     elif deletion_length > 0:
         # Insert zero signal at deletion locations
-        alt = torch.cat([
-            alt[:variant_start_in_vector + 1],
-            torch.zeros(deletion_length, alt.shape[1], device=alt.device, dtype=alt.dtype),
-            alt[variant_start_in_vector + 1:],
-        ], dim=0)
-        alt = alt[:original_length]
+        before = alt[:, :variant_start_in_vector + 1, :]
+        pad = torch.zeros(B, deletion_length, C, device=alt.device, dtype=alt.dtype)
+        after = alt[:, variant_start_in_vector + 1:, :]
+        alt = torch.cat([before, pad, after], dim=1)
+        alt = alt[:, :original_length, :]
 
+    if squeeze_back:
+        alt = alt.squeeze(0)
     return alt
 
 

--- a/src/alphagenome_pytorch/variant_scoring/annotations.py
+++ b/src/alphagenome_pytorch/variant_scoring/annotations.py
@@ -17,7 +17,7 @@ import pandas as pd
 import torch
 
 if TYPE_CHECKING:
-    from .types import Interval
+    from .types import Interval, Variant
 
 
 @dataclass
@@ -243,6 +243,51 @@ class GeneAnnotation:
             if gene_types is not None:
                 if info.gene_type not in gene_types:
                     continue
+
+            genes.append(gene_id)
+
+        return genes
+
+    def get_genes_overlapping_variant(
+        self,
+        variant: 'Variant',
+        gene_types: list[str] | None = None,
+    ) -> list[str]:
+        """Get gene IDs whose body overlaps the variant position.
+
+        Mirrors the upstream JAX behavior: only genes whose body contains
+        the variant's 0-based start position are returned. Used by splicing
+        scorers to restrict scoring to variant-overlapping genes.
+
+        Args:
+            variant: Variant whose 0-based start defines the overlap query
+            gene_types: Optional list of gene types to include
+                (e.g., ['protein_coding', 'lncRNA'])
+
+        Returns:
+            List of gene IDs (without version)
+        """
+        # Ensure index is built by accessing df
+        _ = self.df
+
+        chrom = variant.chromosome
+        pos = variant.start  # 0-based
+        genes = []
+
+        for gene_id, info in self._gene_index.items():
+            # Check chromosome match (handle chr prefix differences)
+            if info.chromosome != chrom:
+                if info.chromosome == 'chr' + chrom or chrom == 'chr' + info.chromosome:
+                    pass
+                else:
+                    continue
+
+            # Variant 0-based position must lie within [start, end)
+            if not (info.start <= pos < info.end):
+                continue
+
+            if gene_types is not None and info.gene_type not in gene_types:
+                continue
 
             genes.append(gene_id)
 

--- a/src/alphagenome_pytorch/variant_scoring/inference.py
+++ b/src/alphagenome_pytorch/variant_scoring/inference.py
@@ -356,6 +356,7 @@ class VariantScoringModel:
         organism: str | int | None = None,
         to_cpu: bool = False,
         unified_splicing: bool = False,
+        heads: tuple[str, ...] | None = None,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Get reference and alternate predictions for a variant.
 
@@ -367,6 +368,8 @@ class VariantScoringModel:
                 Recommended for visualization or when processing many variants.
             unified_splicing: If True, performs a second pass to align splice
                 sites between Ref and Alt predictions. Required for SpliceJunctionScorer.
+            heads: Optional tuple of head names to compute. If None, all heads
+                run. Forwarded to the model forward pass to skip unused heads.
 
         Returns:
             Tuple of (ref_outputs, alt_outputs) dictionaries.
@@ -397,13 +400,32 @@ class VariantScoringModel:
 
         # First pass: Get standard predictions with embeddings if needed
         return_embeddings = unified_splicing
-        ref_outputs = self.predict(ref_seq, organism, return_embeddings=return_embeddings)
-        alt_outputs = self.predict(alt_seq, organism, return_embeddings=return_embeddings)
+        predict_kwargs: dict[str, Any] = {'return_embeddings': return_embeddings}
+        if heads is not None:
+            predict_kwargs['heads'] = heads
+        ref_outputs = self.predict(ref_seq, organism, **predict_kwargs)
+        alt_outputs = self.predict(alt_seq, organism, **predict_kwargs)
 
         if unified_splicing:
             # Calculate unified splice site positions (max of Ref and Alt)
             from ..utils.splicing import generate_splice_site_positions
-            
+            from .aggregations import align_alternate
+
+            # Align ALT embeddings + splice-site probs into REF coordinate
+            # space before generating unified positions and re-running the
+            # junction head. Identity for SNVs (ref_len == alt_len).
+            if variant.is_indel:
+                ref_len = len(variant.reference_bases)
+                alt_len = len(variant.alternate_bases)
+                alt_outputs['embeddings_1bp'] = align_alternate(
+                    alt_outputs['embeddings_1bp'],
+                    variant.start, ref_len, alt_len, interval.start,
+                )
+                alt_outputs['splice_sites']['probs'] = align_alternate(
+                    alt_outputs['splice_sites']['probs'],
+                    variant.start, ref_len, alt_len, interval.start,
+                )
+
             ref_probs = ref_outputs['splice_sites']['probs']
             alt_probs = alt_outputs['splice_sites']['probs']
             
@@ -505,9 +527,19 @@ class VariantScoringModel:
         # Alternative: isinstance(s, SpliceJunctionScorer) if imported
         # Let's check typical string representation
 
+        # Build the union of heads required by the active scorers so the model
+        # forward pass can skip unused heads. Empty union means no scorers
+        # declared requirements; in that case fall back to running all heads.
+        required_heads: set[str] = set()
+        for s in scorers:
+            required_heads.update(s.required_heads)
+        heads_arg = tuple(sorted(required_heads)) if required_heads else None
+
         # Get predictions
         ref_outputs, alt_outputs = self.predict_variant(
-            interval, variant, organism, unified_splicing=unified_splicing
+            interval, variant, organism,
+            unified_splicing=unified_splicing,
+            heads=heads_arg,
         )
 
         # Use instance gene annotation if not provided

--- a/src/alphagenome_pytorch/variant_scoring/inference.py
+++ b/src/alphagenome_pytorch/variant_scoring/inference.py
@@ -374,6 +374,18 @@ class VariantScoringModel:
         Returns:
             Tuple of (ref_outputs, alt_outputs) dictionaries.
         """
+        # The unified-splicing second pass reads splice_sites['probs'] (and
+        # aligns it for indels) to derive unified positions, so a head filter
+        # that omits splice_sites would otherwise fail with an opaque KeyError.
+        # The junction head itself is recomputed from embeddings and need not be
+        # in `heads`. Embeddings come from return_embeddings, not the filter.
+        if unified_splicing and heads is not None and 'splice_sites' not in heads:
+            raise ValueError(
+                "unified_splicing=True requires 'splice_sites' in heads "
+                f"(got {heads}); it is needed to derive unified splice-site "
+                "positions for the junction head's second pass."
+            )
+
         # Handle indels: for deletions, extend extraction to compensate for
         # sequence shrinkage. For insertions, the alt is longer and gets
         # truncated. Both ref and alt are truncated to the original interval

--- a/src/alphagenome_pytorch/variant_scoring/scorers/base.py
+++ b/src/alphagenome_pytorch/variant_scoring/scorers/base.py
@@ -36,6 +36,16 @@ class BaseVariantScorer(ABC):
         pass
 
     @property
+    def required_heads(self) -> frozenset[str]:
+        """Set of model head names this scorer needs from the forward pass.
+
+        Used by VariantScoringModel.score_variant() to skip unused heads.
+        Defaults to the scorer's requested_output head; subclasses with
+        compound requirements (e.g., SpliceJunctionScorer) override.
+        """
+        return frozenset({self.requested_output.value})
+
+    @property
     @abstractmethod
     def is_signed(self) -> bool:
         """Whether scores are directional (can be negative)."""

--- a/src/alphagenome_pytorch/variant_scoring/scorers/splicing.py
+++ b/src/alphagenome_pytorch/variant_scoring/scorers/splicing.py
@@ -281,8 +281,11 @@ class SpliceJunctionScorer(BaseVariantScorer):
     @property
     def required_heads(self) -> frozenset[str]:
         # The unified-splicing flow needs splice_sites probs to derive unified
-        # site positions, then re-runs the junction head on cached embeddings.
-        return frozenset({'splice_sites', 'splice_junctions'})
+        # site positions. The junction head is re-run in the second pass on
+        # cached embeddings with those unified positions, which unconditionally
+        # overwrites any first-pass result, so requesting 'splice_junctions'
+        # here would just do a redundant junction-head forward per sequence.
+        return frozenset({'splice_sites'})
 
     @property
     def is_signed(self) -> bool:

--- a/src/alphagenome_pytorch/variant_scoring/scorers/splicing.py
+++ b/src/alphagenome_pytorch/variant_scoring/scorers/splicing.py
@@ -191,7 +191,9 @@ class GeneMaskSplicingScorer(BaseVariantScorer):
                 )
 
             if gene_ids is None:
-                gene_ids = gene_annotation.get_genes_in_interval(interval)
+                # Match upstream JAX: restrict to genes whose body contains
+                # the variant, not all genes in the prediction interval.
+                gene_ids = gene_annotation.get_genes_overlapping_variant(variant)
 
             if not gene_ids:
                 return []
@@ -275,6 +277,12 @@ class SpliceJunctionScorer(BaseVariantScorer):
     @property
     def requested_output(self) -> OutputType:
         return OutputType.SPLICE_JUNCTIONS
+
+    @property
+    def required_heads(self) -> frozenset[str]:
+        # The unified-splicing flow needs splice_sites probs to derive unified
+        # site positions, then re-runs the junction head on cached embeddings.
+        return frozenset({'splice_sites', 'splice_junctions'})
 
     @property
     def is_signed(self) -> bool:
@@ -362,7 +370,7 @@ class SpliceJunctionScorer(BaseVariantScorer):
         # Get genes overlapping the variant
         # JAX uses VARIANT_OVERLAPPING query type and filters to protein_coding
         if gene_ids is None:
-            gene_ids = gene_annotation.get_genes_in_interval(interval)
+            gene_ids = gene_annotation.get_genes_overlapping_variant(variant)
 
         if not gene_ids:
             return []

--- a/tests/unit/test_align_alternate.py
+++ b/tests/unit/test_align_alternate.py
@@ -1,0 +1,104 @@
+"""Tests for align_alternate, including 3D (batched) support added for B2.3."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from alphagenome_pytorch.variant_scoring.aggregations import align_alternate
+
+
+@pytest.mark.unit
+def test_align_alternate_snv_is_identity_2d():
+    alt = torch.randn(16, 4)
+    out = align_alternate(alt, variant_start=10, ref_length=1, alt_length=1, interval_start=0)
+    assert out.shape == alt.shape
+    assert torch.equal(out, alt)
+
+
+@pytest.mark.unit
+def test_align_alternate_snv_is_identity_3d():
+    alt = torch.randn(2, 16, 4)
+    out = align_alternate(alt, variant_start=10, ref_length=1, alt_length=1, interval_start=0)
+    assert out.shape == alt.shape
+    assert torch.equal(out, alt)
+
+
+@pytest.mark.unit
+def test_align_alternate_2d_and_3d_match_for_insertion():
+    """3D path with B=1 must give the same answer as the 2D path."""
+    torch.manual_seed(0)
+    alt2d = torch.randn(16, 4)
+    alt3d = alt2d.unsqueeze(0).clone()  # (1, 16, 4)
+
+    kw = dict(variant_start=8, ref_length=1, alt_length=3, interval_start=0)
+    out2d = align_alternate(alt2d, **kw)
+    out3d = align_alternate(alt3d, **kw)
+
+    assert out2d.shape == (16, 4)
+    assert out3d.shape == (1, 16, 4)
+    torch.testing.assert_close(out2d, out3d.squeeze(0))
+
+
+@pytest.mark.unit
+def test_align_alternate_2d_and_3d_match_for_deletion():
+    torch.manual_seed(1)
+    alt2d = torch.randn(16, 4)
+    alt3d = alt2d.unsqueeze(0).clone()
+
+    kw = dict(variant_start=5, ref_length=3, alt_length=1, interval_start=0)
+    out2d = align_alternate(alt2d, **kw)
+    out3d = align_alternate(alt3d, **kw)
+    torch.testing.assert_close(out2d, out3d.squeeze(0))
+
+
+@pytest.mark.unit
+def test_align_alternate_insertion_pools_with_max_3d():
+    """For an insertion of length 2, the inserted region collapses to max."""
+    # Create a tensor where positions 8, 9, 10 have known patterns
+    alt = torch.zeros(2, 16, 1)  # B=2, S=16, T=1
+    # Make the variant region distinguishable
+    alt[0, 8, 0] = 1.0
+    alt[0, 9, 0] = 5.0  # max in this batch row
+    alt[0, 10, 0] = 3.0
+    alt[1, 8, 0] = 2.0
+    alt[1, 9, 0] = 4.0
+    alt[1, 10, 0] = 7.0  # max in this batch row
+
+    # variant_start=8 (interval_start=0), ref_length=1, alt_length=3
+    # variant_start_in_vector = 8 + min(1,3)-1 = 8
+    # insertion pool spans [8, 11)
+    out = align_alternate(alt, variant_start=8, ref_length=1, alt_length=3, interval_start=0)
+
+    assert out.shape == (2, 16, 1)
+    # At position 8 we expect the max of [8,9,10] for each batch row
+    assert out[0, 8, 0].item() == pytest.approx(5.0)
+    assert out[1, 8, 0].item() == pytest.approx(7.0)
+    # Last 2 positions should be zero-padded
+    assert torch.all(out[:, -2:, :] == 0.0)
+
+
+@pytest.mark.unit
+def test_align_alternate_deletion_inserts_zeros_3d():
+    """For a deletion of length 2, two zero rows are inserted after the variant."""
+    alt = torch.ones(1, 16, 3)
+    # variant_start=5, ref_length=3, alt_length=1
+    # variant_start_in_vector = 5 + min(3,1)-1 = 5
+    # zeros inserted starting at index 6 (length 2)
+    out = align_alternate(alt, variant_start=5, ref_length=3, alt_length=1, interval_start=0)
+    assert out.shape == (1, 16, 3)
+    # Positions 6, 7 should be zero
+    assert torch.all(out[0, 6:8, :] == 0.0)
+    # Position 5 should be unchanged (= 1.0)
+    assert torch.all(out[0, 5, :] == 1.0)
+
+
+@pytest.mark.unit
+def test_align_alternate_rejects_invalid_shape():
+    with pytest.raises(ValueError):
+        align_alternate(torch.zeros(4), variant_start=0, ref_length=1, alt_length=1, interval_start=0)
+    with pytest.raises(ValueError):
+        align_alternate(
+            torch.zeros(2, 1, 16, 4),
+            variant_start=0, ref_length=1, alt_length=1, interval_start=0,
+        )

--- a/tests/unit/test_gene_annotation_overlap.py
+++ b/tests/unit/test_gene_annotation_overlap.py
@@ -1,0 +1,89 @@
+"""Unit tests for GeneAnnotation.get_genes_overlapping_variant (B2.2)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from alphagenome_pytorch.variant_scoring import Interval, Variant
+from alphagenome_pytorch.variant_scoring.annotations import GeneAnnotation
+
+
+def _make_annotation(tmp_path, rows):
+    df = pd.DataFrame(rows)
+    out = tmp_path / "anno.parquet"
+    df.to_parquet(out)
+    return GeneAnnotation(out)
+
+
+@pytest.mark.unit
+def test_get_genes_overlapping_variant_returns_only_overlapping(tmp_path):
+    rows = [
+        # Gene A spans [100, 200), Gene B spans [300, 400)
+        {
+            'Feature': 'gene', 'gene_id': 'A', 'gene_name': 'A',
+            'gene_type': 'protein_coding', 'Chromosome': 'chr1',
+            'Start': 100, 'End': 200, 'Strand': '+',
+        },
+        {
+            'Feature': 'gene', 'gene_id': 'B', 'gene_name': 'B',
+            'gene_type': 'protein_coding', 'Chromosome': 'chr1',
+            'Start': 300, 'End': 400, 'Strand': '+',
+        },
+    ]
+    anno = _make_annotation(tmp_path, rows)
+
+    # Variant inside A only (1-based 150 -> 0-based 149)
+    variant_in_a = Variant('chr1', 150, 'A', 'C')
+    overlap = anno.get_genes_overlapping_variant(variant_in_a)
+    assert overlap == ['A']
+
+    # Compare against interval-spanning query: returns both
+    interval_spanning = Interval('chr1', 50, 500)
+    in_interval = anno.get_genes_in_interval(interval_spanning)
+    assert set(in_interval) == {'A', 'B'}
+
+
+@pytest.mark.unit
+def test_get_genes_overlapping_variant_at_boundaries(tmp_path):
+    rows = [
+        {
+            'Feature': 'gene', 'gene_id': 'G', 'gene_name': 'G',
+            'gene_type': 'protein_coding', 'Chromosome': 'chr1',
+            'Start': 100, 'End': 200, 'Strand': '+',
+        },
+    ]
+    anno = _make_annotation(tmp_path, rows)
+
+    # Variant at 0-based 100 (inclusive start) => overlaps
+    v_start = Variant('chr1', 101, 'A', 'C')
+    assert anno.get_genes_overlapping_variant(v_start) == ['G']
+
+    # Variant at 0-based 199 (last included pos) => overlaps
+    v_last = Variant('chr1', 200, 'A', 'C')
+    assert anno.get_genes_overlapping_variant(v_last) == ['G']
+
+    # Variant at 0-based 200 (exclusive end) => does NOT overlap
+    v_end = Variant('chr1', 201, 'A', 'C')
+    assert anno.get_genes_overlapping_variant(v_end) == []
+
+
+@pytest.mark.unit
+def test_get_genes_overlapping_variant_filters_gene_types(tmp_path):
+    rows = [
+        {
+            'Feature': 'gene', 'gene_id': 'A', 'gene_name': 'A',
+            'gene_type': 'protein_coding', 'Chromosome': 'chr1',
+            'Start': 100, 'End': 200, 'Strand': '+',
+        },
+        {
+            'Feature': 'gene', 'gene_id': 'B', 'gene_name': 'B',
+            'gene_type': 'lncRNA', 'Chromosome': 'chr1',
+            'Start': 100, 'End': 200, 'Strand': '+',
+        },
+    ]
+    anno = _make_annotation(tmp_path, rows)
+
+    v = Variant('chr1', 150, 'A', 'C')
+    assert anno.get_genes_overlapping_variant(v, gene_types=['protein_coding']) == ['A']
+    assert set(anno.get_genes_overlapping_variant(v)) == {'A', 'B'}

--- a/tests/unit/test_score_variant_head_filtering.py
+++ b/tests/unit/test_score_variant_head_filtering.py
@@ -1,0 +1,185 @@
+"""Unit tests for VariantScoringModel.score_variant() head filtering (B2.1).
+
+Verifies that score_variant unions each scorer's required_heads and forwards
+them to the model forward pass via predict_variant -> predict.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from alphagenome_pytorch.variant_scoring import (
+    AggregationType,
+    CenterMaskScorer,
+    ContactMapScorer,
+    GeneMaskActiveScorer,
+    GeneMaskLFCScorer,
+    GeneMaskSplicingScorer,
+    Interval,
+    OutputType,
+    PolyadenylationScorer,
+    SpliceJunctionScorer,
+    Variant,
+    VariantScoringModel,
+)
+
+
+class _RecordingModel(torch.nn.Module):
+    """Mock model that records the heads kwarg passed to forward()."""
+
+    num_organisms = 2
+
+    def __init__(self):
+        super().__init__()
+        self.last_heads_seen: tuple[str, ...] | None = None
+        self.heads_history: list[tuple[str, ...] | None] = []
+
+        # Tiny dtype_policy stub so .predict() can read compute_dtype.
+        class _DP:
+            compute_dtype = torch.float32
+        self.dtype_policy = _DP()
+
+    def forward(self, dna, organism_index, **kwargs):
+        h = kwargs.get('heads')
+        self.last_heads_seen = h
+        self.heads_history.append(h)
+        # Return shape that center mask scorer can consume (B, S, T) at 128bp
+        # We only need the requested key to exist.
+        B = dna.shape[0]
+        S128 = dna.shape[1] // 128
+        T = 4
+        out: dict = {}
+        # Always return atac so center-mask works in tests that ask for it
+        out['atac'] = {128: torch.zeros(B, S128, T), 1: torch.zeros(B, dna.shape[1], T)}
+        out['rna_seq'] = {128: torch.zeros(B, S128, T), 1: torch.zeros(B, dna.shape[1], T)}
+        out['dnase'] = {128: torch.zeros(B, S128, T), 1: torch.zeros(B, dna.shape[1], T)}
+        out['contact_maps'] = torch.zeros(B, S128, S128, T)
+        return out
+
+
+def _make_model() -> VariantScoringModel:
+    model = _RecordingModel()
+    # Skip device move; feed a tiny tensor through predict directly.
+    sm = VariantScoringModel.__new__(VariantScoringModel)
+    sm.model = model
+    sm.num_organisms = 2
+    sm.organism_map = {'human': 0, 'homo_sapiens': 0, 'mouse': 1, 'mus_musculus': 1}
+    sm.default_organism_index = 0
+    sm.device = torch.device('cpu')
+    sm._fasta_extractor = None
+    sm._gene_annotation = None
+    sm._polya_annotation = None
+    sm._track_metadata = {0: {}, 1: {}}
+    return sm
+
+
+@pytest.mark.unit
+def test_required_heads_default_uses_requested_output():
+    scorer = CenterMaskScorer(OutputType.ATAC, 501, AggregationType.DIFF_LOG2_SUM)
+    assert scorer.required_heads == frozenset({'atac'})
+
+    rna = GeneMaskLFCScorer(OutputType.RNA_SEQ)
+    assert rna.required_heads == frozenset({'rna_seq'})
+
+    contact = ContactMapScorer()
+    assert contact.required_heads == frozenset({'contact_maps'})
+
+
+@pytest.mark.unit
+def test_required_heads_splice_junction_includes_splice_sites():
+    sj = SpliceJunctionScorer()
+    assert sj.required_heads == frozenset({'splice_sites', 'splice_junctions'})
+
+
+@pytest.mark.unit
+def test_required_heads_splicing_scorer_uses_requested_output():
+    s1 = GeneMaskSplicingScorer(OutputType.SPLICE_SITES, width=None)
+    assert s1.required_heads == frozenset({'splice_sites'})
+    s2 = GeneMaskSplicingScorer(OutputType.SPLICE_SITE_USAGE, width=None)
+    assert s2.required_heads == frozenset({'splice_site_usage'})
+
+
+@pytest.mark.unit
+def test_score_variant_forwards_union_of_required_heads(monkeypatch):
+    """When score_variant runs, model.forward must receive heads union."""
+    sm = _make_model()
+
+    # Bypass the FASTA-driven path: monkeypatch predict_variant to call predict()
+    # with the constructed heads kwarg, exactly as the real flow does, but with
+    # a synthetic sequence so we don't need a fasta.
+    seq_len = 256
+
+    def fake_predict_variant(interval, variant, organism=None, to_cpu=False,
+                             unified_splicing=False, heads=None):
+        kwargs = {'return_embeddings': unified_splicing}
+        if heads is not None:
+            kwargs['heads'] = heads
+        seq = torch.zeros(1, seq_len, 4)
+        ref = sm.model(seq, torch.zeros(1, dtype=torch.long), **kwargs)
+        alt = sm.model(seq, torch.zeros(1, dtype=torch.long), **kwargs)
+        return ref, alt
+
+    sm.predict_variant = fake_predict_variant
+
+    interval = Interval('chr1', 0, seq_len)
+    variant = Variant('chr1', 100, 'A', 'C')
+
+    scorers = [
+        CenterMaskScorer(OutputType.ATAC, 501, AggregationType.DIFF_LOG2_SUM),
+        GeneMaskActiveScorer(OutputType.RNA_SEQ),  # needs gene_annotation, but we won't trigger if no scorers => abort early
+    ]
+
+    # GeneMaskActiveScorer requires gene_annotation; supply a stub to satisfy it
+    class _StubAnno:
+        def get_genes_in_interval(self, interval, gene_types=None):
+            return []
+
+    sm._gene_annotation = _StubAnno()
+
+    sm.score_variant(interval, variant, scorers)
+
+    # The model should have been called with heads being the union {atac, rna_seq}
+    assert sm.model.last_heads_seen is not None
+    assert set(sm.model.last_heads_seen) == {'atac', 'rna_seq'}
+
+
+@pytest.mark.unit
+def test_score_variant_subset_only_atac():
+    sm = _make_model()
+    seq_len = 256
+
+    def fake_predict_variant(interval, variant, organism=None, to_cpu=False,
+                             unified_splicing=False, heads=None):
+        kwargs = {'return_embeddings': unified_splicing}
+        if heads is not None:
+            kwargs['heads'] = heads
+        seq = torch.zeros(1, seq_len, 4)
+        ref = sm.model(seq, torch.zeros(1, dtype=torch.long), **kwargs)
+        alt = sm.model(seq, torch.zeros(1, dtype=torch.long), **kwargs)
+        return ref, alt
+
+    sm.predict_variant = fake_predict_variant
+
+    scorers = [CenterMaskScorer(OutputType.ATAC, 501, AggregationType.DIFF_LOG2_SUM)]
+    sm.score_variant(Interval('chr1', 0, seq_len), Variant('chr1', 100, 'A', 'C'), scorers)
+    assert set(sm.model.last_heads_seen) == {'atac'}
+
+
+@pytest.mark.unit
+def test_score_variant_empty_scorers_runs_all_heads():
+    """If no scorers declare requirements, heads is None (run everything)."""
+    sm = _make_model()
+    seq_len = 256
+
+    captured = {}
+
+    def fake_predict_variant(interval, variant, organism=None, to_cpu=False,
+                             unified_splicing=False, heads=None):
+        captured['heads'] = heads
+        # Return minimal outputs (won't be consumed since scorers list is empty)
+        return {}, {}
+
+    sm.predict_variant = fake_predict_variant
+    sm.score_variant(Interval('chr1', 0, seq_len), Variant('chr1', 100, 'A', 'C'), [])
+    assert captured['heads'] is None

--- a/tests/unit/test_score_variant_head_filtering.py
+++ b/tests/unit/test_score_variant_head_filtering.py
@@ -87,9 +87,11 @@ def test_required_heads_default_uses_requested_output():
 
 
 @pytest.mark.unit
-def test_required_heads_splice_junction_includes_splice_sites():
+def test_required_heads_splice_junction_only_splice_sites():
+    # The junction head is recomputed in the unified-splicing second pass, so
+    # the first pass only needs splice_sites to derive unified positions.
     sj = SpliceJunctionScorer()
-    assert sj.required_heads == frozenset({'splice_sites', 'splice_junctions'})
+    assert sj.required_heads == frozenset({'splice_sites'})
 
 
 @pytest.mark.unit
@@ -127,7 +129,7 @@ def test_score_variant_forwards_union_of_required_heads(monkeypatch):
 
     scorers = [
         CenterMaskScorer(OutputType.ATAC, 501, AggregationType.DIFF_LOG2_SUM),
-        GeneMaskActiveScorer(OutputType.RNA_SEQ),  # needs gene_annotation, but we won't trigger if no scorers => abort early
+        GeneMaskActiveScorer(OutputType.RNA_SEQ),  # included so required_heads adds rna_seq; its score() still runs, but the stub annotation below returns no genes so it finishes quickly
     ]
 
     # GeneMaskActiveScorer requires gene_annotation; supply a stub to satisfy it


### PR DESCRIPTION
Port three upstream `alphagenome_research` correctness items into this PyTorch fork:

1. **Performance:** infer the set of model heads needed by the active scorers and skip the rest, instead of running every head on every variant.
   - Upstream commit: [google-deepmind/alphagenome_research@82b061e](https://github.com/google-deepmind/alphagenome_research/commit/82b061ef94fb205042aa825707e4f7a80a4d4a06)

2. **Fix:** splicing scorers (`GeneMaskSplicingScorer`, `SpliceJunctionScorer`) now restrict scoring to genes whose body contains the variant, instead of querying every gene that overlaps the prediction interval.
   - Upstream commit: [google-deepmind/alphagenome_research@bddf51f](https://github.com/google-deepmind/alphagenome_research/commit/bddf51fde8b65cfed2114b52dfc2471c06f1bf58)

3. **Fix:** in the `unified_splicing` flow, ALT 1bp embeddings and splice-site probs are now aligned into REF coordinate space before generating unified positions and re-running the junction head, so indel splice-junction scoring is no longer mis-positioned. SNV path is identity (regression-tested).
   - Upstream commit: [google-deepmind/alphagenome_research@58db264](https://github.com/google-deepmind/alphagenome_research/commit/58db26464d77859442ef0390545f84f35d7ae679)
   - Upstream issue: [google-deepmind/alphagenome_research#18](https://github.com/google-deepmind/alphagenome_research/issues/18)

## Requested-head inference in `score_variant`

The model forward already supports a `heads=...` filter, but `score_variant()` was running every head on every variant. Each scorer now declares its required heads, and `score_variant()` unions them and forwards the union as `heads=tuple(union)` into `predict_variant()` → `predict()`.

```python
# scorers/base.py
@property
def required_heads(self) -> frozenset[str]:
    return frozenset({self.requested_output.value})

# scorers/splicing.py — SpliceJunctionScorer needs splice_sites for unified
# position generation in the first pass, and splice_junctions itself.
@property
def required_heads(self) -> frozenset[str]:
    return frozenset({'splice_sites', 'splice_junctions'})
```

`score_variant()`:

```python
required_heads: set[str] = set()
for s in scorers:
    required_heads.update(s.required_heads)
heads_arg = tuple(sorted(required_heads)) if required_heads else None

ref_outputs, alt_outputs = self.predict_variant(
    interval, variant, organism,
    unified_splicing=unified_splicing,
    heads=heads_arg,
)
```

When `scorers` is empty or no requirements are declared, `heads=None` is forwarded and the model runs all heads (existing behavior).

## Variant-overlapping gene bodies for splicing scorers

Upstream restricts splice-site / junction scoring to genes whose body contains the variant; we previously queried every gene in the prediction interval, which inflated the per-variant work and diverged from upstream scores around gene-rich loci.

New in `GeneAnnotation`:

```python
def get_genes_overlapping_variant(self, variant, gene_types=None):
    pos = variant.start  # 0-based
    return [
        gid for gid, info in self._gene_index.items()
        if info.start <= pos < info.end
        and (gene_types is None or info.gene_type in gene_types)
    ]
```

`GeneMaskSplicingScorer.score()` and `SpliceJunctionScorer.score()` switch from `get_genes_in_interval(interval)` to `get_genes_overlapping_variant(variant)`. `GeneMaskLFCScorer`, `GeneMaskActiveScorer`, and `PolyadenylationScorer` are intentionally untouched — those operate over the full interval by design.

## ALT alignment for splice-junction indels

`align_alternate()` was only called inside the per-track splicing scorers; the `unified_splicing` flow re-ran the junction head on cached ALT embeddings without aligning either the embeddings or the splice-site probs first, so indel junction scores were mis-positioned at the variant locus.

`align_alternate()` was generalized from `(S, T)` to also accept `(B, S, T)` so it works directly on embeddings (NLC `[B, S, C]`) and splice-site probs (`[B, S, T]`) without per-batch unsqueeze/squeeze:

```python
if alt.dim() == 2:
    alt = alt.unsqueeze(0)
    squeeze_back = True
# ... operate on dim=1 ...
```

In `predict_variant()`'s `unified_splicing` branch, before generating unified positions and before the second junction-head pass:

```python
if variant.is_indel:
    ref_len = len(variant.reference_bases)
    alt_len = len(variant.alternate_bases)
    alt_outputs['embeddings_1bp'] = align_alternate(
        alt_outputs['embeddings_1bp'],
        variant.start, ref_len, alt_len, interval.start,
    )
    alt_outputs['splice_sites']['probs'] = align_alternate(
        alt_outputs['splice_sites']['probs'],
        variant.start, ref_len, alt_len, interval.start,
    )
```

For SNVs (`ref_len == alt_len == 1`) this is a no-op — pinned by `test_align_alternate_snv_is_identity_{2d,3d}`.

## Tests

- `tests/unit/test_score_variant_head_filtering.py`
- `tests/unit/test_gene_annotation_overlap.py`
- `tests/unit/test_align_alternate.py`
