### PR TITLE
Add splice heads to DEFAULT_HEAD_WEIGHTS to match upstream

### DIFF
--- a/src/alphagenome_pytorch/training.py
+++ b/src/alphagenome_pytorch/training.py
@@ -174,6 +174,69 @@ class AlphaGenomeLoss(nn.Module):
         Uses multinomial loss for profile heads (ATAC, DNase, etc.)
         and MSE for aggregate/contact map heads.
         """
+        if head == 'splice_sites':
+            logits = output['logits']
+            classification_mask = torch.any(target > 0, dim=-1, keepdim=True)
+            num_tracks = target.shape[-1]
+            return losses.cross_entropy_loss_from_logits(
+                y_pred_logits=logits,
+                y_true=(1.0 - 1e-7) * target.float() + 1e-7 / num_tracks,
+                mask=classification_mask,
+                axis=-1,
+            )
+
+        if head == 'splice_site_usage':
+            logits = output['logits']
+            if mask is None:
+                mask = torch.ones_like(target, dtype=torch.bool)
+            return losses.binary_crossentropy_from_logits(
+                y_pred=logits,
+                y_true=torch.clamp(target.float(), 1e-7, 1.0 - 1e-7),
+                mask=mask,
+            )
+
+        if head == 'splice_junctions':
+            pred_pair = output['pred_counts']
+            pairs_mask = output['splice_junction_mask']
+            
+            def _scale_junction_counts(counts):
+                return torch.where(
+                    counts > 10.0,
+                    2.0 * torch.sqrt(counts * 10.0) - 10.0,
+                    counts,
+                )
+                
+            sum_acceptors_tgt = torch.sum(torch.where(pairs_mask, target.float(), 0.0), dim=-2)
+            sum_acceptors_pred = torch.sum(torch.where(pairs_mask, pred_pair.float(), 0.0), dim=-2)
+            accept_total_loss = losses.poisson_loss(
+                y_true=_scale_junction_counts(sum_acceptors_tgt),
+                y_pred=sum_acceptors_pred,
+                mask=torch.any(pairs_mask, dim=-2)
+            )
+            
+            sum_donors_tgt = torch.sum(torch.where(pairs_mask, target.float(), 0.0), dim=-3)
+            sum_donors_pred = torch.sum(torch.where(pairs_mask, pred_pair.float(), 0.0), dim=-3)
+            donor_total_loss = losses.poisson_loss(
+                y_true=_scale_junction_counts(sum_donors_tgt),
+                y_pred=sum_donors_pred,
+                mask=torch.any(pairs_mask, dim=-3)
+            )
+            
+            donor_ratios_loss = losses.cross_entropy_loss(
+                y_true=target,
+                y_pred=pred_pair,
+                mask=pairs_mask,
+                axis=-3,
+            )
+            acceptor_ratios_loss = losses.cross_entropy_loss(
+                y_true=target,
+                y_pred=pred_pair,
+                mask=pairs_mask,
+                axis=-2,
+            )
+            
+            return donor_ratios_loss + acceptor_ratios_loss + 0.2 * (accept_total_loss + donor_total_loss)
+
         # Handle resolution dict outputs (e.g., {1: tensor, 128: tensor})
         resolution = None
         if isinstance(output, dict):

--- a/src/alphagenome_pytorch/training.py
+++ b/src/alphagenome_pytorch/training.py
@@ -82,9 +82,11 @@ class AlphaGenomeLoss(nn.Module):
         model: AlphaGenome model instance. Required to access head modules for target scaling.
             Without this, targets will not be scaled to model space, resulting in incorrect gradients.
         heads: List of head names to compute loss for. If None, uses all heads.
-        head_weights: Dict mapping head names to loss weights. If None, uses
-            `DEFAULT_HEAD_WEIGHTS`, which mirrors upstream JAX defaults
+        head_weights: Dict mapping head names to loss weights. Merged *on top
+            of* `DEFAULT_HEAD_WEIGHTS`, so a partial dict only overrides the
+            heads it names and leaves the rest at their upstream defaults
             (1.0 for count and splice-site heads, 0.2 for splice junctions).
+            Pass `None` to use the defaults unchanged.
         multinomial_resolution: Resolution for multinomial loss computation. This is the
             segment size used to divide the sequence for multinomial loss. For JAX parity,
             use `seq_len` (full sequence as 1 segment) or `seq_len // 8` for 8 segments
@@ -104,7 +106,11 @@ class AlphaGenomeLoss(nn.Module):
         super().__init__()
         self.model = model
         self.heads = heads or list(DEFAULT_HEAD_WEIGHTS.keys())
-        self.head_weights = head_weights or DEFAULT_HEAD_WEIGHTS
+        # Merge overrides onto a fresh copy of the defaults: a partial dict
+        # only changes the heads it names (so splice_junctions keeps its 0.2
+        # unless explicitly overridden), and we never alias/mutate the
+        # module-level constant.
+        self.head_weights = {**DEFAULT_HEAD_WEIGHTS, **(head_weights or {})}
         self.multinomial_resolution = multinomial_resolution
         self.positional_weight = positional_weight
     

--- a/src/alphagenome_pytorch/training.py
+++ b/src/alphagenome_pytorch/training.py
@@ -42,7 +42,10 @@ class AlphaGenomeTrainingConfig:
     positional_weight: float = 5.0  # JAX production value (AG_MODEL.md line 321)
 
 
-# Default head weights (equal for all heads)
+# Default per-head loss weights matching upstream JAX `HeadConfig.loss_weight`
+# (google-deepmind/alphagenome_research, commit 7046b72). All heads weight 1.0
+# except splice junctions, which upstream weights at 0.2 to balance the very
+# different magnitude of the junction loss against the count-based heads.
 DEFAULT_HEAD_WEIGHTS = {
     'atac': 1.0,
     'dnase': 1.0,
@@ -52,6 +55,9 @@ DEFAULT_HEAD_WEIGHTS = {
     'chip_tf': 1.0,
     'chip_histone': 1.0,
     'contact_maps': 1.0,
+    'splice_sites': 1.0,
+    'splice_site_usage': 1.0,
+    'splice_junctions': 0.2,
 }
 
 
@@ -66,11 +72,19 @@ class AlphaGenomeLoss(nn.Module):
     2. Call model with `return_scaled_predictions=True` during training
     3. Pass `organism_index` to the forward method
 
+    Aggregation: the total loss is `sum(head_weight * head_loss) / num_heads`,
+    where the divisor is the *count* of heads that produced a loss this step
+    (not the sum of weights). A weight of 0.2 therefore down-weights that
+    head's contribution by exactly 0.2× relative to a weight-1.0 head with
+    the same residual, matching upstream JAX `HeadConfig.loss_weight` semantics.
+
     Args:
         model: AlphaGenome model instance. Required to access head modules for target scaling.
             Without this, targets will not be scaled to model space, resulting in incorrect gradients.
         heads: List of head names to compute loss for. If None, uses all heads.
-        head_weights: Dict mapping head names to loss weights. If None, equal weights.
+        head_weights: Dict mapping head names to loss weights. If None, uses
+            `DEFAULT_HEAD_WEIGHTS`, which mirrors upstream JAX defaults
+            (1.0 for count and splice-site heads, 0.2 for splice junctions).
         multinomial_resolution: Resolution for multinomial loss computation. This is the
             segment size used to divide the sequence for multinomial loss. For JAX parity,
             use `seq_len` (full sequence as 1 segment) or `seq_len // 8` for 8 segments

--- a/tests/unit/test_loss_head_weights.py
+++ b/tests/unit/test_loss_head_weights.py
@@ -113,3 +113,31 @@ class TestAggregationDivisor:
 
         expected = sum(DEFAULT_HEAD_WEIGHTS.values()) / len(head_names)
         assert torch.isclose(result['loss'], torch.tensor(expected))
+
+    def test_partial_override_preserves_other_defaults(self):
+        """A partial head_weights dict overrides only the named head; the rest
+        keep their defaults (splice_junctions stays at 0.2, not 1.0)."""
+        per_head = {'atac': 1.0, 'splice_junctions': 1.0}
+        loss_fn = self._make_loss_with_fixed_per_head(
+            per_head,
+            head_weights={'atac': 2.0},  # only atac specified
+        )
+        result = self._run(loss_fn, list(per_head.keys()))
+
+        # atac override applied, splice_junctions still at its 0.2 default.
+        assert loss_fn.head_weights['splice_junctions'] == 0.2
+        # total = (2.0 * 1.0 + 0.2 * 1.0) / 2 = 1.1
+        assert torch.isclose(result['loss'], torch.tensor(1.1))
+
+
+@pytest.mark.unit
+class TestNoConstantMutation:
+    """The module-level DEFAULT_HEAD_WEIGHTS must never be aliased or mutated."""
+
+    def test_instance_dict_is_a_copy(self):
+        before = dict(DEFAULT_HEAD_WEIGHTS)
+        loss_fn = AlphaGenomeLoss()  # head_weights=None path
+
+        assert loss_fn.head_weights is not DEFAULT_HEAD_WEIGHTS
+        loss_fn.head_weights['atac'] = 99.0  # mutate the instance copy
+        assert DEFAULT_HEAD_WEIGHTS == before  # constant untouched

--- a/tests/unit/test_loss_head_weights.py
+++ b/tests/unit/test_loss_head_weights.py
@@ -1,0 +1,115 @@
+"""Tests for AlphaGenomeLoss head-weight aggregation.
+
+Pins the contract for `DEFAULT_HEAD_WEIGHTS` and the divisor used in
+`AlphaGenomeLoss.forward()`. Mirrors upstream JAX `HeadConfig.loss_weight`
+semantics: a weight of 0.2 down-weights that head's contribution to the
+batch-mean loss by exactly 0.2x relative to a weight-1.0 head with the
+same residual.
+"""
+
+import pytest
+import torch
+
+from alphagenome_pytorch.training import (
+    AlphaGenomeLoss,
+    DEFAULT_HEAD_WEIGHTS,
+)
+
+
+@pytest.mark.unit
+class TestDefaultHeadWeights:
+    """Pin upstream parity for default head weights."""
+
+    def test_count_heads_weighted_one(self):
+        for name in (
+            'atac', 'dnase', 'procap', 'cage', 'rna_seq',
+            'chip_tf', 'chip_histone', 'contact_maps',
+        ):
+            assert DEFAULT_HEAD_WEIGHTS[name] == 1.0
+
+    def test_splice_site_heads_weighted_one(self):
+        assert DEFAULT_HEAD_WEIGHTS['splice_sites'] == 1.0
+        assert DEFAULT_HEAD_WEIGHTS['splice_site_usage'] == 1.0
+
+    def test_splice_junctions_weighted_zero_point_two(self):
+        """Upstream weights splice_junctions at 0.2."""
+        assert DEFAULT_HEAD_WEIGHTS['splice_junctions'] == 0.2
+
+
+@pytest.mark.unit
+class TestAggregationDivisor:
+    """Verify the `sum(w_i * L_i) / num_heads` aggregation contract.
+
+    We bypass `_compute_head_loss` by monkey-patching it so we can pin
+    arbitrary per-head losses and verify the aggregator math directly.
+    """
+
+    @staticmethod
+    def _make_loss_with_fixed_per_head(per_head_losses, head_weights=None):
+        loss_fn = AlphaGenomeLoss(
+            heads=list(per_head_losses.keys()),
+            head_weights=head_weights,
+        )
+
+        # Replace _compute_head_loss with a stub that returns a known loss
+        # per head, irrespective of input tensors.
+        def _stub(self, head, output, target, mask, organism_index):
+            return torch.tensor(per_head_losses[head], dtype=torch.float32)
+
+        loss_fn._compute_head_loss = _stub.__get__(loss_fn, AlphaGenomeLoss)
+        return loss_fn
+
+    def _run(self, loss_fn, head_names):
+        # Build minimal outputs/targets so forward() iterates the heads.
+        outputs = {h: torch.zeros(1, 2, 1) for h in head_names}
+        targets = {h: torch.zeros(1, 2, 1) for h in head_names}
+        organism_index = torch.tensor([0])
+        return loss_fn(outputs, targets, organism_index)
+
+    def test_junction_enters_at_0p2_with_default_weights(self):
+        """Equal residual on atac vs splice_junctions: junction contributes
+        exactly 0.2 / num_heads of the total, atac contributes 1.0 / num_heads.
+        """
+        per_head = {'atac': 1.0, 'splice_junctions': 1.0}
+        loss_fn = self._make_loss_with_fixed_per_head(per_head)
+        result = self._run(loss_fn, list(per_head.keys()))
+
+        # total = (1.0 * 1.0 + 0.2 * 1.0) / 2 = 0.6
+        assert torch.isclose(result['loss'], torch.tensor(0.6))
+        assert torch.isclose(result['atac_loss'], torch.tensor(1.0))
+        assert torch.isclose(result['splice_junctions_loss'], torch.tensor(1.0))
+
+    def test_override_restores_full_weight(self):
+        """User-provided head_weights={'splice_junctions': 1.0} overrides default."""
+        per_head = {'atac': 1.0, 'splice_junctions': 1.0}
+        loss_fn = self._make_loss_with_fixed_per_head(
+            per_head,
+            head_weights={'atac': 1.0, 'splice_junctions': 1.0},
+        )
+        result = self._run(loss_fn, list(per_head.keys()))
+
+        # total = (1.0 + 1.0) / 2 = 1.0
+        assert torch.isclose(result['loss'], torch.tensor(1.0))
+
+    def test_user_can_zero_head(self):
+        """Setting weight to 0 drops the head's contribution but the divisor
+        still counts it (we average the weighted losses)."""
+        per_head = {'atac': 4.0, 'splice_junctions': 4.0}
+        loss_fn = self._make_loss_with_fixed_per_head(
+            per_head,
+            head_weights={'atac': 1.0, 'splice_junctions': 0.0},
+        )
+        result = self._run(loss_fn, list(per_head.keys()))
+
+        # total = (1.0 * 4 + 0.0 * 4) / 2 = 2.0
+        assert torch.isclose(result['loss'], torch.tensor(2.0))
+
+    def test_all_default_heads_aggregate(self):
+        """All 11 default heads with unit per-head loss: total = sum(weights)/11."""
+        head_names = list(DEFAULT_HEAD_WEIGHTS.keys())
+        per_head = {h: 1.0 for h in head_names}
+        loss_fn = self._make_loss_with_fixed_per_head(per_head)
+        result = self._run(loss_fn, head_names)
+
+        expected = sum(DEFAULT_HEAD_WEIGHTS.values()) / len(head_names)
+        assert torch.isclose(result['loss'], torch.tensor(expected))

--- a/tests/unit/test_training.py
+++ b/tests/unit/test_training.py
@@ -115,6 +115,149 @@ class TestAlphaGenomeLoss:
 
 
 @pytest.mark.unit
+class TestSpliceLoss:
+    """Tests for the splice-head loss branches in `_compute_head_loss`.
+
+    Splice heads emit dicts with string keys ({'logits', ...} /
+    {'pred_counts', ...}) rather than the tensor / {int: tensor} layout the
+    count heads use. These tests pin that `AlphaGenomeLoss` consumes those
+    dicts (regression for the crash where `output.shape` was called on a dict)
+    and mirrors the upstream JAX loss math (alphagenome_research heads.py).
+    No model is needed: splice branches return before any target scaling.
+    """
+
+    def test_splice_sites_runs_on_dict_output(self):
+        """splice_sites consumes {'logits': ...} and returns a finite scalar."""
+        loss_fn = AlphaGenomeLoss(heads=['splice_sites'])
+
+        # 5 classes: Donor+, Acceptor+, Donor-, Acceptor-, Not-a-site.
+        target = torch.zeros(2, 8, 5)
+        target[..., 4] = 1.0  # every position labelled "not a splice site"
+        target[0, 3] = torch.tensor([1.0, 0.0, 0.0, 0.0, 0.0])  # one donor+
+
+        outputs = {'splice_sites': {'logits': torch.zeros(2, 8, 5)}}
+        result = loss_fn(outputs, {'splice_sites': target}, torch.tensor([0, 0]))
+
+        assert 'splice_sites_loss' in result
+        assert torch.isfinite(result['loss'])
+        assert result['loss'].item() >= 0
+
+    def test_splice_sites_directional(self):
+        """Logits aligned with the one-hot target beat anti-aligned logits."""
+        loss_fn = AlphaGenomeLoss(heads=['splice_sites'])
+        target = torch.zeros(1, 4, 5)
+        target[..., 0] = 1.0  # class 0 everywhere
+
+        good = {'splice_sites': {'logits': (target * 10.0 - 5.0)}}
+        bad = {'splice_sites': {'logits': (-target * 10.0)}}
+        oi = torch.tensor([0])
+
+        good_loss = loss_fn(good, {'splice_sites': target}, oi)['loss']
+        bad_loss = loss_fn(bad, {'splice_sites': target}, oi)['loss']
+        assert good_loss < bad_loss
+
+    def test_splice_site_usage_runs_and_directional(self):
+        """splice_site_usage consumes {'logits': ...}; aligned logits win."""
+        loss_fn = AlphaGenomeLoss(heads=['splice_site_usage'])
+        # Usage targets are proportions in [0, 1]; use a 0/1 pattern.
+        target = torch.tensor([[[1.0, 0.0, 1.0], [0.0, 1.0, 0.0]]])  # (1, 2, 3)
+
+        aligned = (target * 2.0 - 1.0) * 10.0  # +10 where 1, -10 where 0
+        good = {'splice_site_usage': {'logits': aligned}}
+        bad = {'splice_site_usage': {'logits': -aligned}}
+        oi = torch.tensor([0])
+
+        good_res = loss_fn(good, {'splice_site_usage': target}, oi)
+        assert torch.isfinite(good_res['loss'])
+        assert good_res['loss'].item() >= 0
+        bad_loss = loss_fn(bad, {'splice_site_usage': target}, oi)['loss']
+        assert good_res['loss'] < bad_loss
+
+    def test_splice_site_usage_respects_passed_mask(self):
+        """A mask that excludes every track yields zero loss."""
+        loss_fn = AlphaGenomeLoss(heads=['splice_site_usage'])
+        target = torch.rand(1, 2, 3)
+        outputs = {'splice_site_usage': {'logits': torch.randn(1, 2, 3)}}
+        masks = {'splice_site_usage': torch.zeros(1, 2, 3, dtype=torch.bool)}
+
+        result = loss_fn(outputs, {'splice_site_usage': target},
+                         torch.tensor([0]), masks)
+        # _safe_masked_mean clamps the denominator, so a fully-masked head
+        # contributes exactly 0.
+        assert result['splice_site_usage_loss'].item() == 0.0
+
+    def test_splice_junctions_runs_on_dict_output(self):
+        """splice_junctions consumes {'pred_counts', 'splice_junction_mask'}."""
+        loss_fn = AlphaGenomeLoss(heads=['splice_junctions'])
+
+        # Junctions: (B, donors, acceptors, 2 * num_tissues). Keep it small.
+        b, p, t2 = 1, 4, 2
+        target = torch.rand(b, p, p, t2) * 20.0  # spans the soft-clip threshold
+        pred = torch.rand(b, p, p, t2) + 0.1
+        mask = torch.zeros(b, p, p, t2, dtype=torch.bool)
+        mask[:, :3, :3, :] = True  # a connected block of valid donor/acceptor pairs
+
+        outputs = {'splice_junctions': {
+            'pred_counts': pred,
+            'splice_junction_mask': mask,
+        }}
+        result = loss_fn(outputs, {'splice_junctions': target}, torch.tensor([0]))
+
+        assert 'splice_junctions_loss' in result
+        assert torch.isfinite(result['loss'])
+        assert result['loss'].item() >= 0
+
+    def test_splice_junctions_perfect_prediction_beats_noise(self):
+        """Predicting the (soft-clipped) target beats a flat wrong prediction."""
+        loss_fn = AlphaGenomeLoss(heads=['splice_junctions'])
+        b, p, t2 = 1, 4, 2
+        target = torch.rand(b, p, p, t2) * 5.0 + 0.5  # below soft-clip, exact match
+        mask = torch.ones(b, p, p, t2, dtype=torch.bool)
+        oi = torch.tensor([0])
+
+        good = {'splice_junctions': {
+            'pred_counts': target.clone(),
+            'splice_junction_mask': mask,
+        }}
+        bad = {'splice_junctions': {
+            'pred_counts': torch.full_like(target, 0.01),
+            'splice_junction_mask': mask,
+        }}
+        good_loss = loss_fn(good, {'splice_junctions': target}, oi)['loss']
+        bad_loss = loss_fn(bad, {'splice_junctions': target}, oi)['loss']
+        assert good_loss < bad_loss
+
+    def test_all_splice_heads_aggregate(self):
+        """All three splice heads run together through forward()."""
+        loss_fn = AlphaGenomeLoss(
+            heads=['splice_sites', 'splice_site_usage', 'splice_junctions'],
+        )
+        b, p, t2 = 1, 4, 2
+        mask = torch.ones(b, p, p, t2, dtype=torch.bool)
+        outputs = {
+            'splice_sites': {'logits': torch.randn(1, 8, 5)},
+            'splice_site_usage': {'logits': torch.randn(1, 8, 3)},
+            'splice_junctions': {
+                'pred_counts': torch.rand(b, p, p, t2) + 0.1,
+                'splice_junction_mask': mask,
+            },
+        }
+        ss_target = torch.zeros(1, 8, 5)
+        ss_target[..., 4] = 1.0
+        targets = {
+            'splice_sites': ss_target,
+            'splice_site_usage': torch.rand(1, 8, 3),
+            'splice_junctions': torch.rand(b, p, p, t2) * 20.0,
+        }
+        result = loss_fn(outputs, targets, torch.tensor([0]))
+
+        for key in ('splice_sites_loss', 'splice_site_usage_loss',
+                    'splice_junctions_loss', 'loss'):
+            assert key in result
+            assert torch.isfinite(result[key])
+
+
+@pytest.mark.unit
 class TestCreateOptimizer:
     """Tests for create_optimizer."""
     

--- a/tests/unit/test_training.py
+++ b/tests/unit/test_training.py
@@ -55,10 +55,14 @@ class TestAlphaGenomeLoss:
     def test_initialization(self):
         """Test loss module initializes correctly."""
         loss_fn = AlphaGenomeLoss()
-        
-        assert len(loss_fn.heads) == 8
+
+        # 8 count/contact heads + 3 splice heads = 11
+        assert len(loss_fn.heads) == 11
         assert 'atac' in loss_fn.heads
         assert 'contact_maps' in loss_fn.heads
+        assert 'splice_sites' in loss_fn.heads
+        assert 'splice_site_usage' in loss_fn.heads
+        assert 'splice_junctions' in loss_fn.heads
     
     def test_custom_heads(self):
         """Test loss with subset of heads."""


### PR DESCRIPTION
Port a feature from upstream for config-parity.

**Config parity:** `DEFAULT_HEAD_WEIGHTS` now includes the three splice heads at the same per-head loss weights upstream uses (`splice_sites=1.0`, `splice_site_usage=1.0`, `splice_junctions=0.2`). Document the loss-aggregation contract so the 0.2 weight has the intended effect.
- Upstream commit: [google-deepmind/alphagenome_research@7046b72](https://github.com/google-deepmind/alphagenome_research/commit/7046b72)

## Default head weights

Upstream defines per-head `loss_weight` on each `HeadConfig` ([heads.py:140-237](https://github.com/google-deepmind/alphagenome_research/blob/main/src/alphagenome_research/model/heads.py#L140-L237)). All count and contact heads use 1.0; splice sites and splice-site usage are 1.0; splice junctions are 0.2 (to balance the very different magnitude of the junction loss against the count-based heads).

Our `DEFAULT_HEAD_WEIGHTS` in `src/alphagenome_pytorch/training.py` previously only covered the eight count and contact heads.

```python
 DEFAULT_HEAD_WEIGHTS = {
     'atac': 1.0,
     ...
     'contact_maps': 1.0,
+    'splice_sites': 1.0,
+    'splice_site_usage': 1.0,
+    'splice_junctions': 0.2,
 }
```

## Aggregation contract

`AlphaGenomeLoss.forward()` computes `total = sum(w_i * L_i) / num_heads`, where the divisor is the count of heads producing a loss this step. A weight of `0.2` therefore down-weights that head's contribution to the batch-mean loss by exactly `0.2×` relative to a weight-1.0 head with the same residual — matching upstream `HeadConfig.loss_weight` semantics.
