### PR TITLE
Add optional strand-pair averaging to compute_track_means

### DIFF
--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -244,6 +244,11 @@ def _normalize_strand_pairs(
             )
     else:
         parser.error(f"strand_pairs for '{modality}' has unsupported type: {type(raw)}")
+    if not pairs:
+        parser.error(
+            f"strand_pairs for '{modality}' is empty; specify 'auto' or at least "
+            f"one 'plus,minus' pair, or omit it entirely to keep per-track means"
+        )
     for pair in pairs:
         if len(pair) != 2:
             parser.error(

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -200,6 +200,79 @@ def unwrap_training_model(model: nn.Module) -> nn.Module:
 # =============================================================================
 
 
+def _normalize_strand_pairs(
+    raw: object,
+    n_bigwigs: int,
+    modality: str,
+    parser: argparse.ArgumentParser,
+) -> list[tuple[int, int]] | None:
+    """Normalize a strand-pair spec into [(plus_idx, minus_idx), ...].
+
+    Accepts three forms (indices are 0-based into that modality's bigwig list):
+      - 'auto'            : pair consecutive bigwigs (0,1),(2,3),... (needs even count)
+      - 'p,m;p,m;...'     : CLI string of explicit pairs
+      - [[p, m], ...]     : config list-of-lists of explicit pairs
+
+    Index validity (bounds, distinctness, no reuse) is enforced downstream by
+    compute_track_means; this only handles syntax and the 'auto' expansion.
+    """
+    if raw is None:
+        return None
+    if raw == "auto":
+        if n_bigwigs % 2 != 0:
+            parser.error(
+                f"strand_pairs 'auto' for '{modality}' needs an even number of "
+                f"bigwigs; got {n_bigwigs}"
+            )
+        return [(i, i + 1) for i in range(0, n_bigwigs, 2)]
+    if isinstance(raw, str):
+        chunks = [c for c in (s.strip() for s in raw.split(";")) if c]
+        try:
+            pairs = [tuple(int(x) for x in c.split(",")) for c in chunks]
+        except ValueError:
+            parser.error(
+                f"strand_pairs for '{modality}' must be 'plus,minus' pairs; "
+                f"got {raw!r}"
+            )
+    elif isinstance(raw, (list, tuple)):
+        try:
+            pairs = [tuple(int(x) for x in pair) for pair in raw]
+        except (TypeError, ValueError):
+            parser.error(
+                f"strand_pairs for '{modality}' must be a list of [plus, minus] "
+                f"pairs; got {raw!r}"
+            )
+    else:
+        parser.error(f"strand_pairs for '{modality}' has unsupported type: {type(raw)}")
+    for pair in pairs:
+        if len(pair) != 2:
+            parser.error(
+                f"strand_pairs for '{modality}' must contain exactly two indices "
+                f"per pair; got {pair!r}"
+            )
+    return pairs
+
+
+def _parse_cli_strand_pairs(
+    spec: str | None,
+    modalities: list[str],
+    parser: argparse.ArgumentParser,
+) -> dict[str, str]:
+    """Parse '--strand-pairs' into {modality: raw_pairs_string} (unnormalized)."""
+    result: dict[str, str] = {}
+    if not spec:
+        return result
+    for entry in spec.split():
+        if ":" not in entry:
+            parser.error(f"--strand-pairs entry must be 'modality:pairs'; got {entry!r}")
+        modality, pairs_str = entry.split(":", 1)
+        modality = modality.strip()
+        if modality not in modalities:
+            parser.error(f"Unknown modality in --strand-pairs: {modality!r}")
+        result[modality] = pairs_str.strip()
+    return result
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
@@ -267,6 +340,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         type=int,
         default=16,
         help="Max threads for parallel BigWig I/O (default: 16)",
+    )
+    data.add_argument(
+        "--strand-pairs",
+        type=str,
+        default=None,
+        help=(
+            "Average +/- strand track means so paired strands share a scaling "
+            "factor (recommended for stranded RNA-seq/CAGE/PRO-cap). Format: "
+            "space-separated 'modality:pairs', where pairs is either 'auto' "
+            "(pair consecutive bigwigs: (0,1),(2,3),...) or semicolon-separated "
+            "'plus,minus' index pairs. Examples: --strand-pairs 'rna_seq:auto' "
+            "or --strand-pairs 'rna_seq:0,1;2,3 cage:0,1'. Indices are 0-based "
+            "into that modality's --bigwig list. Overrides per-modality "
+            "'strand_pairs' from --config."
+        ),
     )
 
     # Model arguments
@@ -576,6 +664,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             )
         if "task_weight" in mod_cfg and mod_cfg["task_weight"] is not None:
             spec["task_weight"] = float(mod_cfg["task_weight"])
+        if "strand_pairs" in mod_cfg and mod_cfg["strand_pairs"] is not None:
+            spec["strand_pairs"] = mod_cfg["strand_pairs"]
         modality_specs[modality] = spec
 
     cli_modality_to_bigwigs: dict[str, list[str]] = {}
@@ -616,9 +706,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         if not value:
             parser.error(f"{flag} is required (or provide it in --config)")
 
+    cli_strand_pairs = _parse_cli_strand_pairs(args.strand_pairs, args.modalities, parser)
+
     args.modality_to_bigwigs = {}
     args.modality_resolutions = {}
     args.modality_weight_dict = {}
+    args.modality_strand_pairs = {}
     for modality in args.modalities:
         spec = modality_specs.get(modality, {})
         if "bigwig" not in spec or not spec["bigwig"]:
@@ -626,6 +719,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         args.modality_to_bigwigs[modality] = list(spec["bigwig"])
         args.modality_resolutions[modality] = spec.get("resolutions", args.global_resolutions)
         args.modality_weight_dict[modality] = float(spec.get("task_weight", 1.0))
+        # CLI --strand-pairs overrides per-modality config 'strand_pairs'.
+        raw_pairs = cli_strand_pairs.get(modality, spec.get("strand_pairs"))
+        args.modality_strand_pairs[modality] = _normalize_strand_pairs(
+            raw_pairs, len(args.modality_to_bigwigs[modality]), modality, parser
+        )
 
     if "--modality-weights" not in cli_flags:
         for mod, weight in _parse_weight_overrides(
@@ -1075,6 +1173,7 @@ def main(args: argparse.Namespace | None = None) -> None:
                 args.train_bed,
                 sequence_length=args.sequence_length,
                 max_samples=args.track_means_samples,
+                strand_pair_groups=args.modality_strand_pairs.get(modality),
             )
             print(f"  {modality}: mean={modality_track_means[modality].mean():.4f}")
     modality_track_means = broadcast_object(modality_track_means, src=0)

--- a/src/alphagenome_pytorch/extensions/finetuning/README.md
+++ b/src/alphagenome_pytorch/extensions/finetuning/README.md
@@ -47,9 +47,21 @@ python scripts/finetune.py --mode lora \
     --pretrained-weights alphagenome.pth \
     --train-bed train.bed --val-bed val.bed \
     --modality atac --bigwig cell1_atac.bw cell2_atac.bw \
-    --modality rna_seq --bigwig cell1_rna.bw \
-    --modality-weights "atac:1.0,rna_seq:0.5"
+    --modality rna_seq --bigwig cell1_rna_plus.bw cell1_rna_minus.bw \
+    --modality-weights "atac:1.0,rna_seq:0.5" \
+    --strand-pairs "rna_seq:auto"
 ```
+
+For stranded assays (RNA-seq, CAGE, PRO-cap) the `+`/`-` bigwigs of a track
+should share one scaling factor. `--strand-pairs` averages each pair's
+nonzero-mean and broadcasts it back to both strands. Format is space-separated
+`modality:pairs`, where `pairs` is either `auto` (pairs consecutive bigwigs
+`(0,1),(2,3),…`, so order them `plus, minus, plus, minus`) or explicit
+semicolon-separated `plus,minus` index pairs, e.g. `rna_seq:0,2;1,3`. Indices
+are 0-based **into that modality's `--bigwig` list**, so each modality has its
+own index space — unstranded modalities (e.g. ATAC) simply get no entry and are
+left untouched. This affects only the scaling factor, not the loss or per-strand
+outputs.
 
 ### Multi-Modality Fine-tuning (YAML Config)
 
@@ -96,9 +108,11 @@ modalities:
 
   rna_seq:
     bigwig:
-      - /path/to/cell1_rna.bw
+      - /path/to/cell1_rna_plus.bw
+      - /path/to/cell1_rna_minus.bw
     resolutions: "128"    # Per-modality override (optional)
     task_weight: 0.5
+    strand_pairs: auto    # share +/- scaling; or [[0, 1]] for explicit pairs
 
   chip_tf:
     bigwig:
@@ -118,6 +132,7 @@ Notes:
 - Top-level `resolutions` is the global default.
 - `modalities.<name>.resolutions` overrides the global value for that modality.
 - `modalities.<name>.task_weight` sets per-modality loss weighting.
+- `modalities.<name>.strand_pairs` shares +/- strand track-mean scaling (`auto` or a list of `[plus, minus]` index pairs); CLI `--strand-pairs` overrides it.
 - CLI `--modality-weights` overrides YAML task weights when both are provided.
 - `num_segments` and `min_segment_size` apply to both training and validation multinomial loss.
 

--- a/src/alphagenome_pytorch/extensions/finetuning/datasets.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/datasets.py
@@ -774,6 +774,7 @@ def compute_track_means(
     sequence_length: int = 1_048_576,
     resolution: int = 1,
     max_samples: int | None = None,
+    strand_pair_groups: list[tuple[int, int]] | None = None,
 ) -> torch.Tensor:
     """Compute nonzero_mean signal per track from training data.
 
@@ -790,6 +791,13 @@ def compute_track_means(
         max_samples: Maximum number of samples to use for computing means.
             If None, uses all samples. Using a subset (e.g., 1000) speeds
             up computation while giving a good estimate.
+        strand_pair_groups: Optional list of (plus_idx, minus_idx) track
+            index pairs. When provided, the per-track nonzero means within
+            each pair are averaged and broadcast back to both indices, so
+            paired strands share a scaling factor. Mirrors AlphaGenome's
+            official scaling semantics (upstream notebook averages plus/minus
+            strand means by track name). Default `None` keeps existing
+            per-track behavior bit-equal.
 
     Returns:
         Track means tensor of shape (1, n_tracks) suitable for passing
@@ -875,6 +883,12 @@ def compute_track_means(
         track_nonzero_sums / track_nonzero_counts,
         1.0,
     )
+
+    if strand_pair_groups is not None:
+        for plus_idx, minus_idx in strand_pair_groups:
+            paired_mean = 0.5 * (track_means[plus_idx] + track_means[minus_idx])
+            track_means[plus_idx] = paired_mean
+            track_means[minus_idx] = paired_mean
 
     print(f"Computed nonzero_mean per track: {track_means}")
 

--- a/src/alphagenome_pytorch/extensions/finetuning/datasets.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/datasets.py
@@ -885,7 +885,26 @@ def compute_track_means(
     )
 
     if strand_pair_groups is not None:
-        for plus_idx, minus_idx in strand_pair_groups:
+        seen: set[int] = set()
+        for pair in strand_pair_groups:
+            plus_idx, minus_idx = (int(i) for i in pair)  # raises if not a 2-tuple
+            for idx in (plus_idx, minus_idx):
+                if not 0 <= idx < n_tracks:
+                    raise ValueError(
+                        f"strand_pair_groups index {idx} out of range "
+                        f"[0, {n_tracks})"
+                    )
+                if idx in seen:
+                    raise ValueError(
+                        f"strand_pair_groups index {idx} appears in more than "
+                        f"one pair; averaging would be order-dependent"
+                    )
+            if plus_idx == minus_idx:
+                raise ValueError(
+                    f"strand_pair_groups pair ({plus_idx}, {minus_idx}) must "
+                    f"reference two distinct tracks"
+                )
+            seen.update((plus_idx, minus_idx))
             paired_mean = 0.5 * (track_means[plus_idx] + track_means[minus_idx])
             track_means[plus_idx] = paired_mean
             track_means[minus_idx] = paired_mean

--- a/tests/unit/test_finetune_multitask.py
+++ b/tests/unit/test_finetune_multitask.py
@@ -142,6 +142,98 @@ class TestParseArgsMultimodal:
 
 
 @pytest.mark.unit
+class TestParseArgsStrandPairs:
+    """Tests for --strand-pairs / config strand_pairs parsing."""
+
+    def _stranded_argv(self, *extra: str) -> list[str]:
+        return (
+            _required_cli_args()
+            + [
+                "--modality", "atac", "--bigwig", "atac1.bw", "atac2.bw",
+                "--modality", "rna_seq", "--bigwig",
+                "rp1.bw", "rm1.bw", "rp2.bw", "rm2.bw",
+            ]
+            + list(extra)
+        )
+
+    def test_auto_pairs_consecutive_and_leaves_others_none(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", self._stranded_argv("--strand-pairs", "rna_seq:auto"))
+        args = parse_args()
+        assert args.modality_strand_pairs["rna_seq"] == [(0, 1), (2, 3)]
+        # Unstranded modality is untouched.
+        assert args.modality_strand_pairs["atac"] is None
+
+    def test_explicit_string_pairs(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", self._stranded_argv("--strand-pairs", "rna_seq:0,2;1,3"))
+        args = parse_args()
+        assert args.modality_strand_pairs["rna_seq"] == [(0, 2), (1, 3)]
+
+    def test_no_strand_pairs_all_none(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", self._stranded_argv())
+        args = parse_args()
+        assert args.modality_strand_pairs["atac"] is None
+        assert args.modality_strand_pairs["rna_seq"] is None
+
+    def test_auto_rejects_odd_bigwig_count(self, monkeypatch):
+        # atac has 2 bigwigs (even); point auto at a modality with an odd count.
+        argv = (
+            _required_cli_args()
+            + ["--modality", "rna_seq", "--bigwig", "rp1.bw", "rm1.bw", "rp2.bw"]
+            + ["--strand-pairs", "rna_seq:auto"]
+        )
+        monkeypatch.setattr(sys, "argv", argv)
+        with pytest.raises(SystemExit):
+            parse_args()
+
+    def test_rejects_unknown_modality(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", self._stranded_argv("--strand-pairs", "cage:auto"))
+        with pytest.raises(SystemExit):
+            parse_args()
+
+    def test_config_list_of_lists(self, monkeypatch, tmp_path):
+        yaml = pytest.importorskip("yaml")
+        config = {
+            "modalities": {
+                "atac": {"bigwig": ["atac1.bw", "atac2.bw"]},
+                "rna_seq": {
+                    "bigwig": ["rp1.bw", "rm1.bw", "rp2.bw", "rm2.bw"],
+                    "strand_pairs": [[0, 1], [2, 3]],
+                },
+            }
+        }
+        config_path = tmp_path / "train.yaml"
+        config_path.write_text(yaml.safe_dump(config))
+        monkeypatch.setattr(
+            sys, "argv", _required_cli_args() + ["--config", str(config_path)]
+        )
+        args = parse_args()
+        assert args.modality_strand_pairs["rna_seq"] == [(0, 1), (2, 3)]
+        assert args.modality_strand_pairs["atac"] is None
+
+    def test_cli_overrides_config_strand_pairs(self, monkeypatch, tmp_path):
+        yaml = pytest.importorskip("yaml")
+        config = {
+            "modalities": {
+                "rna_seq": {
+                    "bigwig": ["rp1.bw", "rm1.bw", "rp2.bw", "rm2.bw"],
+                    "strand_pairs": "auto",
+                },
+            }
+        }
+        config_path = tmp_path / "train.yaml"
+        config_path.write_text(yaml.safe_dump(config))
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            _required_cli_args()
+            + ["--config", str(config_path), "--strand-pairs", "rna_seq:0,2;1,3"],
+        )
+        args = parse_args()
+        # CLI explicit pairs win over config 'auto'.
+        assert args.modality_strand_pairs["rna_seq"] == [(0, 2), (1, 3)]
+
+
+@pytest.mark.unit
 class TestMultimodalDataset:
     """Tests for MultimodalDataset wrapper."""
 

--- a/tests/unit/test_finetune_multitask.py
+++ b/tests/unit/test_finetune_multitask.py
@@ -190,6 +190,29 @@ class TestParseArgsStrandPairs:
         with pytest.raises(SystemExit):
             parse_args()
 
+    @pytest.mark.parametrize("spec", ["rna_seq:", "rna_seq:;", "rna_seq: ; "])
+    def test_rejects_empty_explicit_spec(self, monkeypatch, spec):
+        # A blank explicit spec is almost certainly a typo: reject rather than
+        # silently apply no averaging.
+        monkeypatch.setattr(sys, "argv", self._stranded_argv("--strand-pairs", spec))
+        with pytest.raises(SystemExit):
+            parse_args()
+
+    def test_rejects_empty_config_list(self, monkeypatch, tmp_path):
+        yaml = pytest.importorskip("yaml")
+        config = {
+            "modalities": {
+                "rna_seq": {"bigwig": ["rp1.bw", "rm1.bw"], "strand_pairs": []},
+            }
+        }
+        config_path = tmp_path / "train.yaml"
+        config_path.write_text(yaml.safe_dump(config))
+        monkeypatch.setattr(
+            sys, "argv", _required_cli_args() + ["--config", str(config_path)]
+        )
+        with pytest.raises(SystemExit):
+            parse_args()
+
     def test_config_list_of_lists(self, monkeypatch, tmp_path):
         yaml = pytest.importorskip("yaml")
         config = {

--- a/tests/unit/test_track_means.py
+++ b/tests/unit/test_track_means.py
@@ -1,0 +1,89 @@
+"""Tests for compute_track_means strand-pair averaging (B3.3).
+
+Verifies the optional `strand_pair_groups` parameter averages per-track
+nonzero means within each (plus, minus) pair so the two strands share a
+scaling factor, matching upstream AlphaGenome's official scaling semantics.
+The default (None) is asserted to keep existing behavior bit-equal.
+"""
+
+import os
+import tempfile
+
+import pytest
+import torch
+
+pyBigWig = pytest.importorskip("pyBigWig")
+
+from alphagenome_pytorch.extensions.finetuning.datasets import compute_track_means
+
+
+@pytest.fixture
+def synthetic_bigwig_pair():
+    """Create two tiny bigwigs whose nonzero means are exactly (2.0, 4.0)."""
+    tmp_dir = tempfile.mkdtemp()
+    chrom = "chrFake"
+    chrom_size = 4096
+
+    bw1_path = os.path.join(tmp_dir, "track_plus.bw")
+    bw2_path = os.path.join(tmp_dir, "track_minus.bw")
+
+    # Track 1: ten positions all = 2.0 inside the central window → nonzero_mean = 2.0
+    bw1 = pyBigWig.open(bw1_path, "w")
+    bw1.addHeader([(chrom, chrom_size)])
+    bw1.addEntries(
+        [chrom] * 10,
+        list(range(2000, 2010)),
+        ends=list(range(2001, 2011)),
+        values=[2.0] * 10,
+    )
+    bw1.close()
+
+    # Track 2: ten positions all = 4.0 → nonzero_mean = 4.0
+    bw2 = pyBigWig.open(bw2_path, "w")
+    bw2.addHeader([(chrom, chrom_size)])
+    bw2.addEntries(
+        [chrom] * 10,
+        list(range(2000, 2010)),
+        ends=list(range(2001, 2011)),
+        values=[4.0] * 10,
+    )
+    bw2.close()
+
+    bed_path = os.path.join(tmp_dir, "regions.bed")
+    # One window centered at 2048 with width 2048 covers [1024, 3072) — includes
+    # all our nonzero positions (2000..2009).
+    with open(bed_path, "w") as f:
+        f.write(f"{chrom}\t1024\t3072\n")
+
+    return [bw1_path, bw2_path], bed_path
+
+
+@pytest.mark.unit
+class TestComputeTrackMeansStrandPair:
+
+    def test_default_no_pairing_preserves_per_track_means(self, synthetic_bigwig_pair):
+        """Without strand_pair_groups, each track keeps its own nonzero mean."""
+        bigwigs, bed = synthetic_bigwig_pair
+        means = compute_track_means(
+            bigwig_files=bigwigs,
+            bed_file=bed,
+            sequence_length=2048,
+            resolution=1,
+        )
+        assert means.shape == (1, 2)
+        assert torch.isclose(means[0, 0], torch.tensor(2.0))
+        assert torch.isclose(means[0, 1], torch.tensor(4.0))
+
+    def test_pairing_averages_paired_strands(self, synthetic_bigwig_pair):
+        """With strand_pair_groups=[(0, 1)], both indices receive the average (3.0)."""
+        bigwigs, bed = synthetic_bigwig_pair
+        means = compute_track_means(
+            bigwig_files=bigwigs,
+            bed_file=bed,
+            sequence_length=2048,
+            resolution=1,
+            strand_pair_groups=[(0, 1)],
+        )
+        assert means.shape == (1, 2)
+        assert torch.isclose(means[0, 0], torch.tensor(3.0))
+        assert torch.isclose(means[0, 1], torch.tensor(3.0))

--- a/tests/unit/test_track_means.py
+++ b/tests/unit/test_track_means.py
@@ -6,9 +6,6 @@ scaling factor, matching upstream AlphaGenome's official scaling semantics.
 The default (None) is asserted to keep existing behavior bit-equal.
 """
 
-import os
-import tempfile
-
 import pytest
 import torch
 
@@ -18,14 +15,13 @@ from alphagenome_pytorch.extensions.finetuning.datasets import compute_track_mea
 
 
 @pytest.fixture
-def synthetic_bigwig_pair():
+def synthetic_bigwig_pair(tmp_path):
     """Create two tiny bigwigs whose nonzero means are exactly (2.0, 4.0)."""
-    tmp_dir = tempfile.mkdtemp()
     chrom = "chrFake"
     chrom_size = 4096
 
-    bw1_path = os.path.join(tmp_dir, "track_plus.bw")
-    bw2_path = os.path.join(tmp_dir, "track_minus.bw")
+    bw1_path = str(tmp_path / "track_plus.bw")
+    bw2_path = str(tmp_path / "track_minus.bw")
 
     # Track 1: ten positions all = 2.0 inside the central window → nonzero_mean = 2.0
     bw1 = pyBigWig.open(bw1_path, "w")
@@ -49,7 +45,7 @@ def synthetic_bigwig_pair():
     )
     bw2.close()
 
-    bed_path = os.path.join(tmp_dir, "regions.bed")
+    bed_path = str(tmp_path / "regions.bed")
     # One window centered at 2048 with width 2048 covers [1024, 3072) — includes
     # all our nonzero positions (2000..2009).
     with open(bed_path, "w") as f:
@@ -87,3 +83,23 @@ class TestComputeTrackMeansStrandPair:
         assert means.shape == (1, 2)
         assert torch.isclose(means[0, 0], torch.tensor(3.0))
         assert torch.isclose(means[0, 1], torch.tensor(3.0))
+
+    @pytest.mark.parametrize(
+        "bad_groups, match",
+        [
+            ([(0, 2)], "out of range"),        # index >= n_tracks
+            ([(-1, 0)], "out of range"),       # negative would silently wrap
+            ([(0, 0)], "two distinct tracks"),  # self-pair
+            ([(0, 1), (1, 0)], "more than one pair"),  # reused index
+        ],
+    )
+    def test_invalid_strand_pair_groups_raise(self, synthetic_bigwig_pair, bad_groups, match):
+        bigwigs, bed = synthetic_bigwig_pair
+        with pytest.raises(ValueError, match=match):
+            compute_track_means(
+                bigwig_files=bigwigs,
+                bed_file=bed,
+                sequence_length=2048,
+                resolution=1,
+                strand_pair_groups=bad_groups,
+            )


### PR DESCRIPTION
Port scaling semantics from upstream.

**Feature:** add an optional `strand_pair_groups` argument to `compute_track_means` that averages the per-track nonzero means within each (plus, minus) pair so paired strands share a scaling factor — matching AlphaGenome's official scaling semantics.

Our `compute_track_means()` in `src/alphagenome_pytorch/extensions/finetuning/datasets.py` computes per-bigwig nonzero means but does not average plus/minus strand pairs by track name. Upstream notebooks pair them so the two strands of the same assay receive identical scaling.

```python
 def compute_track_means(
     bigwig_files: list[str],
     bed_file: str,
     sequence_length: int = 1_048_576,
     resolution: int = 1,
     max_samples: int | None = None,
+    strand_pair_groups: list[tuple[int, int]] | None = None,
 ) -> torch.Tensor:
     ...
+    if strand_pair_groups is not None:
+        for plus_idx, minus_idx in strand_pair_groups:
+            paired_mean = 0.5 * (track_means[plus_idx] + track_means[minus_idx])
+            track_means[plus_idx] = paired_mean
+            track_means[minus_idx] = paired_mean
```

Default `None` keeps existing behavior.

Usage:

```python
track_means = compute_track_means(
    bigwig_files=['atac_plus.bw', 'atac_minus.bw', 'rna_plus.bw', 'rna_minus.bw'],
    bed_file='train.bed',
    strand_pair_groups=[(0, 1), (2, 3)],   # (plus_idx, minus_idx) per assay
)
# track_means[0] == track_means[1]; track_means[2] == track_means[3]
```