### PR TITLE
Smooth and NaN-guard cross_entropy_loss to match upstream fixes

### DIFF
--- a/src/alphagenome_pytorch/losses.py
+++ b/src/alphagenome_pytorch/losses.py
@@ -241,26 +241,36 @@ def cross_entropy_loss(
     eps: float = 1e-7,
 ) -> Tensor:
     """Cross entropy loss on counts.
-    
+
+    Mirrors upstream JAX `cross_entropy_loss` post-fix (see
+    google-deepmind/alphagenome_research@de264f5): adds eps smoothing to
+    targets and predictions, and skips fully-masked reduction axes so they
+    do not propagate NaNs from 0/0 normalization.
+
     Args:
         y_true: Target counts.
         y_pred: Predicted counts.
         mask: Boolean mask.
         axis: Axis for normalization.
-        eps: Small epsilon for numerical stability.
-        
+        eps: Small epsilon used both as smoothing and for numerical stability.
+
     Returns:
         Scalar loss.
     """
-    mask = mask.expand_as(y_true)
+    y_true = y_true.float() + eps
+    y_pred = y_pred.float() + eps
+    mask = mask.expand_as(y_true).bool()
     assert y_true.shape == y_pred.shape == mask.shape
-    
-    y_true = torch.where(mask, y_true.float(), torch.zeros_like(y_true.float()))
-    p_true = y_true / torch.clamp(y_true.sum(dim=axis, keepdim=True), min=eps)
-    
-    masked_pred = torch.where(mask, y_pred, torch.zeros_like(y_pred))
-    log_normalizer = torch.log((masked_pred + eps).sum(dim=axis))
-    log_likelihood = (p_true * torch.log(y_pred + eps)).sum(dim=axis)
-    
-    log_loss = log_normalizer - log_likelihood
-    return _safe_masked_mean(log_loss, mask.any(dim=axis))
+
+    # For axes where every element is masked, set the mask to True so the
+    # per-axis normalization does not divide by zero; we then drop those rows
+    # from the final mean via `axis_mask`.
+    axis_mask = mask.sum(dim=axis, keepdim=True) > 0
+    safe_mask = torch.where(axis_mask, mask, torch.ones_like(mask))
+    safe_mask_f = safe_mask.float()
+
+    p_true = y_true / (y_true * safe_mask_f).sum(dim=axis, keepdim=True)
+    p_pred = y_pred / (y_pred * safe_mask_f).sum(dim=axis, keepdim=True)
+    log_loss = (-p_true * torch.log(p_pred) * safe_mask_f).sum(dim=axis)
+
+    return _safe_masked_mean(log_loss, mask=axis_mask.squeeze(axis))

--- a/tests/unit/test_losses.py
+++ b/tests/unit/test_losses.py
@@ -344,6 +344,97 @@ class TestCrossEntropyLoss:
 
 
 @pytest.mark.unit
+class TestCrossEntropyLossSmoothingFix:
+    """Tests for cross_entropy_loss post-smoothing (B3.4 / upstream de264f5).
+
+    Golden values produced by running the upstream JAX `cross_entropy_loss`
+    on the same inputs (see plan handover for generation script).
+    """
+
+    # Inputs reused across cases.
+    Y_TRUE = torch.tensor([[[1.0, 2.0, 3.0, 4.0],
+                            [0.5, 1.5, 2.5, 3.5]]])
+    Y_PRED = torch.tensor([[[1.5, 2.5, 0.5, 3.0],
+                            [0.8, 1.0, 2.0, 4.0]]])
+
+    def test_jax_parity_full_mask(self):
+        mask = torch.ones((1, 2, 4), dtype=torch.bool)
+        loss = losses.cross_entropy_loss(
+            y_true=self.Y_TRUE, y_pred=self.Y_PRED, mask=mask, axis=-1,
+        )
+        assert torch.isclose(loss, torch.tensor(1.402277946472168), atol=1e-6)
+
+    def test_jax_parity_partial_mask(self):
+        mask = torch.tensor([[[True, True, False, True],
+                              [True, False, True, True]]])
+        loss = losses.cross_entropy_loss(
+            y_true=self.Y_TRUE, y_pred=self.Y_PRED, mask=mask, axis=-1,
+        )
+        assert torch.isclose(loss, torch.tensor(0.9597185850143433), atol=1e-6)
+
+    def test_jax_parity_row_fully_masked(self):
+        """One reduction row entirely masked — must be finite (was NaN before fix)."""
+        mask = torch.tensor([[[True, True, True, True],
+                              [False, False, False, False]]])
+        loss = losses.cross_entropy_loss(
+            y_true=self.Y_TRUE, y_pred=self.Y_PRED, mask=mask, axis=-1,
+        )
+        assert torch.isfinite(loss)
+        assert torch.isclose(loss, torch.tensor(1.5595977306365967), atol=1e-6)
+
+    def test_jax_parity_axis_minus_two(self):
+        y_true = torch.tensor([[[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]])
+        y_pred = torch.tensor([[[1.2, 1.8], [2.8, 4.2], [4.5, 6.5]]])
+        mask = torch.ones((1, 3, 2), dtype=torch.bool)
+        loss = losses.cross_entropy_loss(
+            y_true=y_true, y_pred=y_pred, mask=mask, axis=-2,
+        )
+        assert torch.isclose(loss, torch.tensor(0.9772524237632751), atol=1e-6)
+
+    def test_zero_counts_smoothed(self):
+        """All-zero counts: loss equals entropy of the smoothed uniform distribution.
+
+        With y_true = y_pred = 0 and eps = 1e-7, after smoothing the per-axis
+        distribution is uniform over the axis size (here 3), so the loss is
+        log(3) ≈ 1.0986123. Crucially, no inf from log(0).
+        """
+        y = torch.zeros((1, 2, 3))
+        mask = torch.ones((1, 2, 3), dtype=torch.bool)
+        loss = losses.cross_entropy_loss(
+            y_true=y, y_pred=y, mask=mask, axis=-1,
+        )
+        assert torch.isfinite(loss)
+        assert torch.isclose(loss, torch.tensor(1.0986123085021973), atol=1e-6)
+
+    def test_smoothing_gradient_finite(self):
+        """Zero-count predictions must yield finite gradient (no log(0))."""
+        y_true = torch.zeros((1, 2, 3))
+        y_pred = torch.zeros((1, 2, 3), requires_grad=True)
+        mask = torch.ones((1, 2, 3), dtype=torch.bool)
+        loss = losses.cross_entropy_loss(
+            y_true=y_true, y_pred=y_pred, mask=mask, axis=-1,
+        )
+        loss.backward()
+        assert y_pred.grad is not None
+        assert torch.all(torch.isfinite(y_pred.grad))
+
+    def test_perfect_prediction_closed_form(self):
+        """y_pred == y_true (uniform mask) reduces to entropy of smoothed distribution.
+
+        For y_true = y_pred = [1, 2, 3, 4] with eps = 1e-7 (negligible),
+        p = [0.1, 0.2, 0.3, 0.4]. Loss = -sum p log p ≈ 1.279854.
+        """
+        y = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+        mask = torch.ones((1, 4), dtype=torch.bool)
+        loss = losses.cross_entropy_loss(
+            y_true=y, y_pred=y, mask=mask, axis=-1,
+        )
+        p = torch.tensor([0.1, 0.2, 0.3, 0.4])
+        expected = (-p * torch.log(p)).sum()
+        assert torch.isclose(loss, expected, atol=1e-5)
+
+
+@pytest.mark.unit
 class TestExtremeValues:
     """Tests for numerical stability with extreme inputs."""
 

--- a/tests/unit/test_losses.py
+++ b/tests/unit/test_losses.py
@@ -347,8 +347,8 @@ class TestCrossEntropyLoss:
 class TestCrossEntropyLossSmoothingFix:
     """Tests for cross_entropy_loss post-smoothing (B3.4 / upstream de264f5).
 
-    Golden values produced by running the upstream JAX `cross_entropy_loss`
-    on the same inputs (see plan handover for generation script).
+    Golden values produced by running the upstream JAX
+    `cross_entropy_loss` on the same inputs
     """
 
     # Inputs reused across cases.


### PR DESCRIPTION
Port an upstream change to `cross_entropy_loss`.

**Fix:** `cross_entropy_loss` now adds eps-smoothing to both targets and predictions and skips fully-masked reduction axes via an axis-mask, so the per-axis normalization no longer divides by zero and zero-count rows no longer collapse to `log(eps · N)`.
- Upstream commit: [google-deepmind/alphagenome_research@de264f5](https://github.com/google-deepmind/alphagenome_research/commit/de264f5f151b934c82f661e510b2409b84a40149)
- Upstream issue: [google-deepmind/alphagenome_research#24](https://github.com/google-deepmind/alphagenome_research/issues/24)

Potential issues before:

1. No smoothing on `y_true` / `y_pred`.
2. NaN propagation when an entire reduction axis was fully masked.
3. Asymmetric zero-then-sum normalization that produces strongly negative loss values for all-zero rows.

The fix mirrors upstream:

```python
- mask = mask.expand_as(y_true)
- y_true = torch.where(mask, y_true.float(), 0)
- p_true = y_true / torch.clamp(y_true.sum(dim=axis, keepdim=True), min=eps)
- masked_pred = torch.where(mask, y_pred, 0)
- log_normalizer = torch.log((masked_pred + eps).sum(dim=axis))
- log_likelihood = (p_true * torch.log(y_pred + eps)).sum(dim=axis)
- log_loss = log_normalizer - log_likelihood
- return _safe_masked_mean(log_loss, mask.any(dim=axis))
+ y_true = y_true.float() + eps
+ y_pred = y_pred.float() + eps
+ mask = mask.expand_as(y_true).bool()
+
+ axis_mask = mask.sum(dim=axis, keepdim=True) > 0
+ safe_mask = torch.where(axis_mask, mask, torch.ones_like(mask))
+ safe_mask_f = safe_mask.float()
+
+ p_true = y_true / (y_true * safe_mask_f).sum(dim=axis, keepdim=True)
+ p_pred = y_pred / (y_pred * safe_mask_f).sum(dim=axis, keepdim=True)
+ log_loss = (-p_true * torch.log(p_pred) * safe_mask_f).sum(dim=axis)
+ return _safe_masked_mean(log_loss, mask=axis_mask.squeeze(axis))
```

As a result, loss curves for assays with many zero positions will shift upward; do not compare absolute loss values across the boundary.