### PR TITLE
Add gene LFC loss for RNA-seq fine-tuning

### DIFF
--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -285,7 +285,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help=(
             "Per-track strand string for the rna_seq modality, one char per "
             "BigWig in order. Each char must be '+', '-', or '.'. "
-            "Example: '+-+-' for 4 alternating-strand tracks. "
+            "Compact ('+-+-') or separated ('+,-,+,-' / '+ - + -') forms "
+            "are both accepted; commas and whitespace are stripped. "
             "Required when --gene-loss-weight > 0. Can also be supplied via "
             "the YAML config under modalities.<head>.strand."
         ),
@@ -699,13 +700,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             )
         args.modality_strands["rna_seq"] = args.track_strands
 
-    # Validate strand strings: one char per bigwig, each in {+, -, .}.
-    for modality, strands in args.modality_strands.items():
+    # Normalize and validate strand strings: accept both compact form
+    # ('+-+-.-') and comma/whitespace-separated form ('+,-,+,-,.,-' or
+    # '+ - + - . -'). After stripping separators, exactly one char per
+    # bigwig, each in {+, -, .}.
+    def _normalize_strand_string(s: str) -> str:
+        return "".join(c for c in s if c not in ", \t")
+
+    for modality, strands in list(args.modality_strands.items()):
+        strands = _normalize_strand_string(strands)
+        args.modality_strands[modality] = strands
         n_bw = len(args.modality_to_bigwigs[modality])
         if len(strands) != n_bw:
             parser.error(
-                f"strand string for modality '{modality}' has length "
-                f"{len(strands)} but there are {n_bw} bigwigs"
+                f"strand string for modality '{modality}' has {len(strands)} "
+                f"strand chars but there are {n_bw} bigwigs"
             )
         invalid = sorted({c for c in strands if c not in "+-."})
         if invalid:

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -268,6 +268,52 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=16,
         help="Max threads for parallel BigWig I/O (default: 16)",
     )
+    data.add_argument(
+        "--gtf",
+        type=str,
+        default=None,
+        help=(
+            "Path to a GTF annotation file (Gencode-compatible). Required when "
+            "--gene-loss-weight > 0. The GTF is parsed via pyranges and the "
+            "protein_coding gene rows are used to build per-window gene masks."
+        ),
+    )
+    data.add_argument(
+        "--track-strands",
+        type=str,
+        default=None,
+        help=(
+            "Per-track strand string for the rna_seq modality, one char per "
+            "BigWig in order. Each char must be '+', '-', or '.'. "
+            "Example: '+-+-' for 4 alternating-strand tracks. "
+            "Required when --gene-loss-weight > 0. Can also be supplied via "
+            "the YAML config under modalities.<head>.strand."
+        ),
+    )
+
+    # Gene LFC loss arguments (Decima-style cross-track loss for RNA-seq).
+    gene_lfc = parser.add_argument_group("Gene LFC loss")
+    gene_lfc.add_argument(
+        "--gene-loss-weight",
+        type=float,
+        default=0.0,
+        help=(
+            "Outer weight on the cross-track gene LFC loss for the rna_seq "
+            "head (paper value: 0.1). Default 0.0 disables the term entirely "
+            "and keeps loss values bit-identical to pre-B3.2 behavior. "
+            "When > 0, requires --gtf, rna_seq in --modality, and "
+            "--track-strands (or modalities.rna_seq.strand in YAML)."
+        ),
+    )
+    gene_lfc.add_argument(
+        "--gene-cross-track-weight",
+        type=float,
+        default=5.0,
+        help=(
+            "Inner multinomial weight inside the gene LFC term (paper "
+            "default: 5.0). Only used when --gene-loss-weight > 0."
+        ),
+    )
 
     # Model arguments
     model = parser.add_argument_group("Model")
@@ -534,6 +580,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "save_every",
         "resume",
         "modality_weights",
+        "gtf",
+        "track_strands",
+        "gene_loss_weight",
+        "gene_cross_track_weight",
     ):
         _apply_config_scalar(attr, config_data)
 
@@ -576,6 +626,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             )
         if "task_weight" in mod_cfg and mod_cfg["task_weight"] is not None:
             spec["task_weight"] = float(mod_cfg["task_weight"])
+        if "strand" in mod_cfg and mod_cfg["strand"] is not None:
+            strand_val = mod_cfg["strand"]
+            if isinstance(strand_val, list):
+                strand_val = "".join(str(s) for s in strand_val)
+            elif not isinstance(strand_val, str):
+                parser.error(
+                    f"modalities.{modality}.strand must be a string of "
+                    f"+/-/. characters or a list, got {type(strand_val).__name__}"
+                )
+            spec["strand"] = strand_val
         modality_specs[modality] = spec
 
     cli_modality_to_bigwigs: dict[str, list[str]] = {}
@@ -619,6 +679,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     args.modality_to_bigwigs = {}
     args.modality_resolutions = {}
     args.modality_weight_dict = {}
+    args.modality_strands: dict[str, str] = {}
     for modality in args.modalities:
         spec = modality_specs.get(modality, {})
         if "bigwig" not in spec or not spec["bigwig"]:
@@ -626,6 +687,48 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         args.modality_to_bigwigs[modality] = list(spec["bigwig"])
         args.modality_resolutions[modality] = spec.get("resolutions", args.global_resolutions)
         args.modality_weight_dict[modality] = float(spec.get("task_weight", 1.0))
+        if spec.get("strand"):
+            args.modality_strands[modality] = str(spec["strand"])
+
+    # `--track-strands` CLI flag overrides any YAML strand for rna_seq.
+    if args.track_strands:
+        if "rna_seq" not in args.modality_to_bigwigs:
+            parser.error(
+                "--track-strands is only meaningful with --modality rna_seq, "
+                f"but modalities are: {sorted(args.modality_to_bigwigs)}"
+            )
+        args.modality_strands["rna_seq"] = args.track_strands
+
+    # Validate strand strings: one char per bigwig, each in {+, -, .}.
+    for modality, strands in args.modality_strands.items():
+        n_bw = len(args.modality_to_bigwigs[modality])
+        if len(strands) != n_bw:
+            parser.error(
+                f"strand string for modality '{modality}' has length "
+                f"{len(strands)} but there are {n_bw} bigwigs"
+            )
+        invalid = sorted({c for c in strands if c not in "+-."})
+        if invalid:
+            parser.error(
+                f"strand string for '{modality}' contains invalid chars "
+                f"{invalid}; allowed: '+', '-', '.'"
+            )
+
+    # Validate gene-LFC config consistency.
+    if args.gene_loss_weight > 0:
+        if not args.gtf:
+            parser.error("--gene-loss-weight > 0 requires --gtf")
+        if "rna_seq" not in args.modality_to_bigwigs:
+            parser.error(
+                "--gene-loss-weight > 0 requires rna_seq in --modality / config; "
+                f"got modalities: {sorted(args.modality_to_bigwigs)}"
+            )
+        if "rna_seq" not in args.modality_strands:
+            parser.error(
+                "--gene-loss-weight > 0 requires per-track strand info for "
+                "rna_seq. Pass --track-strands or set "
+                "modalities.rna_seq.strand in the config."
+            )
 
     if "--modality-weights" not in cli_flags:
         for mod, weight in _parse_weight_overrides(
@@ -692,6 +795,41 @@ def create_datasets(
             rank,
         )
 
+    # Optional gene-mask extractor for the gene LFC training loss (B3.2).
+    # Only attached to the rna_seq dataset; gene_mask is sample-level so
+    # MultimodalDataset will propagate it to the batch.
+    gene_mask_extractor = None
+    g_max = None
+    if args.gene_loss_weight > 0:
+        from alphagenome_pytorch.extensions.finetuning.gene_annotation import (
+            GeneMaskExtractor,
+            cached_load_gene_table,
+            derive_g_max,
+        )
+        from alphagenome_pytorch.extensions.finetuning.datasets import (
+            _load_intervals_from_bed,
+        )
+
+        print_rank0(f"Loading GTF for gene LFC loss: {args.gtf}", rank)
+        gene_table = cached_load_gene_table(args.gtf, filter_protein_coding=True)
+        gene_mask_extractor = GeneMaskExtractor(gene_table)
+
+        # Project the BED windows used by the dataset (after centering/expansion
+        # to args.sequence_length) so derive_g_max sees the same intervals
+        # GenomicDataset will request at __getitem__.
+        all_intervals: list[tuple[str, int, int]] = []
+        for bed in (args.train_bed, args.val_bed):
+            raw_intervals, _ = _load_intervals_from_bed(bed)
+            half_len = args.sequence_length // 2
+            for chrom, s, e in raw_intervals:
+                center = (s + e) // 2
+                all_intervals.append((chrom, center - half_len, center + half_len))
+        g_max = derive_g_max(gene_mask_extractor, all_intervals)
+        print_rank0(
+            f"Gene LFC: scanned {len(all_intervals)} intervals, g_max={g_max}",
+            rank,
+        )
+
     # Always create MultimodalDataset (even for single modality) to have a unified interface
     # This is required by train_epoch_sequence_parallel
     print_rank0("Creating datasets...", rank)
@@ -700,6 +838,15 @@ def create_datasets(
 
     for modality, bigwigs in args.modality_to_bigwigs.items():
         resolutions = args.modality_resolutions[modality]
+        # Attach the gene-mask extractor only to the modality that consumes
+        # the gene LFC loss (rna_seq today).
+        attach_gene_mask = (
+            gene_mask_extractor is not None
+            and modality == "rna_seq"
+            and args.gene_loss_weight > 0
+        )
+        gme = gene_mask_extractor if attach_gene_mask else None
+        gme_g_max = g_max if attach_gene_mask else None
         train_datasets[modality] = GenomicDataset(
             genome_fasta=genome,
             bigwig_files=bigwigs,
@@ -709,6 +856,8 @@ def create_datasets(
             cache_genome=cache_genome,
             cache_signals=cache_signals,
             max_io_workers=max_io_workers,
+            gene_mask_extractor=gme,
+            g_max=gme_g_max,
         )
         val_datasets[modality] = GenomicDataset(
             genome_fasta=genome,
@@ -719,6 +868,8 @@ def create_datasets(
             cache_genome=cache_genome,
             cache_signals=cache_signals,
             max_io_workers=max_io_workers,
+            gene_mask_extractor=gme,
+            g_max=gme_g_max,
         )
 
     train_dataset = MultimodalDataset(train_datasets)
@@ -1092,6 +1243,25 @@ def main(args: argparse.Namespace | None = None) -> None:
     )
     model_module = unwrap_training_model(model)
 
+    # Build per-modality strand-channel masks for the gene LFC loss (B3.2).
+    # Empty dict when gene_loss_weight is 0; populated only for modalities
+    # whose strand info was supplied (today: rna_seq via --track-strands or
+    # the YAML strand field). Each mask is `[2, 1, C]` and lives on `device`.
+    gene_strand_channel_masks: dict[str, torch.Tensor] = {}
+    if args.gene_loss_weight > 0:
+        from alphagenome_pytorch.training import _build_strand_channel_mask
+        for modality, strands in args.modality_strands.items():
+            gene_strand_channel_masks[modality] = (
+                _build_strand_channel_mask(strands).to(device)
+            )
+
+    # Per-modality gene_loss_weights dict. Today only rna_seq receives a
+    # non-zero entry; other modalities are absent from the dict and the
+    # training loop's `gene_loss_weights.get(modality, 0.0)` returns 0.0.
+    gene_loss_weights: dict[str, float] = {}
+    if args.gene_loss_weight > 0:
+        gene_loss_weights["rna_seq"] = args.gene_loss_weight
+
     # Sequence parallelism setup
     sequence_parallel = None
     if args.sequence_parallel:
@@ -1364,6 +1534,9 @@ def main(args: argparse.Namespace | None = None) -> None:
                     profile_batches=args.profile_batches if epoch == start_epoch else 0,
                     log_fn=logger.log_step if is_main_process(rank) else None,
                     encoder_only=encoder_only,
+                    gene_loss_weights=gene_loss_weights,
+                    gene_cross_track_weight=args.gene_cross_track_weight,
+                    strand_channel_masks=gene_strand_channel_masks,
                 )
 
             if handler.preempted:

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -1506,6 +1506,9 @@ def main(args: argparse.Namespace | None = None) -> None:
                     profile_batches=args.profile_batches if epoch == start_epoch else 0,
                     log_fn=logger.log_step if is_main_process(rank) else None,
                     encoder_only=encoder_only,
+                    gene_loss_weights=gene_loss_weights,
+                    gene_cross_track_weight=args.gene_cross_track_weight,
+                    strand_channel_masks=gene_strand_channel_masks,
                 )
             else:
                 # Standard multimodal training (uses multihead functions)

--- a/src/alphagenome_pytorch/extensions/finetuning/datasets.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/datasets.py
@@ -466,6 +466,8 @@ class GenomicDataset(Dataset):
         cache_signals: bool = False,
         max_io_workers: int = DEFAULT_MAX_IO_WORKERS,
         use_mmap: bool = False,
+        gene_mask_extractor: "Any | None" = None,
+        g_max: int | None = None,
     ):
         _ensure_genomic_deps()
 
@@ -475,6 +477,20 @@ class GenomicDataset(Dataset):
         self.cache_signals = cache_signals
         self.max_io_workers = max_io_workers
         self.use_mmap = use_mmap
+
+        # Optional gene-mask plumbing for the gene LFC training loss.
+        # When `gene_mask_extractor` is set, __getitem__ returns a 3-tuple
+        # (sequence, targets, gene_mask) instead of (sequence, targets);
+        # `g_max` then defines the fixed gene padding width.
+        self.gene_mask_extractor = gene_mask_extractor
+        if gene_mask_extractor is not None and g_max is None:
+            raise ValueError(
+                "gene_mask_extractor was provided but g_max is None. "
+                "Pass g_max explicitly, or call "
+                "alphagenome_pytorch.extensions.finetuning.gene_annotation.derive_g_max(...) "
+                "first to scan training intervals."
+            )
+        self.g_max = g_max
 
         # Normalise genome input: str path or pre-built CachedGenome
         if isinstance(genome_fasta, CachedGenome):
@@ -693,14 +709,19 @@ class GenomicDataset(Dataset):
 
     def __getitem__(
         self, idx: int
-    ) -> tuple[torch.Tensor, dict[int, torch.Tensor]]:
+    ) -> "tuple[torch.Tensor, dict[int, torch.Tensor]] | tuple[torch.Tensor, dict[int, torch.Tensor], torch.Tensor]":
         """Get a single sample.
 
         Returns:
-            Tuple of (sequence, targets_dict):
+            Tuple of (sequence, targets_dict) by default, or
+            (sequence, targets_dict, gene_mask) when this dataset was
+            constructed with a `gene_mask_extractor`:
                 - sequence: One-hot encoded DNA (seq_len, 4)
                 - targets_dict: Dict mapping resolution to signals
                     {res: tensor of shape (output_len, n_tracks)}
+                - gene_mask: Bool tensor of shape (seq_len, 2, g_max)
+                    where axis 1 is [plus_strand_genes, minus_strand_genes]
+                    and the gene axis is zero-padded to g_max.
         """
         self._ensure_handles()
         chrom, start, end = self._positions_list[idx]
@@ -738,10 +759,24 @@ class GenomicDataset(Dataset):
                 binned = raw_signals.reshape(output_len, res, self.n_tracks).sum(axis=1)
                 targets_dict[res] = torch.from_numpy(binned).float()
 
-        return (
-            torch.from_numpy(sequence).float(),
-            targets_dict,
-        )
+        seq_tensor = torch.from_numpy(sequence).float()
+
+        if self.gene_mask_extractor is None:
+            return (seq_tensor, targets_dict)
+
+        gene_mask_np, _ = self.gene_mask_extractor.extract(chrom, start, end)
+        # Pad to fixed g_max along the gene axis. Shape: (S, 2, g_max).
+        num_genes = gene_mask_np.shape[-1]
+        if num_genes > self.g_max:
+            raise ValueError(
+                f"Window {chrom}:{start}-{end} contains {num_genes} genes, "
+                f"exceeding g_max={self.g_max}. Increase g_max (e.g. via "
+                "derive_g_max with more headroom) or shrink the window."
+            )
+        padded = np.zeros((self.sequence_length, 2, self.g_max), dtype=bool)
+        if num_genes > 0:
+            padded[:, :, :num_genes] = gene_mask_np
+        return (seq_tensor, targets_dict, torch.from_numpy(padded))
 
     def __del__(self) -> None:
         """Clean up file handles and thread pool (only if we own them)."""
@@ -926,24 +961,37 @@ class MultimodalDataset(Dataset):
 
     def __getitem__(
         self, idx: int
-    ) -> tuple[torch.Tensor, dict[str, dict[int, torch.Tensor]]]:
+    ) -> "tuple[torch.Tensor, dict[str, dict[int, torch.Tensor]]] | tuple[torch.Tensor, dict[str, dict[int, torch.Tensor]], torch.Tensor]":
         """Get sequence and targets for all modalities.
 
         Returns:
-            Tuple of (sequence, modality_targets) where:
-                - sequence: One-hot encoded DNA (seq_len, 4)
-                - modality_targets: Dict mapping modality name to targets_dict
-                    {modality: {resolution: tensor}}
+            Tuple of (sequence, modality_targets) by default. When any
+            wrapped GenomicDataset has a `gene_mask_extractor`, the
+            tuple is extended to (sequence, modality_targets, gene_mask)
+            using the gene_mask from the first such dataset (gene_mask is
+            sample-level, not per-modality, so any one source suffices).
         """
-        # Get sequence from primary dataset
-        sequence, _ = self._primary_dataset[idx]
+        # Get sequence (and possibly gene_mask) from primary dataset.
+        primary_result = self._primary_dataset[idx]
+        if len(primary_result) == 3:
+            sequence, _, gene_mask = primary_result
+        else:
+            sequence, _ = primary_result
+            gene_mask = None
 
-        # Get targets from all datasets
-        modality_targets = {}
+        # Get targets from all datasets. If the primary didn't have a
+        # gene_mask but another dataset does, use the first one we find.
+        modality_targets: dict[str, dict[int, torch.Tensor]] = {}
         for modality, dataset in self.datasets.items():
-            _, targets_dict = dataset[idx]
+            result = dataset[idx]
+            if len(result) == 3 and gene_mask is None:
+                _, targets_dict, gene_mask = result
+            else:
+                targets_dict = result[1]
             modality_targets[modality] = targets_dict
 
+        if gene_mask is not None:
+            return sequence, modality_targets, gene_mask
         return sequence, modality_targets
 
 

--- a/src/alphagenome_pytorch/extensions/finetuning/gene_annotation.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/gene_annotation.py
@@ -208,14 +208,18 @@ class GeneMaskExtractor:
 def derive_g_max(
     extractor: GeneMaskExtractor,
     intervals: list[Tuple[str, int, int]],
-    *,
-    headroom: int = 16,
 ) -> int:
     """Scan training intervals once to pick a fixed `G_max`.
 
-    Returns `observed_max + headroom`. Any window exceeding
-    `PAD_NUM_GENES_CEILING` raises during the scan via the extractor's own
-    bound check; this function therefore needs no additional cap.
+    Returns the exact `observed_max` over the supplied intervals. Pass
+    every interval you intend to feed through the resulting dataset
+    (train + val + any held-out splits) so the returned width is tight.
+    Adding intervals later without re-running this scan and exceeding
+    the previous max will raise at `GenomicDataset.__getitem__`.
+
+    Any single window with more than `PAD_NUM_GENES_CEILING` genes raises
+    during the scan via the extractor's own bound check; this function
+    therefore needs no additional cap.
 
     Reuses the extractor's LRU cache so masks built here are still warm
     when training begins.
@@ -224,7 +228,7 @@ def derive_g_max(
     for chrom, start, end in intervals:
         mask, _ = extractor.extract(chrom, start, end)
         observed_max = max(observed_max, mask.shape[-1])
-    return observed_max + headroom
+    return observed_max
 
 
 @functools.lru_cache(maxsize=4)

--- a/src/alphagenome_pytorch/extensions/finetuning/gene_annotation.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/gene_annotation.py
@@ -1,0 +1,247 @@
+"""Gene annotation extractor for fine-tuning datasets.
+
+Builds per-interval gene-body boolean masks from a user-supplied GTF, for use
+in the cross-track gene LFC training loss (mirrors AlphaGenome's upstream
+`_GeneBodyAnnotationExtractor`).
+
+The user MUST supply their own GTF — this module never downloads or relies on
+hosted reference data. Reads GTFs via `pyranges.read_gtf`, which produces a
+DataFrame with the columns the extractor expects (`Chromosome`, `Start`, `End`,
+`Strand`, `Feature`, `gene_id`, `gene_type`, ...).
+"""
+
+from __future__ import annotations
+
+import functools
+from collections import OrderedDict
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+
+
+# Maximum genes per training window. Mirrors upstream's
+# `GeneVariantScorer.pad_num_genes=256` ceiling. If a window exceeds this we
+# raise rather than silently truncate — same behavior as upstream.
+PAD_NUM_GENES_CEILING = 256
+
+
+def load_gene_table(
+    gtf_path: str,
+    *,
+    filter_protein_coding: bool = True,
+) -> pd.DataFrame:
+    """Load a GTF as a gene-body DataFrame.
+
+    Returns rows with `Feature == "gene"` and the seven columns
+    `_GeneBodyAnnotationExtractor` requires.
+
+    Args:
+        gtf_path: Path to a GTF file readable by `pyranges.read_gtf`.
+        filter_protein_coding: If True (default), keep only rows with
+            `gene_type == "protein_coding"`. Set False for assemblies / GTFs
+            that don't have or use that biotype.
+    """
+    import pyranges  # local import: heavy dep, only needed when GTF is supplied
+
+    pr = pyranges.read_gtf(gtf_path)
+    df = pr.df if hasattr(pr, "df") else pr  # pyranges 0.x → .df, 1.x → DataFrame
+
+    required = {"Chromosome", "Start", "End", "Strand", "Feature", "gene_id"}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(
+            f"GTF at {gtf_path} is missing required columns: {sorted(missing)}. "
+            f"Got columns: {sorted(df.columns)}"
+        )
+
+    gene_rows = df[df["Feature"] == "gene"]
+    if gene_rows.empty:
+        raise ValueError(
+            f"GTF at {gtf_path} contains no `Feature == 'gene'` rows. "
+            "AlphaGenome gene LFC loss requires gene-level features; "
+            "transcript-only or exon-only GTFs are not supported."
+        )
+
+    if filter_protein_coding:
+        if "gene_type" not in gene_rows.columns:
+            raise ValueError(
+                f"filter_protein_coding=True requires a 'gene_type' column "
+                f"in the GTF, but it was not found. Pass "
+                f"filter_protein_coding=False to disable, or use a GTF with "
+                f"biotype annotations."
+            )
+        gene_rows = gene_rows[gene_rows["gene_type"] == "protein_coding"]
+        if gene_rows.empty:
+            raise ValueError(
+                f"No protein_coding genes found in {gtf_path}. "
+                "Pass filter_protein_coding=False if your GTF uses different "
+                "biotype labels."
+            )
+
+    keep_cols = ["Chromosome", "Start", "End", "Strand", "gene_id"]
+    if "gene_name" in gene_rows.columns:
+        keep_cols.append("gene_name")
+    if "gene_type" in gene_rows.columns:
+        keep_cols.append("gene_type")
+
+    return gene_rows[keep_cols].reset_index(drop=True)
+
+
+class GeneMaskExtractor:
+    """Per-interval gene-body mask extractor.
+
+    Mirrors upstream `_GeneBodyAnnotationExtractor` but:
+      - sources the gene table from a user-supplied GTF (via `load_gene_table`),
+        never from upstream's hosted feathers;
+      - returns a strand-bucketed `[S, 2, G]` mask directly (upstream returns
+        `[S, G]` and lets the caller bucket by strand). Bucketing here keeps
+        the loss-side einsum simple.
+
+    The mask uses 0-based, half-open coordinates (consistent with `pyranges`
+    output and the rest of this codebase).
+
+    Args:
+        gene_table: DataFrame from `load_gene_table` (or an equivalent).
+        cache_size: LRU cache size on (chromosome, start, end). Larger is
+            useful at training time when intervals repeat across epochs.
+            Defaults to 1024.
+    """
+
+    def __init__(self, gene_table: pd.DataFrame, *, cache_size: int = 1024):
+        self._gene_table = gene_table
+        self._cache_size = cache_size
+        self._cache: "OrderedDict[Tuple[str, int, int], Tuple[np.ndarray, pd.DataFrame]]" = (
+            OrderedDict()
+        )
+        # Pre-group by chromosome for fast filtering.
+        self._by_chrom: dict[str, pd.DataFrame] = {
+            str(chrom): grp
+            for chrom, grp in gene_table.groupby("Chromosome", observed=True)
+        }
+
+    def extract(
+        self,
+        chromosome: str,
+        start: int,
+        end: int,
+    ) -> Tuple[np.ndarray, pd.DataFrame]:
+        """Extract `[S, 2, G]` gene-body mask for a half-open interval.
+
+        Args:
+            chromosome: Chromosome name (must match GTF naming, e.g. "chr1").
+            start: 0-based inclusive start.
+            end: 0-based exclusive end.
+
+        Returns:
+            Tuple `(mask, metadata)`:
+              - mask: bool array of shape `(end - start, 2, G)`. Axis 1 is
+                `[plus_strand_genes, minus_strand_genes]`. `G` is the number
+                of genes contained in the interval (variable; may be 0).
+              - metadata: DataFrame slice for the contained genes (one row
+                per column of axis 2, in the same order).
+        """
+        key = (chromosome, int(start), int(end))
+        if key in self._cache:
+            self._cache.move_to_end(key)
+            mask, metadata = self._cache[key]
+            return mask, metadata
+
+        width = end - start
+        chrom_df = self._by_chrom.get(chromosome)
+        if chrom_df is None or chrom_df.empty:
+            mask = np.zeros((width, 2, 0), dtype=bool)
+            metadata = self._gene_table.iloc[:0].copy()
+            self._cache_set(key, mask, metadata)
+            return mask, metadata
+
+        # Genes fully contained in the interval (matches upstream's
+        # INTERVAL_CONTAINED query type). Genes that overhang are skipped
+        # since their per-gene total would be biased.
+        contained = chrom_df[
+            (chrom_df["Start"].values >= start) & (chrom_df["End"].values <= end)
+        ]
+
+        num_genes = len(contained)
+        if num_genes > PAD_NUM_GENES_CEILING:
+            raise ValueError(
+                f"Window {chromosome}:{start}-{end} contains {num_genes} genes, "
+                f"exceeding the ceiling of {PAD_NUM_GENES_CEILING}. "
+                "Either reduce the window size or relax the ceiling in "
+                "alphagenome_pytorch.extensions.finetuning.gene_annotation."
+            )
+
+        mask = np.zeros((width, 2, num_genes), dtype=bool)
+        for i, row in enumerate(contained.itertuples(index=False)):
+            rel_start = max(int(row.Start) - start, 0)
+            rel_end = min(int(row.End) - start, width)
+            strand = str(row.Strand)
+            # Match upstream's strand-channel semantics: "+" → bucket 0 only,
+            # "-" → bucket 1 only, "." (unstranded) → BOTH buckets, so an
+            # unstranded gene aggregates from + and - tracks alike.
+            if strand in ("+", "."):
+                mask[rel_start:rel_end, 0, i] = True
+            if strand in ("-", "."):
+                mask[rel_start:rel_end, 1, i] = True
+            if strand not in ("+", "-", "."):
+                raise ValueError(
+                    f"Unknown Strand value {strand!r} for gene "
+                    f"{getattr(row, 'gene_id', '<unknown>')!r}. "
+                    "Strand must be one of '+', '-', '.'."
+                )
+
+        metadata = contained.reset_index(drop=True)
+        self._cache_set(key, mask, metadata)
+        return mask, metadata
+
+    def _cache_set(
+        self,
+        key: Tuple[str, int, int],
+        mask: np.ndarray,
+        metadata: pd.DataFrame,
+    ) -> None:
+        self._cache[key] = (mask, metadata)
+        while len(self._cache) > self._cache_size:
+            self._cache.popitem(last=False)
+
+
+def derive_g_max(
+    extractor: GeneMaskExtractor,
+    intervals: list[Tuple[str, int, int]],
+    *,
+    headroom: int = 16,
+) -> int:
+    """Scan training intervals once to pick a fixed `G_max`.
+
+    Returns `observed_max + headroom`. Any window exceeding
+    `PAD_NUM_GENES_CEILING` raises during the scan via the extractor's own
+    bound check; this function therefore needs no additional cap.
+
+    Reuses the extractor's LRU cache so masks built here are still warm
+    when training begins.
+    """
+    observed_max = 0
+    for chrom, start, end in intervals:
+        mask, _ = extractor.extract(chrom, start, end)
+        observed_max = max(observed_max, mask.shape[-1])
+    return observed_max + headroom
+
+
+@functools.lru_cache(maxsize=4)
+def cached_load_gene_table(gtf_path: str, filter_protein_coding: bool = True) -> pd.DataFrame:
+    """Module-level cache for `load_gene_table`.
+
+    GTF parsing is expensive (~seconds for hg38). When the same script
+    constructs train + val datasets back-to-back from the same GTF, this
+    avoids re-parsing.
+    """
+    return load_gene_table(gtf_path, filter_protein_coding=filter_protein_coding)
+
+
+__all__ = [
+    "GeneMaskExtractor",
+    "load_gene_table",
+    "cached_load_gene_table",
+    "derive_g_max",
+    "PAD_NUM_GENES_CEILING",
+]

--- a/src/alphagenome_pytorch/extensions/finetuning/training.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/training.py
@@ -273,12 +273,23 @@ def compute_finetuning_loss(
 
         # Add gene LFC term at 1bp resolution when enabled. Mirrors upstream
         # which only threads gene_mask through the resolution=1 head path.
-        if (
-            res == 1
-            and gene_loss_weight > 0
-            and gene_mask is not None
-            and strand_channel_mask is not None
-        ):
+        if res == 1 and gene_loss_weight > 0:
+            # Fail loud on a wiring error: when the gene term is enabled, the
+            # dataset always yields a (possibly all-zero) gene_mask tensor and
+            # strand_channel_mask is required. A None here means a dependency
+            # was never threaded through, so silently skipping would train
+            # without the intended term.
+            missing_args = []
+            if gene_mask is None:
+                missing_args.append("gene_mask")
+            if strand_channel_mask is None:
+                missing_args.append("strand_channel_mask")
+            if missing_args:
+                raise ValueError(
+                    "gene_loss_weight > 0 requires "
+                    f"{', '.join(missing_args)} to be provided for the gene "
+                    "LFC loss at 1bp resolution."
+                )
             # gene_lfc_loss expects channels-last; transpose if needed.
             if channels_last:
                 pred_nlc, target_nlc, mask_nlc = pred, target, mask

--- a/src/alphagenome_pytorch/extensions/finetuning/training.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/training.py
@@ -1789,6 +1789,10 @@ def train_epoch_sequence_parallel(
     profile_batches: int = 0,
     log_fn: Any | None = None,
     encoder_only: bool = False,
+    *,
+    gene_loss_weights: dict[str, float] | None = None,
+    gene_cross_track_weight: float = 5.0,
+    strand_channel_masks: dict[str, Tensor] | None = None,
 ) -> tuple[float, dict[str, float]]:
     """Train for one epoch with sequence parallelism.
 
@@ -1862,7 +1866,16 @@ def train_epoch_sequence_parallel(
     else:
         pbar = train_loader
 
-    for batch_idx, (sequences, modality_targets) in enumerate(pbar):
+    gene_loss_weights = gene_loss_weights or {}
+
+    for batch_idx, batch_data in enumerate(pbar):
+        # Dataset returns 3-tuple when gene_mask is configured, else 2-tuple.
+        if len(batch_data) == 3:
+            sequences, modality_targets, gene_mask = batch_data
+            gene_mask = gene_mask.to(device)
+        else:
+            sequences, modality_targets = batch_data
+            gene_mask = None
         sequences = sequences.to(device)
         organism_idx = torch.zeros(sequences.shape[0], dtype=torch.long, device=device)
 
@@ -1983,6 +1996,38 @@ def train_epoch_sequence_parallel(
                 )
 
                 res_loss = loss_dict["loss"] * weight
+
+                # Optional gene LFC term (Decima-style cross-track loss) for
+                # the rna_seq head at 1bp resolution. Slice gene_mask along
+                # S to match this rank's local shard, exactly as we sliced
+                # targets above.
+                gene_w = gene_loss_weights.get(modality, 0.0)
+                if (
+                    res == 1
+                    and gene_w > 0
+                    and gene_mask is not None
+                    and strand_channel_masks is not None
+                    and modality in strand_channel_masks
+                ):
+                    g_full_len = gene_mask.shape[1]
+                    g_local_len = g_full_len // world_size
+                    g_start = rank * g_local_len
+                    local_gene_mask = gene_mask[
+                        :, g_start:g_start + g_local_len, :, :
+                    ]
+                    gene_loss, gene_aux = losses.gene_lfc_loss(
+                        predictions=pred,
+                        targets=targets,
+                        targets_mask=mask,
+                        gene_mask=local_gene_mask,
+                        strand_channel_mask=strand_channel_masks[modality],
+                        gene_cross_track_weight=gene_cross_track_weight,
+                    )
+                    res_loss = res_loss + weight * gene_w * gene_loss
+                    loss_components[f"{modality}_gene_lfc"] = gene_loss.item()
+                    loss_components[f"{modality}_gene_total_count"] = gene_aux["gene_loss_total_count"].item()
+                    loss_components[f"{modality}_gene_positional"] = gene_aux["gene_loss_positional"].item()
+
                 modality_loss = modality_loss + res_loss
                 loss_components[f"{modality}_loss_{res}bp"] = res_loss.item()
 

--- a/src/alphagenome_pytorch/extensions/finetuning/training.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/training.py
@@ -24,6 +24,7 @@ from torch.utils.data.distributed import DistributedSampler
 import torch.distributed as dist
 from tqdm import tqdm
 
+from alphagenome_pytorch import losses
 from alphagenome_pytorch.losses import multinomial_loss
 
 # Number of segments for multinomial loss computation.
@@ -187,11 +188,24 @@ def compute_finetuning_loss(
     positional_weight: float,
     device: torch.device,
     channels_last: bool = True,
+    *,
+    gene_mask: Tensor | None = None,
+    gene_loss_weight: float = 0.0,
+    gene_cross_track_weight: float = 5.0,
+    strand_channel_mask: Tensor | None = None,
 ) -> tuple[Tensor, dict[str, Tensor]]:
     """Compute combined loss across resolutions.
 
     Uses dynamic multinomial_resolution = seq_len // 8 for consistent loss
     granularity across different sequence lengths.
+
+    Optionally adds the cross-track gene LFC term (Decima-style; see
+    `losses.gene_lfc_loss`) at 1bp resolution when:
+      - `gene_loss_weight > 0`
+      - `gene_mask` and `strand_channel_mask` are both provided
+      - `predictions` / `targets` contain key `1`
+    The gene LFC contribution is `resolution_weights[1] * gene_loss_weight *
+    gene_lfc_term` so it scales with the existing 1bp resolution weight.
 
     Args:
         predictions: Dict mapping resolution to prediction tensors.
@@ -200,6 +214,15 @@ def compute_finetuning_loss(
         positional_weight: Weight for positional component of multinomial loss.
         device: Torch device.
         channels_last: If True, assumes (B, S, C). If False, assumes (B, C, S).
+        gene_mask: Optional `[B, S, 2, G]` gene-body mask for the gene LFC
+            term. Ignored if `gene_loss_weight <= 0`.
+        gene_loss_weight: Outer weight on the gene LFC term (paper: 0.1).
+            Default 0.0 disables the term entirely (no behavioral change vs.
+            the pre-B3.2 loss path).
+        gene_cross_track_weight: Inner weight on the multinomial component
+            of the gene LFC term (paper default: 5.0).
+        strand_channel_mask: Optional `[2, 1, C]` track strand-compatibility
+            mask, required when `gene_loss_weight > 0`.
 
     Returns:
         Tuple of (total_loss, loss_dict) where loss_dict contains per-resolution
@@ -246,8 +269,38 @@ def compute_finetuning_loss(
             channels_last=channels_last,
         )
 
-        total_loss = total_loss + weight * res_loss_dict["loss"]
-        loss_dict[f"loss_{res}bp"] = res_loss_dict["loss"]
+        res_loss = res_loss_dict["loss"]
+
+        # Add gene LFC term at 1bp resolution when enabled. Mirrors upstream
+        # which only threads gene_mask through the resolution=1 head path.
+        if (
+            res == 1
+            and gene_loss_weight > 0
+            and gene_mask is not None
+            and strand_channel_mask is not None
+        ):
+            # gene_lfc_loss expects channels-last; transpose if needed.
+            if channels_last:
+                pred_nlc, target_nlc, mask_nlc = pred, target, mask
+            else:
+                pred_nlc = pred.transpose(-1, -2).contiguous()
+                target_nlc = target.transpose(-1, -2).contiguous()
+                mask_nlc = mask.transpose(-1, -2).contiguous()
+            gene_loss, gene_aux = losses.gene_lfc_loss(
+                predictions=pred_nlc,
+                targets=target_nlc,
+                targets_mask=mask_nlc,
+                gene_mask=gene_mask,
+                strand_channel_mask=strand_channel_mask,
+                gene_cross_track_weight=gene_cross_track_weight,
+            )
+            res_loss = res_loss + gene_loss_weight * gene_loss
+            loss_dict["loss_gene_lfc"] = gene_loss
+            loss_dict["loss_gene_total_count"] = gene_aux["gene_loss_total_count"]
+            loss_dict["loss_gene_positional"] = gene_aux["gene_loss_positional"]
+
+        total_loss = total_loss + weight * res_loss
+        loss_dict[f"loss_{res}bp"] = res_loss
 
     loss_dict["loss"] = total_loss
     return total_loss, loss_dict
@@ -267,6 +320,10 @@ def train_epoch(
     use_amp: bool = True,
     accumulation_steps: int = 1,
     resolutions: tuple[int, ...] | None = None,
+    *,
+    gene_loss_weight: float = 0.0,
+    gene_cross_track_weight: float = 5.0,
+    strand_channel_mask: Tensor | None = None,
 ) -> float:
     """Train for one epoch.
 
@@ -288,6 +345,14 @@ def train_epoch(
         resolutions: Tuple of resolutions to train on (e.g., (1,), (128,), or (1, 128)).
             If None, inferred from resolution_weights keys. Training on 1bp resolution
             requires significantly more memory than 128bp.
+        gene_loss_weight: Outer weight on the gene LFC term (paper: 0.1 for
+            RNA-seq). Default 0.0 disables. Requires `train_loader` to yield
+            3-tuples (sequence, targets, gene_mask) and `strand_channel_mask`
+            to be set.
+        gene_cross_track_weight: Inner multinomial weight inside the gene LFC
+            term (paper default: 5.0).
+        strand_channel_mask: `[2, 1, C]` track strand-compatibility mask,
+            required when gene_loss_weight > 0.
 
     Returns:
         Average training loss for the epoch.
@@ -304,6 +369,11 @@ def train_epoch(
     if invalid := (set(resolutions) - {1, 128}):
         raise ValueError(f"Invalid resolutions {invalid}, must be 1 or 128")
 
+    if gene_loss_weight > 0 and strand_channel_mask is None:
+        raise ValueError(
+            "gene_loss_weight > 0 requires strand_channel_mask to be set."
+        )
+
     # Set up autocast context (bfloat16 on CUDA, no-op on CPU)
     if use_amp and device.type == "cuda":
         amp_context = autocast(device_type="cuda", dtype=torch.bfloat16)
@@ -311,7 +381,14 @@ def train_epoch(
         amp_context = nullcontext()
 
     pbar = tqdm(train_loader, desc=f"Epoch {epoch}")
-    for batch_idx, (sequences, targets_dict) in enumerate(pbar):
+    for batch_idx, batch_data in enumerate(pbar):
+        # Dataset returns a 3-tuple when gene_mask is configured, else 2-tuple.
+        if len(batch_data) == 3:
+            sequences, targets_dict, gene_mask = batch_data
+            gene_mask = gene_mask.to(device)
+        else:
+            sequences, targets_dict = batch_data
+            gene_mask = None
         sequences = sequences.to(device)
         targets_dict = {k: v.to(device) for k, v in targets_dict.items() if k in resolutions}
 
@@ -344,6 +421,10 @@ def train_epoch(
                 positional_weight=positional_weight,
                 device=device,
                 channels_last=True,
+                gene_mask=gene_mask,
+                gene_loss_weight=gene_loss_weight,
+                gene_cross_track_weight=gene_cross_track_weight,
+                strand_channel_mask=strand_channel_mask,
             )
 
         # Scale loss for gradient accumulation
@@ -1139,6 +1220,10 @@ def train_epoch_multihead(
     profile_batches: int = 0,
     log_fn: Any | None = None,
     encoder_only: bool = False,
+    *,
+    gene_loss_weights: dict[str, float] | None = None,
+    gene_cross_track_weight: float = 5.0,
+    strand_channel_masks: dict[str, Tensor] | None = None,
 ) -> tuple[float, dict[str, float]]:
     """Train for one epoch with multiple modality heads.
 
@@ -1208,7 +1293,17 @@ def train_epoch_multihead(
     running_loss = 0.0
     accumulated_batches = 0
 
-    for batch_idx, (sequences, modality_targets) in enumerate(pbar):
+    gene_loss_weights = gene_loss_weights or {}
+
+    for batch_idx, batch_data in enumerate(pbar):
+        # Dataset returns 3-tuple when gene_mask is configured, else 2-tuple.
+        if len(batch_data) == 3:
+            sequences, modality_targets, gene_mask = batch_data
+            gene_mask = gene_mask.to(device)
+        else:
+            sequences, modality_targets = batch_data
+            gene_mask = None
+
         is_profiling = do_profile and batch_idx < profile_batches
 
         if is_profiling and batch_idx > 0:
@@ -1320,6 +1415,32 @@ def train_epoch_multihead(
                 )
 
                 res_loss = loss_dict["loss"] * weight
+
+                # Optional gene LFC term (Decima-style cross-track loss).
+                # Only applies at 1bp resolution to the head whose modality
+                # has a non-zero entry in `gene_loss_weights`. Mirrors
+                # upstream which threads gene_mask only through res=1.
+                gene_w = gene_loss_weights.get(modality, 0.0)
+                if (
+                    res == 1
+                    and gene_w > 0
+                    and gene_mask is not None
+                    and strand_channel_masks is not None
+                    and modality in strand_channel_masks
+                ):
+                    gene_loss, gene_aux = losses.gene_lfc_loss(
+                        predictions=pred,
+                        targets=targets,
+                        targets_mask=mask,
+                        gene_mask=gene_mask,
+                        strand_channel_mask=strand_channel_masks[modality],
+                        gene_cross_track_weight=gene_cross_track_weight,
+                    )
+                    res_loss = res_loss + weight * gene_w * gene_loss
+                    loss_components[f"{modality}_gene_lfc"] = gene_loss.item()
+                    loss_components[f"{modality}_gene_total_count"] = gene_aux["gene_loss_total_count"].item()
+                    loss_components[f"{modality}_gene_positional"] = gene_aux["gene_loss_positional"].item()
+
                 modality_loss = modality_loss + res_loss
                 loss_components[f"{modality}_loss_{res}bp"] = res_loss.item()
                 loss_components[f"{modality}_loss_{res}bp_count"] = loss_dict["loss_total"].item()

--- a/src/alphagenome_pytorch/losses.py
+++ b/src/alphagenome_pytorch/losses.py
@@ -4,7 +4,7 @@ Losses for AlphaGenome PyTorch.
 Ported from alphagenome_research.model.losses (JAX implementation).
 """
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
@@ -264,3 +264,102 @@ def cross_entropy_loss(
     
     log_loss = log_normalizer - log_likelihood
     return _safe_masked_mean(log_loss, mask.any(dim=axis))
+
+
+def gene_lfc_loss(
+    *,
+    predictions: Tensor,
+    targets: Tensor,
+    targets_mask: Optional[Tensor],
+    gene_mask: Tensor,
+    strand_channel_mask: Tensor,
+    gene_cross_track_weight: float = 5.0,
+) -> Tuple[Tensor, Dict[str, Tensor]]:
+    """Cross-track gene-level loss (Decima-style).
+
+    PyTorch port of upstream JAX `GenomeTracksHead._compute_cross_track_loss`
+    (google-deepmind/alphagenome_research, commit fd44ed0). Aggregates
+    predictions and targets within gene boundaries, length-normalizes per
+    gene, then computes:
+      - Poisson NLL on the per-gene total expression across active tracks.
+      - Multinomial NLL on the cross-track (tissue) distribution per gene,
+        weighted by `gene_cross_track_weight` (paper default 5.0).
+
+    Strand-channel filtering is applied: positive-strand genes only see
+    `+`/`.` tracks, negative-strand genes only see `-`/`.` tracks.
+
+    Args:
+        predictions: Scaled predictions, shape `[B, S, C]` (channels-last).
+        targets: Scaled targets in model space, shape `[B, S, C]`.
+        targets_mask: Optional `[B, 1, C]` boolean availability mask over
+            tracks. If None, all tracks are treated as available.
+        gene_mask: Boolean gene mask, shape `[B, S, 2, G]`. Axis 2 dim 0
+            is positive-strand genes, dim 1 is negative-strand. The gene
+            axis must be zero-padded to a fixed `G` for batchability.
+        strand_channel_mask: Boolean track strand-compatibility mask,
+            shape `[2, 1, C]`. Built from per-track strand metadata.
+        gene_cross_track_weight: Inner multiplier on the multinomial term.
+
+    Returns:
+        (loss, aux) where aux carries `gene_loss_total_count` and
+        `gene_loss_positional` for logging/diagnostics.
+    """
+    if gene_mask.dim() != 4:
+        raise ValueError(
+            f"gene_mask must have shape [B, S, 2, G]; got {tuple(gene_mask.shape)}"
+        )
+
+    gene_mask_f = gene_mask.float()
+
+    # gene_length: [B, 2, G] (sum over S)
+    gene_length = gene_mask_f.sum(dim=-3)
+    safe_gene_length = gene_length.unsqueeze(-1).clamp(min=1.0)  # [B, 2, G, 1]
+
+    # Aggregate within gene boundaries, length-normalized: [B, 2, G, C]
+    y_true = torch.einsum('bsc,bszg->bzgc', targets.float(), gene_mask_f) / safe_gene_length
+    y_pred = torch.einsum('bsc,bszg->bzgc', predictions.float(), gene_mask_f) / safe_gene_length
+
+    batch_size, _, num_channels = predictions.shape
+
+    # Reduce track availability mask over S: [B, 1, C]
+    if targets_mask is not None:
+        targets_mask_f = targets_mask.float().amax(dim=-2, keepdim=True)
+    else:
+        targets_mask_f = torch.ones(
+            (batch_size, 1, num_channels), device=predictions.device
+        )
+
+    # Combined mask [B, 2, G, C]: gene present AND track available AND
+    # strand-channel compatibility.
+    gene_present = (gene_length > 0).unsqueeze(-1).float()  # [B, 2, G, 1]
+    track_avail = targets_mask_f.view(batch_size, 1, 1, num_channels)
+    combined_mask = gene_present * track_avail
+    combined_mask = combined_mask * strand_channel_mask.float().unsqueeze(0)
+    combined_mask = combined_mask.bool()
+    combined_mask_f = combined_mask.float()
+
+    # Poisson loss on per-gene totals (sum over channels weighted by combined_mask).
+    total_pred = torch.einsum('bzgc,bzgc->bzg', y_pred, combined_mask_f).unsqueeze(-1)
+    total_true = torch.einsum('bzgc,bzgc->bzg', y_true, combined_mask_f).unsqueeze(-1)
+
+    loss_total_count = poisson_loss(
+        y_true=total_true,
+        y_pred=total_pred,
+        mask=combined_mask.any(dim=-1, keepdim=True),
+    )
+
+    # Magnitude-invariance: divide by max number of active channels per gene.
+    num_active = combined_mask_f.sum(dim=-1, keepdim=True)  # [B, 2, G, 1]
+    loss_total_count = loss_total_count / num_active.max().clamp(min=1.0)
+
+    # Multinomial NLL on cross-track distribution per gene.
+    prob_predictions = y_pred / (total_pred + 1e-7)
+    loss_positional = -y_true * torch.log(prob_predictions + 1e-7)
+    loss_positional = _safe_masked_mean(loss_positional, combined_mask)
+
+    loss = loss_total_count + gene_cross_track_weight * loss_positional
+    aux = {
+        'gene_loss_total_count': loss_total_count,
+        'gene_loss_positional': loss_positional,
+    }
+    return loss, aux

--- a/src/alphagenome_pytorch/training.py
+++ b/src/alphagenome_pytorch/training.py
@@ -318,88 +318,24 @@ class AlphaGenomeLoss(nn.Module):
     def _compute_gene_lfc(
         self,
         *,
-        predictions: torch.Tensor,            # [B, S, C], NLC
-        targets: torch.Tensor,                # [B, S, C], NLC, in model space
-        targets_mask: Optional[torch.Tensor], # [B, 1, C] or None
-        gene_mask: torch.Tensor,              # [B, S, 2, G] bool
-        strand_channel_mask: torch.Tensor,    # [2, 1, C] bool
+        predictions: torch.Tensor,
+        targets: torch.Tensor,
+        targets_mask: Optional[torch.Tensor],
+        gene_mask: torch.Tensor,
+        strand_channel_mask: torch.Tensor,
     ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
-        """Cross-track gene-level loss (Decima-style).
-
-        PyTorch port of upstream `GenomeTracksHead._compute_cross_track_loss`
-        (google-deepmind/alphagenome_research, commit fd44ed0). Aggregates
-        predicted/target counts within gene boundaries, length-normalizes,
-        then computes a weighted sum of:
-          - Poisson NLL on total normalized expression per gene
-          - Multinomial NLL on the cross-track (tissue) distribution per gene
-
-        Returns:
-            (loss, aux) where aux has 'gene_loss_total_count' and
-            'gene_loss_positional' diagnostic scalars.
+        """Thin wrapper around `losses.gene_lfc_loss` using this loss's
+        configured `gene_cross_track_weight`. Kept as a method for
+        clarity at call sites and for backward-compat with existing tests.
         """
-        if gene_mask.dim() != 4:
-            raise ValueError(
-                f"gene_mask must have shape [B, S, 2, G]; got {tuple(gene_mask.shape)}"
-            )
-
-        gene_mask_f = gene_mask.float()
-
-        # gene_length: [B, 2, G] (sum over S)
-        gene_length = gene_mask_f.sum(dim=-3)
-        safe_gene_length = gene_length.unsqueeze(-1).clamp(min=1.0)  # [B, 2, G, 1]
-
-        # Aggregate within gene boundaries, length-normalized: [B, 2, G, C]
-        # einsum 'bsc, bszg -> bzgc' (z = strand axis size 2)
-        y_true = torch.einsum('bsc,bszg->bzgc', targets.float(), gene_mask_f) / safe_gene_length
-        y_pred = torch.einsum('bsc,bszg->bzgc', predictions.float(), gene_mask_f) / safe_gene_length
-
-        batch_size, _, num_channels = predictions.shape
-
-        # Reduce track availability mask over S: [B, 1, C]
-        if targets_mask is not None:
-            targets_mask_f = targets_mask.float().amax(dim=-2, keepdim=True)
-        else:
-            targets_mask_f = torch.ones(
-                (batch_size, 1, num_channels), device=predictions.device
-            )
-
-        # combined_mask [B, 2, G, C]: gene present AND track available AND
-        # strand-channel compatibility (plus genes with +/. tracks; minus
-        # genes with -/. tracks).
-        gene_present = (gene_length > 0).unsqueeze(-1).float()  # [B, 2, G, 1]
-        track_avail = targets_mask_f.view(batch_size, 1, 1, num_channels)
-        combined_mask = gene_present * track_avail
-        combined_mask = combined_mask * strand_channel_mask.float().unsqueeze(0)  # broadcast B
-        combined_mask = combined_mask.bool()
-        combined_mask_f = combined_mask.float()
-
-        # Poisson loss on total counts per gene (sum over channels weighted
-        # by combined_mask, then collapse to [B, 2, G, 1]).
-        total_pred = torch.einsum('bzgc,bzgc->bzg', y_pred, combined_mask_f).unsqueeze(-1)
-        total_true = torch.einsum('bzgc,bzgc->bzg', y_true, combined_mask_f).unsqueeze(-1)
-
-        loss_total_count = losses.poisson_loss(
-            y_true=total_true,
-            y_pred=total_pred,
-            mask=combined_mask.any(dim=-1, keepdim=True),
+        return losses.gene_lfc_loss(
+            predictions=predictions,
+            targets=targets,
+            targets_mask=targets_mask,
+            gene_mask=gene_mask,
+            strand_channel_mask=strand_channel_mask,
+            gene_cross_track_weight=self.gene_cross_track_weight,
         )
-
-        # Magnitude-invariance: divide by the maximum number of active
-        # channels per gene (matches upstream).
-        num_active = combined_mask_f.sum(dim=-1, keepdim=True)  # [B, 2, G, 1]
-        loss_total_count = loss_total_count / num_active.max().clamp(min=1.0)
-
-        # Multinomial NLL on tissue distribution per gene.
-        prob_predictions = y_pred / (total_pred + 1e-7)
-        loss_positional = -y_true * torch.log(prob_predictions + 1e-7)
-        loss_positional = losses._safe_masked_mean(loss_positional, combined_mask)
-
-        loss = loss_total_count + self.gene_cross_track_weight * loss_positional
-        aux = {
-            'gene_loss_total_count': loss_total_count,
-            'gene_loss_positional': loss_positional,
-        }
-        return loss, aux
     
     def _get_device(self, outputs: Dict) -> torch.device:
         """Get device from first tensor in outputs."""

--- a/src/alphagenome_pytorch/training.py
+++ b/src/alphagenome_pytorch/training.py
@@ -5,8 +5,8 @@ Provides configuration, loss aggregation, optimizer/scheduler factories,
 and metrics for training AlphaGenome models.
 """
 
-from dataclasses import dataclass 
-from typing import Dict, List, Optional, Any
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Any, Tuple
 import math
 
 import torch
@@ -14,6 +14,31 @@ import torch.nn as nn
 from torch.optim.lr_scheduler import LambdaLR
 
 from . import losses
+
+
+def _build_strand_channel_mask(strands: Sequence[str]) -> torch.Tensor:
+    """Build a `[2, 1, C]` strand-channel mask from a per-track strand list.
+
+    Mirrors upstream `GenomeTracksHead._get_strand_channel_mask` semantics:
+      - axis 0 dim 0 (positive-strand bucket): `+` and `.` tracks contribute.
+      - axis 0 dim 1 (negative-strand bucket): `-` and `.` tracks contribute.
+
+    Args:
+        strands: Sequence of one-character strand codes per track. Each must
+            be one of `+`, `-`, `.`. Length defines C.
+
+    Returns:
+        Bool tensor of shape `[2, 1, C]`.
+    """
+    valid = {"+", "-", "."}
+    invalid = sorted({s for s in strands if s not in valid})
+    if invalid:
+        raise ValueError(
+            f"track strands must be one of {sorted(valid)}; got invalid values: {invalid}"
+        )
+    plus_compat = torch.tensor([s in ("+", ".") for s in strands], dtype=torch.bool)
+    minus_compat = torch.tensor([s in ("-", ".") for s in strands], dtype=torch.bool)
+    return torch.stack([plus_compat, minus_compat], dim=0).unsqueeze(1)  # [2, 1, C]
 
 
 @dataclass
@@ -86,6 +111,9 @@ class AlphaGenomeLoss(nn.Module):
         head_weights: Optional[Dict[str, float]] = None,
         multinomial_resolution: int = 128,
         positional_weight: float = 5.0,  # JAX production value
+        gene_loss_weights: Optional[Dict[str, float]] = None,
+        gene_cross_track_weight: float = 5.0,
+        track_strands: Optional[Dict[str, Sequence[str]]] = None,
     ):
         super().__init__()
         self.model = model
@@ -93,6 +121,29 @@ class AlphaGenomeLoss(nn.Module):
         self.head_weights = head_weights or DEFAULT_HEAD_WEIGHTS
         self.multinomial_resolution = multinomial_resolution
         self.positional_weight = positional_weight
+
+        # Gene LFC loss config (B3.2 / Decima-style).
+        # `gene_loss_weights[head]` is the OUTER multiplier on the head's gene
+        # LFC term, not on the head's overall loss. Default empty means off.
+        # `gene_cross_track_weight` is the INNER multiplier on the multinomial
+        # (positional) component within the gene LFC term; paper value 5.0.
+        self.gene_loss_weights: Dict[str, float] = dict(gene_loss_weights or {})
+        self.gene_cross_track_weight = gene_cross_track_weight
+
+        # Per-head strand-channel masks `[2, 1, C]` registered as buffers so
+        # they follow `.to(device)` with the loss module. Stored under
+        # mangled attribute names because `register_buffer` does not accept
+        # nested keys; we look them up via `_get_strand_channel_mask(head)`.
+        self._strand_mask_heads: List[str] = []
+        if track_strands:
+            for head, strands in track_strands.items():
+                buffer_name = f"_strand_channel_mask__{head}"
+                self.register_buffer(buffer_name, _build_strand_channel_mask(strands))
+                self._strand_mask_heads.append(head)
+
+    def _get_strand_channel_mask(self, head: str) -> Optional[torch.Tensor]:
+        """Return the `[2, 1, C]` strand-channel mask for a head, or None."""
+        return getattr(self, f"_strand_channel_mask__{head}", None)
     
     def forward(
         self,
@@ -100,6 +151,7 @@ class AlphaGenomeLoss(nn.Module):
         targets: Dict[str, torch.Tensor],
         organism_index: torch.Tensor,
         masks: Optional[Dict[str, torch.Tensor]] = None,
+        gene_mask: Optional[torch.Tensor] = None,
     ) -> Dict[str, torch.Tensor]:
         """Compute per-head losses and aggregate.
 
@@ -108,6 +160,9 @@ class AlphaGenomeLoss(nn.Module):
             targets: Target values dict with same structure as outputs.
             organism_index: Organism indices (B,). Required for target scaling.
             masks: Optional boolean masks dict for each head.
+            gene_mask: Optional `[B, S, 2, G]` gene-body mask for the gene
+                LFC training loss. Only consumed by heads with a non-zero
+                entry in `self.gene_loss_weights`.
 
         Returns:
             Dict with 'loss' (total), and per-head losses like 'atac_loss', etc.
@@ -130,17 +185,18 @@ class AlphaGenomeLoss(nn.Module):
 
             # Compute loss based on head type
             head_loss = self._compute_head_loss(
-                head, head_output, head_target, head_mask, organism_index
+                head, head_output, head_target, head_mask, organism_index,
+                gene_mask=gene_mask,
             )
-            
+
             head_losses[f'{head}_loss'] = head_loss
             total_loss = total_loss + self.head_weights.get(head, 1.0) * head_loss
             num_heads += 1
-        
+
         # Average across heads
         if num_heads > 0:
             total_loss = total_loss / num_heads
-            
+
         head_losses['loss'] = total_loss
         return head_losses
     
@@ -151,6 +207,7 @@ class AlphaGenomeLoss(nn.Module):
         target: torch.Tensor,
         mask: Optional[torch.Tensor],
         organism_index: torch.Tensor,
+        gene_mask: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Compute loss for a single head.
 
@@ -158,7 +215,9 @@ class AlphaGenomeLoss(nn.Module):
         and scales targets to match before loss computation.
 
         Uses multinomial loss for profile heads (ATAC, DNase, etc.)
-        and MSE for aggregate/contact map heads.
+        and MSE for aggregate/contact map heads. Optionally adds the gene
+        LFC term (Decima-style cross-track loss) when this head has a
+        non-zero entry in `self.gene_loss_weights`.
         """
         # Handle resolution dict outputs (e.g., {1: tensor, 128: tensor})
         resolution = None
@@ -183,7 +242,7 @@ class AlphaGenomeLoss(nn.Module):
                 num_tracks = self.model.heads[head].num_tracks
                 if output.shape[-2] == num_tracks and output.shape[-1] != num_tracks:
                     is_channels_last = False
-            
+
             if is_channels_last:
                 num_channels = output.shape[-1]
                 mask = torch.ones((batch_size, 1, num_channels), dtype=torch.bool, device=output.device)
@@ -216,7 +275,131 @@ class AlphaGenomeLoss(nn.Module):
             positional_weight=self.positional_weight,
             channels_last=is_channels_last,
         )
-        return result['loss']
+        head_loss = result['loss']
+
+        # Optional gene LFC (cross-track) loss. Mirrors upstream's
+        # `_compute_cross_track_loss`; gated on (a) head has a non-zero
+        # gene_loss_weight, (b) gene_mask is present this batch, and
+        # (c) we are at 1bp resolution (matching upstream which only
+        # threads gene_mask through resolution == 1).
+        gene_w = self.gene_loss_weights.get(head, 0.0)
+        if gene_w > 0 and gene_mask is not None and resolution == 1:
+            # multinomial_loss internally normalizes to NLC; re-derive that
+            # form here for the gene LFC einsum, which expects [B, S, C].
+            if not is_channels_last:
+                pred_nlc = output.transpose(-1, -2).contiguous()
+                target_nlc = scaled_target.transpose(-1, -2).contiguous()
+                track_mask_nlc = mask.transpose(-1, -2).contiguous()
+            else:
+                pred_nlc = output
+                target_nlc = scaled_target
+                track_mask_nlc = mask
+
+            strand_channel_mask = self._get_strand_channel_mask(head)
+            if strand_channel_mask is None:
+                raise ValueError(
+                    f"head '{head}' has gene_loss_weight={gene_w} but no "
+                    f"track_strands were provided to AlphaGenomeLoss. "
+                    f"Pass `track_strands={{'{head}': '<+/-/. per track>'}}` "
+                    f"so the strand-channel mask can be built."
+                )
+
+            gene_loss, _ = self._compute_gene_lfc(
+                predictions=pred_nlc,
+                targets=target_nlc,
+                targets_mask=track_mask_nlc,
+                gene_mask=gene_mask,
+                strand_channel_mask=strand_channel_mask,
+            )
+            head_loss = head_loss + gene_w * gene_loss
+
+        return head_loss
+
+    def _compute_gene_lfc(
+        self,
+        *,
+        predictions: torch.Tensor,            # [B, S, C], NLC
+        targets: torch.Tensor,                # [B, S, C], NLC, in model space
+        targets_mask: Optional[torch.Tensor], # [B, 1, C] or None
+        gene_mask: torch.Tensor,              # [B, S, 2, G] bool
+        strand_channel_mask: torch.Tensor,    # [2, 1, C] bool
+    ) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:
+        """Cross-track gene-level loss (Decima-style).
+
+        PyTorch port of upstream `GenomeTracksHead._compute_cross_track_loss`
+        (google-deepmind/alphagenome_research, commit fd44ed0). Aggregates
+        predicted/target counts within gene boundaries, length-normalizes,
+        then computes a weighted sum of:
+          - Poisson NLL on total normalized expression per gene
+          - Multinomial NLL on the cross-track (tissue) distribution per gene
+
+        Returns:
+            (loss, aux) where aux has 'gene_loss_total_count' and
+            'gene_loss_positional' diagnostic scalars.
+        """
+        if gene_mask.dim() != 4:
+            raise ValueError(
+                f"gene_mask must have shape [B, S, 2, G]; got {tuple(gene_mask.shape)}"
+            )
+
+        gene_mask_f = gene_mask.float()
+
+        # gene_length: [B, 2, G] (sum over S)
+        gene_length = gene_mask_f.sum(dim=-3)
+        safe_gene_length = gene_length.unsqueeze(-1).clamp(min=1.0)  # [B, 2, G, 1]
+
+        # Aggregate within gene boundaries, length-normalized: [B, 2, G, C]
+        # einsum 'bsc, bszg -> bzgc' (z = strand axis size 2)
+        y_true = torch.einsum('bsc,bszg->bzgc', targets.float(), gene_mask_f) / safe_gene_length
+        y_pred = torch.einsum('bsc,bszg->bzgc', predictions.float(), gene_mask_f) / safe_gene_length
+
+        batch_size, _, num_channels = predictions.shape
+
+        # Reduce track availability mask over S: [B, 1, C]
+        if targets_mask is not None:
+            targets_mask_f = targets_mask.float().amax(dim=-2, keepdim=True)
+        else:
+            targets_mask_f = torch.ones(
+                (batch_size, 1, num_channels), device=predictions.device
+            )
+
+        # combined_mask [B, 2, G, C]: gene present AND track available AND
+        # strand-channel compatibility (plus genes with +/. tracks; minus
+        # genes with -/. tracks).
+        gene_present = (gene_length > 0).unsqueeze(-1).float()  # [B, 2, G, 1]
+        track_avail = targets_mask_f.view(batch_size, 1, 1, num_channels)
+        combined_mask = gene_present * track_avail
+        combined_mask = combined_mask * strand_channel_mask.float().unsqueeze(0)  # broadcast B
+        combined_mask = combined_mask.bool()
+        combined_mask_f = combined_mask.float()
+
+        # Poisson loss on total counts per gene (sum over channels weighted
+        # by combined_mask, then collapse to [B, 2, G, 1]).
+        total_pred = torch.einsum('bzgc,bzgc->bzg', y_pred, combined_mask_f).unsqueeze(-1)
+        total_true = torch.einsum('bzgc,bzgc->bzg', y_true, combined_mask_f).unsqueeze(-1)
+
+        loss_total_count = losses.poisson_loss(
+            y_true=total_true,
+            y_pred=total_pred,
+            mask=combined_mask.any(dim=-1, keepdim=True),
+        )
+
+        # Magnitude-invariance: divide by the maximum number of active
+        # channels per gene (matches upstream).
+        num_active = combined_mask_f.sum(dim=-1, keepdim=True)  # [B, 2, G, 1]
+        loss_total_count = loss_total_count / num_active.max().clamp(min=1.0)
+
+        # Multinomial NLL on tissue distribution per gene.
+        prob_predictions = y_pred / (total_pred + 1e-7)
+        loss_positional = -y_true * torch.log(prob_predictions + 1e-7)
+        loss_positional = losses._safe_masked_mean(loss_positional, combined_mask)
+
+        loss = loss_total_count + self.gene_cross_track_weight * loss_positional
+        aux = {
+            'gene_loss_total_count': loss_total_count,
+            'gene_loss_positional': loss_positional,
+        }
+        return loss, aux
     
     def _get_device(self, outputs: Dict) -> torch.device:
         """Get device from first tensor in outputs."""
@@ -287,4 +470,5 @@ __all__ = [
     'create_optimizer',
     'create_scheduler',
     'DEFAULT_HEAD_WEIGHTS',
+    '_build_strand_channel_mask',
 ]

--- a/tests/integration/test_gene_lfc_e2e.py
+++ b/tests/integration/test_gene_lfc_e2e.py
@@ -1,0 +1,236 @@
+"""End-to-end smoke test for the gene LFC training path.
+
+Not a model-correctness test. Verifies that the dataset → DataLoader →
+compute_finetuning_loss path threads `gene_mask` through cleanly when
+configured: shapes line up, default_collate handles the 3-tuple, and a
+backward pass through the gene LFC term produces a finite gradient.
+
+Synthetic everything: tiny FASTA, one bigwig per RNA-seq track, a 2-line
+BED, and a hand-rolled GTF with one protein-coding gene fully contained
+in the test window.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+from torch.utils.data import DataLoader
+
+from alphagenome_pytorch.extensions.finetuning.datasets import GenomicDataset
+from alphagenome_pytorch.extensions.finetuning.gene_annotation import (
+    GeneMaskExtractor,
+    derive_g_max,
+    load_gene_table,
+)
+from alphagenome_pytorch.extensions.finetuning.training import (
+    compute_finetuning_loss,
+)
+from alphagenome_pytorch.training import _build_strand_channel_mask
+
+pyBigWig = pytest.importorskip("pyBigWig")
+pyfaidx = pytest.importorskip("pyfaidx")
+pyranges = pytest.importorskip("pyranges")
+
+
+CHROM = "chr1"
+CHROM_SIZE = 4096
+SEQ_LEN = 2048
+
+
+@pytest.fixture
+def setup_files(tmp_path: Path):
+    """Build a tiny self-contained training corpus on disk.
+
+    Layout:
+      - hg38_tiny.fa: one chromosome of A's
+      - track_{plus,minus,plus2,minus2}.bw: 4 bigwigs with simple ramps
+      - regions.bed: one window centered at chr1:1024 (covering [0, 2048))
+      - genes.gtf: one + strand and one - strand gene fully inside the window
+    """
+    fasta_path = tmp_path / "hg38_tiny.fa"
+    with open(fasta_path, "w") as f:
+        f.write(f">{CHROM}\n{'A' * CHROM_SIZE}\n")
+
+    bw_paths = []
+    # Bigwigs require strictly increasing, non-overlapping intervals.
+    # Fixed positions across tracks; per-track signal differs by track index.
+    starts = [200, 300, 400, 500, 600, 1100, 1200, 1300]
+    ends = [220, 320, 420, 520, 620, 1120, 1220, 1320]
+    for i, name in enumerate(["plus", "minus", "plus2", "minus2"]):
+        path = tmp_path / f"track_{name}.bw"
+        bw = pyBigWig.open(str(path), "w")
+        bw.addHeader([(CHROM, CHROM_SIZE)])
+        bw.addEntries(
+            [CHROM] * len(starts),
+            starts,
+            ends=ends,
+            values=[float(j + 1 + i) for j in range(len(starts))],
+        )
+        bw.close()
+        bw_paths.append(str(path))
+
+    bed_path = tmp_path / "regions.bed"
+    with open(bed_path, "w") as f:
+        f.write(f"{CHROM}\t0\t{SEQ_LEN}\n")
+        f.write(f"{CHROM}\t{CHROM_SIZE - SEQ_LEN}\t{CHROM_SIZE}\n")
+
+    # Two genes inside [0, 2048) — one plus, one minus, both protein_coding.
+    gtf_path = tmp_path / "genes.gtf"
+    with open(gtf_path, "w") as f:
+        f.write(
+            'chr1\tHAVANA\tgene\t101\t800\t.\t+\t.\t'
+            'gene_id "GENE-PLUS"; gene_name "PLUS"; gene_type "protein_coding";\n'
+        )
+        f.write(
+            'chr1\tHAVANA\tgene\t1001\t1700\t.\t-\t.\t'
+            'gene_id "GENE-MINUS"; gene_name "MINUS"; gene_type "protein_coding";\n'
+        )
+
+    return {
+        "fasta": str(fasta_path),
+        "bigwigs": bw_paths,
+        "bed": str(bed_path),
+        "gtf": str(gtf_path),
+    }
+
+
+@pytest.mark.integration
+def test_dataloader_yields_three_tuple_with_gene_mask(setup_files):
+    """DataLoader's default_collate should batch the 3-tuple element-wise,
+    yielding (sequence, targets_dict, gene_mask) as batched tensors."""
+    table = load_gene_table(setup_files["gtf"])
+    extractor = GeneMaskExtractor(table)
+
+    # Project BED windows to fixed length, matching GenomicDataset's behavior.
+    intervals = [(CHROM, 0, SEQ_LEN), (CHROM, CHROM_SIZE - SEQ_LEN, CHROM_SIZE)]
+    g_max = derive_g_max(extractor, intervals)
+    assert g_max >= 1  # at least one gene fits in window 0
+
+    ds = GenomicDataset(
+        genome_fasta=setup_files["fasta"],
+        bigwig_files=setup_files["bigwigs"],
+        bed_file=setup_files["bed"],
+        sequence_length=SEQ_LEN,
+        resolutions=(1,),
+        gene_mask_extractor=extractor,
+        g_max=g_max,
+    )
+    loader = DataLoader(ds, batch_size=2, shuffle=False, num_workers=0)
+    batch = next(iter(loader))
+    assert len(batch) == 3
+    sequences, targets_dict, gene_mask = batch
+    assert sequences.shape == (2, SEQ_LEN, 4)
+    assert 1 in targets_dict
+    assert targets_dict[1].shape == (2, SEQ_LEN, 4)  # 4 tracks
+    assert gene_mask.shape == (2, SEQ_LEN, 2, g_max)
+    assert gene_mask.dtype == torch.bool
+
+
+@pytest.mark.integration
+def test_compute_finetuning_loss_with_gene_mask_backward(setup_files):
+    """End-to-end: build dataset, fetch a batch, run compute_finetuning_loss
+    with gene LFC enabled, do a backward, assert finite gradient.
+
+    The "predictions" here are a small learnable parameter tensor — we don't
+    need a real model to exercise the loss-side wiring.
+    """
+    table = load_gene_table(setup_files["gtf"])
+    extractor = GeneMaskExtractor(table)
+    intervals = [(CHROM, 0, SEQ_LEN)]
+    g_max = derive_g_max(extractor, intervals)
+
+    ds = GenomicDataset(
+        genome_fasta=setup_files["fasta"],
+        bigwig_files=setup_files["bigwigs"],
+        bed_file=setup_files["bed"],
+        sequence_length=SEQ_LEN,
+        resolutions=(1,),
+        gene_mask_extractor=extractor,
+        g_max=g_max,
+    )
+    loader = DataLoader(ds, batch_size=1, shuffle=False, num_workers=0)
+    sequences, targets_dict, gene_mask = next(iter(loader))
+
+    # Stand-in predictions: same shape as targets, requires_grad for backward.
+    targets_1bp = targets_dict[1]
+    preds_1bp = torch.rand_like(targets_1bp).requires_grad_(True)
+    predictions = {1: preds_1bp}
+    targets = {1: targets_1bp}
+
+    strand_mask = _build_strand_channel_mask("+-+-")  # 4 tracks
+    loss, loss_dict = compute_finetuning_loss(
+        predictions=predictions,
+        targets=targets,
+        resolution_weights={1: 1.0},
+        positional_weight=1.0,
+        device=torch.device("cpu"),
+        gene_mask=gene_mask,
+        gene_loss_weight=0.1,  # paper value
+        gene_cross_track_weight=5.0,
+        strand_channel_mask=strand_mask,
+    )
+    assert torch.isfinite(loss)
+    assert loss.item() > 0
+    assert "loss_gene_lfc" in loss_dict
+    assert "loss_gene_total_count" in loss_dict
+    assert "loss_gene_positional" in loss_dict
+
+    loss.backward()
+    assert preds_1bp.grad is not None
+    assert torch.all(torch.isfinite(preds_1bp.grad))
+
+
+@pytest.mark.integration
+def test_loss_off_when_weight_zero(setup_files):
+    """gene_loss_weight=0.0 with gene_mask present must give the exact same
+    loss as the no-gene-mask path. Pins the "default-off" contract."""
+    table = load_gene_table(setup_files["gtf"])
+    extractor = GeneMaskExtractor(table)
+    intervals = [(CHROM, 0, SEQ_LEN)]
+    g_max = derive_g_max(extractor, intervals)
+
+    ds_with = GenomicDataset(
+        genome_fasta=setup_files["fasta"],
+        bigwig_files=setup_files["bigwigs"],
+        bed_file=setup_files["bed"],
+        sequence_length=SEQ_LEN,
+        resolutions=(1,),
+        gene_mask_extractor=extractor,
+        g_max=g_max,
+    )
+    ds_without = GenomicDataset(
+        genome_fasta=setup_files["fasta"],
+        bigwig_files=setup_files["bigwigs"],
+        bed_file=setup_files["bed"],
+        sequence_length=SEQ_LEN,
+        resolutions=(1,),
+    )
+
+    sequences_w, targets_w, gene_mask = ds_with[0]
+    sequences_wo, targets_wo = ds_without[0]
+    # Targets/sequences identical regardless of gene-mask plumbing.
+    torch.testing.assert_close(sequences_w, sequences_wo)
+    torch.testing.assert_close(targets_w[1], targets_wo[1])
+
+    preds = {1: torch.rand_like(targets_w[1]).unsqueeze(0) + 0.5}
+    targets = {1: targets_w[1].unsqueeze(0)}
+    strand_mask = _build_strand_channel_mask("+-+-")
+
+    loss_no_gene, _ = compute_finetuning_loss(
+        predictions=preds, targets=targets,
+        resolution_weights={1: 1.0}, positional_weight=1.0,
+        device=torch.device("cpu"),
+    )
+    loss_zero_w, _ = compute_finetuning_loss(
+        predictions=preds, targets=targets,
+        resolution_weights={1: 1.0}, positional_weight=1.0,
+        device=torch.device("cpu"),
+        gene_mask=gene_mask.unsqueeze(0),
+        gene_loss_weight=0.0,
+        strand_channel_mask=strand_mask,
+    )
+    torch.testing.assert_close(loss_no_gene, loss_zero_w)

--- a/tests/jax_comparison/test_gene_lfc_jax.py
+++ b/tests/jax_comparison/test_gene_lfc_jax.py
@@ -1,0 +1,307 @@
+"""JAX-PyTorch equivalence tests for gene LFC (cross-track) loss.
+
+Verifies that `alphagenome_pytorch.losses.gene_lfc_loss` is numerically
+equivalent to the upstream JAX `GenomeTracksHead._compute_cross_track_loss`
+(google-deepmind/alphagenome_research, commit fd44ed0).
+
+Pattern follows tests/jax_comparison/test_losses_jax.py: inline the JAX
+math as a free helper (the upstream version is a method on a Haiku module
+that pulls strand-channel mask and gene_cross_track_weight from `self`,
+both of which we pass in here as plain arrays/floats), then compare
+JAX-vs-PyTorch results to `decimal=5`.
+
+Run: pytest tests/jax_comparison/test_gene_lfc_jax.py -v
+"""
+
+import numpy as np
+import pytest
+
+# Skip module if JAX is unavailable.
+pytest.importorskip("jax")
+pytest.importorskip("jax.numpy")
+
+import jax.numpy as jnp
+
+
+@pytest.fixture
+def jax_losses():
+    from alphagenome_research.model import losses as jax_losses
+    return jax_losses
+
+
+@pytest.fixture
+def torch_losses():
+    from alphagenome_pytorch import losses as torch_losses
+    return torch_losses
+
+
+@pytest.fixture
+def torch():
+    import torch
+    return torch
+
+
+def _jax_gene_lfc(
+    *,
+    jax_losses,
+    organism_index,
+    predictions,
+    targets,
+    targets_mask,
+    gene_mask,
+    strand_channel_mask,
+    gene_cross_track_weight,
+):
+    """Verbatim port of upstream `_compute_cross_track_loss` body.
+
+    The only differences vs. the upstream method:
+      - `strand_channel_mask` is passed in instead of read from
+        `self._strand_channel_mask`. Shape `[num_organisms, 2, 1, C]`.
+      - `gene_cross_track_weight` is a parameter instead of `self.`.
+      - The chex rank check is omitted; not needed for a numerical test.
+
+    Mirrors upstream's `_get_param_for_index` via simple advanced indexing.
+    """
+    gene_length = jnp.sum(gene_mask.astype(jnp.float32), axis=-3)
+    safe_gene_length = jnp.maximum(gene_length[..., None], 1.0)
+
+    y_true = (
+        jnp.einsum('bsc,bs2g->b2gc', targets.astype(jnp.float32), gene_mask)
+        / safe_gene_length
+    )
+    y_pred = (
+        jnp.einsum('bsc,bs2g->b2gc', predictions.astype(jnp.float32), gene_mask)
+        / safe_gene_length
+    )
+
+    batch_size, *_, num_channels = predictions.shape
+    if targets_mask is not None:
+        targets_mask = jnp.max(
+            targets_mask.astype(jnp.float32), axis=-2, keepdims=True
+        )
+    else:
+        targets_mask = jnp.ones((batch_size, 1, num_channels))
+    combined_mask = (gene_length > 0)[..., None] * targets_mask.reshape(
+        batch_size, 1, 1, num_channels
+    )
+
+    # Per-organism strand mask, broadcast to [B, 2, 1, C].
+    strand_mask = jnp.asarray(strand_channel_mask)[(organism_index,)]
+    combined_mask = (combined_mask * strand_mask).astype(bool)
+
+    total_pred = jnp.einsum('b2gc,b2gc->b2g', y_pred, combined_mask)[..., None]
+    total_true = jnp.einsum('b2gc,b2gc->b2g', y_true, combined_mask)[..., None]
+
+    loss_total_count = jax_losses.poisson_loss(
+        y_true=total_true,
+        y_pred=total_pred,
+        mask=combined_mask.any(axis=-1, keepdims=True),
+    )
+    num_active = jnp.sum(
+        combined_mask.astype(jnp.float32), axis=-1, keepdims=True
+    )
+    loss_total_count = loss_total_count / jnp.maximum(jnp.max(num_active), 1.0)
+
+    prob_predictions = y_pred.astype(jnp.float32) / (total_pred + 1e-7)
+    loss_positional = -y_true * jnp.log(prob_predictions + 1e-7)
+    # Upstream renamed `_safe_masked_mean` → `safe_masked_mean` in fd44ed0;
+    # fall back to the private name for older checkouts.
+    smm = getattr(
+        jax_losses, "safe_masked_mean",
+        getattr(jax_losses, "_safe_masked_mean", None),
+    )
+    loss_positional = smm(loss_positional, combined_mask)
+
+    return loss_total_count + gene_cross_track_weight * loss_positional
+
+
+def _make_inputs(B=2, S=64, C=4, G=3, num_organisms=1, seed=0):
+    """Synthetic inputs for both implementations. Returns numpy arrays
+    so each implementation does its own jnp / torch.tensor conversion.
+    """
+    rng = np.random.default_rng(seed)
+    predictions = (rng.random((B, S, C)).astype(np.float32) + 0.5)
+    targets = (rng.random((B, S, C)).astype(np.float32) + 0.5)
+    targets_mask = np.ones((B, 1, C), dtype=bool)
+
+    # Place a few genes inside the window. + strand on bucket 0,
+    # - strand on bucket 1. G slots, some zero-padded.
+    gene_mask = np.zeros((B, S, 2, G), dtype=bool)
+    gene_mask[:, 8:24, 0, 0] = True   # + strand gene
+    gene_mask[:, 30:50, 1, 1] = True  # - strand gene
+    # gene index 2 left as zero-padding to exercise the gene_length=0 path.
+
+    # `[num_organisms, 2, 1, C]` strand-channel mask. Tracks alternate +/-
+    # for the first half, '.' for the rest.
+    strands_per_org = []
+    for _ in range(num_organisms):
+        plus = np.array([(c % 2 == 0) or c >= C // 2 for c in range(C)])
+        minus = np.array([(c % 2 == 1) or c >= C // 2 for c in range(C)])
+        strands_per_org.append(np.stack([plus, minus])[:, None, :])
+    strand_channel_mask = np.stack(strands_per_org)  # [num_orgs, 2, 1, C]
+
+    organism_index = np.zeros((B,), dtype=np.int32)
+    return predictions, targets, targets_mask, gene_mask, strand_channel_mask, organism_index
+
+
+@pytest.mark.jax
+class TestGeneLFCLossEquivalence:
+    """Numerical parity between PyTorch `gene_lfc_loss` and a verbatim
+    JAX port of upstream's `_compute_cross_track_loss`."""
+
+    def test_random_inputs(self, jax_losses, torch_losses, torch):
+        preds, targets, tmask, gmask, scm, oid = _make_inputs(seed=42)
+        gctw = 5.0
+
+        jax_loss = _jax_gene_lfc(
+            jax_losses=jax_losses,
+            organism_index=jnp.array(oid),
+            predictions=jnp.array(preds),
+            targets=jnp.array(targets),
+            targets_mask=jnp.array(tmask),
+            gene_mask=jnp.array(gmask),
+            strand_channel_mask=jnp.array(scm),
+            gene_cross_track_weight=gctw,
+        )
+
+        # PyTorch: strand_channel_mask is [2, 1, C] (no organism dim) since
+        # all organism_index values point at the same row.
+        torch_loss, _ = torch_losses.gene_lfc_loss(
+            predictions=torch.tensor(preds),
+            targets=torch.tensor(targets),
+            targets_mask=torch.tensor(tmask),
+            gene_mask=torch.tensor(gmask),
+            strand_channel_mask=torch.tensor(scm[0]),
+            gene_cross_track_weight=gctw,
+        )
+        np.testing.assert_almost_equal(
+            float(jax_loss), torch_loss.item(), decimal=5
+        )
+
+    def test_with_partial_track_mask(self, jax_losses, torch_losses, torch):
+        """Some tracks unavailable → both implementations must drop them
+        identically when computing per-gene totals and tissue distribution."""
+        preds, targets, _, gmask, scm, oid = _make_inputs(seed=7)
+        # Mask out 2nd and 4th tracks (out of 4).
+        tmask = np.array([[[True, False, True, False]]] * preds.shape[0], dtype=bool)
+        gctw = 5.0
+
+        jax_loss = _jax_gene_lfc(
+            jax_losses=jax_losses,
+            organism_index=jnp.array(oid),
+            predictions=jnp.array(preds),
+            targets=jnp.array(targets),
+            targets_mask=jnp.array(tmask),
+            gene_mask=jnp.array(gmask),
+            strand_channel_mask=jnp.array(scm),
+            gene_cross_track_weight=gctw,
+        )
+        torch_loss, _ = torch_losses.gene_lfc_loss(
+            predictions=torch.tensor(preds),
+            targets=torch.tensor(targets),
+            targets_mask=torch.tensor(tmask),
+            gene_mask=torch.tensor(gmask),
+            strand_channel_mask=torch.tensor(scm[0]),
+            gene_cross_track_weight=gctw,
+        )
+        np.testing.assert_almost_equal(
+            float(jax_loss), torch_loss.item(), decimal=5
+        )
+
+    def test_no_track_mask_defaults_to_all_available(
+        self, jax_losses, torch_losses, torch
+    ):
+        """JAX takes None and replaces with ones. Our PyTorch impl does the
+        same. Match must hold."""
+        preds, targets, _, gmask, scm, oid = _make_inputs(seed=11)
+        gctw = 5.0
+
+        jax_loss = _jax_gene_lfc(
+            jax_losses=jax_losses,
+            organism_index=jnp.array(oid),
+            predictions=jnp.array(preds),
+            targets=jnp.array(targets),
+            targets_mask=None,
+            gene_mask=jnp.array(gmask),
+            strand_channel_mask=jnp.array(scm),
+            gene_cross_track_weight=gctw,
+        )
+        torch_loss, _ = torch_losses.gene_lfc_loss(
+            predictions=torch.tensor(preds),
+            targets=torch.tensor(targets),
+            targets_mask=None,
+            gene_mask=torch.tensor(gmask),
+            strand_channel_mask=torch.tensor(scm[0]),
+            gene_cross_track_weight=gctw,
+        )
+        np.testing.assert_almost_equal(
+            float(jax_loss), torch_loss.item(), decimal=5
+        )
+
+    def test_zero_padded_gene_columns_are_inert(
+        self, jax_losses, torch_losses, torch
+    ):
+        """The trailing G_max - num_genes columns of gene_mask are all zero
+        (i.e. gene_length=0 for those slots). Both implementations must
+        produce the same loss whether G is sized tightly or generously."""
+        preds, targets, tmask, gmask_tight, scm, oid = _make_inputs(G=2, seed=3)
+        # Pad the gene axis with extra zero columns (G=2 → G=5).
+        B, S = gmask_tight.shape[:2]
+        gmask_padded = np.concatenate(
+            [gmask_tight, np.zeros((B, S, 2, 3), dtype=bool)], axis=-1
+        )
+        assert gmask_padded.shape[-1] == 5
+        gctw = 5.0
+
+        for gmask_variant in (gmask_tight, gmask_padded):
+            jax_loss = _jax_gene_lfc(
+                jax_losses=jax_losses,
+                organism_index=jnp.array(oid),
+                predictions=jnp.array(preds),
+                targets=jnp.array(targets),
+                targets_mask=jnp.array(tmask),
+                gene_mask=jnp.array(gmask_variant),
+                strand_channel_mask=jnp.array(scm),
+                gene_cross_track_weight=gctw,
+            )
+            torch_loss, _ = torch_losses.gene_lfc_loss(
+                predictions=torch.tensor(preds),
+                targets=torch.tensor(targets),
+                targets_mask=torch.tensor(tmask),
+                gene_mask=torch.tensor(gmask_variant),
+                strand_channel_mask=torch.tensor(scm[0]),
+                gene_cross_track_weight=gctw,
+            )
+            np.testing.assert_almost_equal(
+                float(jax_loss), torch_loss.item(), decimal=5
+            )
+
+    def test_varying_gene_cross_track_weight(
+        self, jax_losses, torch_losses, torch
+    ):
+        """Inner multinomial weight: paper uses 5.0 but the parity must hold
+        for any value. Pin a few."""
+        preds, targets, tmask, gmask, scm, oid = _make_inputs(seed=99)
+        for gctw in (0.0, 1.0, 5.0, 10.0):
+            jax_loss = _jax_gene_lfc(
+                jax_losses=jax_losses,
+                organism_index=jnp.array(oid),
+                predictions=jnp.array(preds),
+                targets=jnp.array(targets),
+                targets_mask=jnp.array(tmask),
+                gene_mask=jnp.array(gmask),
+                strand_channel_mask=jnp.array(scm),
+                gene_cross_track_weight=gctw,
+            )
+            torch_loss, _ = torch_losses.gene_lfc_loss(
+                predictions=torch.tensor(preds),
+                targets=torch.tensor(targets),
+                targets_mask=torch.tensor(tmask),
+                gene_mask=torch.tensor(gmask),
+                strand_channel_mask=torch.tensor(scm[0]),
+                gene_cross_track_weight=gctw,
+            )
+            np.testing.assert_almost_equal(
+                float(jax_loss), torch_loss.item(), decimal=5,
+                err_msg=f"mismatch at gene_cross_track_weight={gctw}",
+            )

--- a/tests/unit/test_dataset_gene_mask.py
+++ b/tests/unit/test_dataset_gene_mask.py
@@ -20,9 +20,10 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import pyBigWig
 import pytest
 import torch
+
+pyBigWig = pytest.importorskip("pyBigWig")
 
 from alphagenome_pytorch.extensions.finetuning.datasets import (
     GenomicDataset,

--- a/tests/unit/test_dataset_gene_mask.py
+++ b/tests/unit/test_dataset_gene_mask.py
@@ -1,0 +1,224 @@
+"""Tests for gene_mask integration in GenomicDataset / MultimodalDataset.
+
+Verifies that:
+  - Without `gene_mask_extractor`, datasets keep their original 2-tuple
+    return shape (no behavioral regression).
+  - With an extractor + g_max, GenomicDataset returns a 3-tuple whose
+    third element is a `[S, 2, g_max]` bool tensor padded along the
+    gene axis.
+  - MultimodalDataset propagates gene_mask from the first dataset that
+    yields one (gene_mask is sample-level, not per-modality).
+  - g_max overflow raises a clear error.
+  - Forgetting g_max when extractor is set raises in the constructor.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pyBigWig
+import pytest
+import torch
+
+from alphagenome_pytorch.extensions.finetuning.datasets import (
+    GenomicDataset,
+    MultimodalDataset,
+)
+from alphagenome_pytorch.extensions.finetuning.gene_annotation import (
+    GeneMaskExtractor,
+)
+
+
+CHROM = "chr1"
+CHROM_SIZE = 8_192
+
+
+@pytest.fixture
+def tmp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+@pytest.fixture
+def fasta_file(tmp_dir):
+    """Tiny FASTA with one chromosome of A's."""
+    path = tmp_dir / "genome.fa"
+    with open(path, "w") as f:
+        f.write(f">{CHROM}\n")
+        f.write("A" * CHROM_SIZE + "\n")
+    # pyfaidx will create the .fai on first open; nothing else needed here.
+    return str(path)
+
+
+@pytest.fixture
+def bigwig_file(tmp_dir):
+    """Tiny bigwig with constant signal."""
+    path = tmp_dir / "track.bw"
+    bw = pyBigWig.open(str(path), "w")
+    bw.addHeader([(CHROM, CHROM_SIZE)])
+    bw.addEntries(
+        [CHROM] * 4,
+        [1000, 2000, 3000, 4000],
+        ends=[1100, 2100, 3100, 4100],
+        values=[1.0, 2.0, 3.0, 4.0],
+    )
+    bw.close()
+    return str(path)
+
+
+@pytest.fixture
+def bed_file(tmp_dir):
+    """One window centered at 4096 with width 2048."""
+    path = tmp_dir / "regions.bed"
+    with open(path, "w") as f:
+        f.write(f"{CHROM}\t3072\t5120\n")
+    return str(path)
+
+
+@pytest.fixture
+def extractor():
+    """Two genes, one in the test window, one outside."""
+    table = pd.DataFrame(
+        {
+            "Chromosome": [CHROM, CHROM],
+            "Start": [3500, 7000],
+            "End": [4500, 7500],
+            "Strand": ["+", "-"],
+            "gene_id": ["GENE-IN", "GENE-OUT"],
+            "gene_name": ["in", "out"],
+            "gene_type": ["protein_coding", "protein_coding"],
+        }
+    )
+    return GeneMaskExtractor(table)
+
+
+@pytest.mark.unit
+class TestGenomicDatasetGeneMask:
+
+    def test_no_extractor_returns_two_tuple(
+        self, fasta_file, bigwig_file, bed_file
+    ):
+        ds = GenomicDataset(
+            genome_fasta=fasta_file,
+            bigwig_files=[bigwig_file],
+            bed_file=bed_file,
+            sequence_length=2048,
+            resolutions=(1,),
+        )
+        result = ds[0]
+        assert len(result) == 2
+        seq, targets = result
+        assert seq.shape == (2048, 4)
+        assert isinstance(targets, dict)
+
+    def test_with_extractor_returns_three_tuple(
+        self, fasta_file, bigwig_file, bed_file, extractor
+    ):
+        ds = GenomicDataset(
+            genome_fasta=fasta_file,
+            bigwig_files=[bigwig_file],
+            bed_file=bed_file,
+            sequence_length=2048,
+            resolutions=(1,),
+            gene_mask_extractor=extractor,
+            g_max=4,
+        )
+        result = ds[0]
+        assert len(result) == 3
+        seq, targets, gene_mask = result
+        assert seq.shape == (2048, 4)
+        assert gene_mask.shape == (2048, 2, 4)
+        assert gene_mask.dtype == torch.bool
+
+        # Window is [3072, 5120). GENE-IN spans [3500, 4500), so positions
+        # [428, 1428) relative to window. + strand → axis 1 = 0, gene 0.
+        assert gene_mask[:428, 0, 0].sum() == 0
+        assert gene_mask[428:1428, 0, 0].all()
+        assert gene_mask[1428:, 0, 0].sum() == 0
+        # Other gene slots padded zero.
+        assert gene_mask[:, :, 1:].sum() == 0
+
+    def test_extractor_without_g_max_raises(
+        self, fasta_file, bigwig_file, bed_file, extractor
+    ):
+        with pytest.raises(ValueError, match="g_max is None"):
+            GenomicDataset(
+                genome_fasta=fasta_file,
+                bigwig_files=[bigwig_file],
+                bed_file=bed_file,
+                sequence_length=2048,
+                resolutions=(1,),
+                gene_mask_extractor=extractor,
+                g_max=None,
+            )
+
+    def test_g_max_overflow_raises_at_getitem(
+        self, fasta_file, bigwig_file, bed_file
+    ):
+        # Build an extractor with 5 genes contained in the window, but
+        # tell the dataset g_max=2. __getitem__ must raise.
+        table = pd.DataFrame(
+            {
+                "Chromosome": [CHROM] * 5,
+                "Start": list(range(3500, 4000, 100)),
+                "End": list(range(3550, 4050, 100)),
+                "Strand": ["+"] * 5,
+                "gene_id": [f"G{i}" for i in range(5)],
+                "gene_name": [f"g{i}" for i in range(5)],
+                "gene_type": ["protein_coding"] * 5,
+            }
+        )
+        extractor = GeneMaskExtractor(table)
+        ds = GenomicDataset(
+            genome_fasta=fasta_file,
+            bigwig_files=[bigwig_file],
+            bed_file=bed_file,
+            sequence_length=2048,
+            resolutions=(1,),
+            gene_mask_extractor=extractor,
+            g_max=2,
+        )
+        with pytest.raises(ValueError, match="exceeding g_max"):
+            ds[0]
+
+
+@pytest.mark.unit
+class TestMultimodalDatasetGeneMask:
+
+    def test_no_extractor_anywhere_returns_two_tuple(
+        self, fasta_file, bigwig_file, bed_file
+    ):
+        ds = GenomicDataset(
+            genome_fasta=fasta_file, bigwig_files=[bigwig_file],
+            bed_file=bed_file, sequence_length=2048, resolutions=(1,),
+        )
+        multi = MultimodalDataset({"atac": ds})
+        result = multi[0]
+        assert len(result) == 2
+
+    def test_extractor_on_one_dataset_propagates(
+        self, fasta_file, bigwig_file, bed_file, extractor
+    ):
+        # atac: no extractor; rna_seq: has extractor.
+        atac = GenomicDataset(
+            genome_fasta=fasta_file, bigwig_files=[bigwig_file],
+            bed_file=bed_file, sequence_length=2048, resolutions=(1,),
+        )
+        rna = GenomicDataset(
+            genome_fasta=fasta_file, bigwig_files=[bigwig_file],
+            bed_file=bed_file, sequence_length=2048, resolutions=(1,),
+            gene_mask_extractor=extractor, g_max=4,
+        )
+        # Order matters: primary is the first dataset (atac here, with no
+        # extractor). The propagation logic should still fall through to
+        # rna_seq and pick up its gene_mask.
+        multi = MultimodalDataset({"atac": atac, "rna_seq": rna})
+        result = multi[0]
+        assert len(result) == 3
+        seq, modality_targets, gene_mask = result
+        assert set(modality_targets.keys()) == {"atac", "rna_seq"}
+        assert gene_mask.shape == (2048, 2, 4)

--- a/tests/unit/test_gene_annotation.py
+++ b/tests/unit/test_gene_annotation.py
@@ -169,12 +169,12 @@ class TestGeneMaskExtractor:
 @pytest.mark.unit
 class TestDeriveGMax:
 
-    def test_picks_max_plus_headroom(self):
-        # 3 genes in window 1, 1 gene in window 2 → max=2 (GENE-A + GENE-B)
+    def test_returns_exact_observed_max(self):
+        """3 genes in window 1, 0 in window 2 → max=2 (GENE-A + GENE-B contained)."""
         ex = GeneMaskExtractor(_toy_gene_table())
         intervals = [("chr1", 1000, 2000), ("chr1", 0, 500)]
-        g_max = derive_g_max(ex, intervals, headroom=4)
-        assert g_max == 2 + 4
+        g_max = derive_g_max(ex, intervals)
+        assert g_max == 2
 
     def test_propagates_extractor_ceiling_error(self):
         """If a scanned window blows past the extractor's PAD ceiling,

--- a/tests/unit/test_gene_annotation.py
+++ b/tests/unit/test_gene_annotation.py
@@ -1,0 +1,243 @@
+"""Unit tests for the gene annotation extractor used by the gene LFC loss.
+
+Covers `load_gene_table`, `GeneMaskExtractor.extract`, the LRU cache,
+strand bucketing, the PAD_NUM_GENES_CEILING guard, and `derive_g_max`.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from alphagenome_pytorch.extensions.finetuning.gene_annotation import (
+    GeneMaskExtractor,
+    PAD_NUM_GENES_CEILING,
+    derive_g_max,
+    load_gene_table,
+)
+
+
+def _toy_gene_table() -> pd.DataFrame:
+    """Three protein-coding genes on chr1, one on chr2.
+
+    Designed so a window chr1:1000-2000 fully contains GENE-A (+) and GENE-B (+),
+    overlaps but does not contain GENE-C (- strand, extends past 2000), and
+    excludes the chr2 gene entirely.
+    """
+    return pd.DataFrame(
+        {
+            "Chromosome": ["chr1", "chr1", "chr1", "chr2"],
+            "Start": [1100, 1300, 1700, 5000],
+            "End": [1200, 1500, 2500, 5500],  # GENE-C overhangs the test window
+            "Strand": ["+", "+", "-", "+"],
+            "gene_id": ["GENE-A", "GENE-B", "GENE-C", "GENE-D"],
+            "gene_name": ["A", "B", "C", "D"],
+            "gene_type": ["protein_coding"] * 4,
+        }
+    )
+
+
+@pytest.mark.unit
+class TestGeneMaskExtractor:
+
+    def test_extract_returns_correct_shape(self):
+        ex = GeneMaskExtractor(_toy_gene_table())
+        mask, meta = ex.extract("chr1", 1000, 2000)
+        assert mask.shape == (1000, 2, 2)  # GENE-A + GENE-B contained; GENE-C overhangs
+        assert mask.dtype == bool
+        assert list(meta["gene_id"]) == ["GENE-A", "GENE-B"]
+
+    def test_strand_bucketing(self):
+        """Plus-strand genes go in axis 1 = 0; minus-strand in axis 1 = 1."""
+        # Use a window that fully contains a minus-strand gene by widening.
+        table = _toy_gene_table().copy()
+        table.loc[2, "End"] = 1900  # shrink GENE-C so it's contained in [1000, 2000)
+        ex = GeneMaskExtractor(table)
+        mask, meta = ex.extract("chr1", 1000, 2000)
+
+        assert list(meta["gene_id"]) == ["GENE-A", "GENE-B", "GENE-C"]
+        # GENE-A is plus → bucket 0
+        gene_a_col = list(meta["gene_id"]).index("GENE-A")
+        assert mask[:, 0, gene_a_col].any() and not mask[:, 1, gene_a_col].any()
+        # GENE-C is minus → bucket 1
+        gene_c_col = list(meta["gene_id"]).index("GENE-C")
+        assert mask[:, 1, gene_c_col].any() and not mask[:, 0, gene_c_col].any()
+
+    def test_unstranded_dot_appears_in_both_buckets(self):
+        """A '.' (unstranded) gene must appear in BOTH strand buckets, matching
+        upstream's strand-channel semantics."""
+        table = pd.DataFrame(
+            {
+                "Chromosome": ["chr1"],
+                "Start": [1100],
+                "End": [1200],
+                "Strand": ["."],
+                "gene_id": ["GENE-DOT"],
+                "gene_name": ["dot"],
+                "gene_type": ["protein_coding"],
+            }
+        )
+        ex = GeneMaskExtractor(table)
+        mask, _ = ex.extract("chr1", 1000, 2000)
+        assert mask.shape == (1000, 2, 1)
+        # Both strand buckets should be populated identically.
+        assert mask[:, 0, 0].any()
+        assert mask[:, 1, 0].any()
+        np.testing.assert_array_equal(mask[:, 0, 0], mask[:, 1, 0])
+
+    def test_invalid_strand_raises(self):
+        table = pd.DataFrame(
+            {
+                "Chromosome": ["chr1"],
+                "Start": [1100],
+                "End": [1200],
+                "Strand": ["?"],
+                "gene_id": ["GENE-Q"],
+                "gene_name": ["q"],
+                "gene_type": ["protein_coding"],
+            }
+        )
+        ex = GeneMaskExtractor(table)
+        with pytest.raises(ValueError, match="Strand must be one of"):
+            ex.extract("chr1", 1000, 2000)
+
+    def test_mask_positions_exact(self):
+        """GENE-A spans [1100, 1200) genomic → [100, 200) relative to window 1000."""
+        ex = GeneMaskExtractor(_toy_gene_table())
+        mask, meta = ex.extract("chr1", 1000, 2000)
+        gene_a_col = list(meta["gene_id"]).index("GENE-A")
+        assert mask[:100, 0, gene_a_col].sum() == 0
+        assert mask[100:200, 0, gene_a_col].all()
+        assert mask[200:, 0, gene_a_col].sum() == 0
+
+    def test_unknown_chromosome_returns_empty(self):
+        ex = GeneMaskExtractor(_toy_gene_table())
+        mask, meta = ex.extract("chrFAKE", 0, 1000)
+        assert mask.shape == (1000, 2, 0)
+        assert meta.empty
+
+    def test_window_with_no_contained_genes(self):
+        ex = GeneMaskExtractor(_toy_gene_table())
+        mask, meta = ex.extract("chr1", 0, 500)  # before any gene
+        assert mask.shape == (500, 2, 0)
+        assert meta.empty
+
+    def test_overhanging_gene_excluded(self):
+        """GENE-C extends to 2500, window ends at 2000 → not contained → excluded."""
+        ex = GeneMaskExtractor(_toy_gene_table())
+        mask, meta = ex.extract("chr1", 1000, 2000)
+        assert "GENE-C" not in list(meta["gene_id"])
+
+    def test_lru_cache_hits(self):
+        ex = GeneMaskExtractor(_toy_gene_table(), cache_size=2)
+        m1, _ = ex.extract("chr1", 1000, 2000)
+        m2, _ = ex.extract("chr1", 1000, 2000)  # cache hit
+        # Same array object → cache returned the cached value, not recomputed.
+        assert m1 is m2
+
+    def test_cache_eviction(self):
+        ex = GeneMaskExtractor(_toy_gene_table(), cache_size=1)
+        ex.extract("chr1", 1000, 2000)
+        ex.extract("chr1", 0, 500)  # evicts the first
+        assert ("chr1", 1000, 2000) not in ex._cache
+        assert ("chr1", 0, 500) in ex._cache
+
+    def test_pad_ceiling_raises(self):
+        """A window exceeding PAD_NUM_GENES_CEILING raises rather than truncating."""
+        n = PAD_NUM_GENES_CEILING + 1
+        table = pd.DataFrame(
+            {
+                "Chromosome": ["chr1"] * n,
+                "Start": list(range(0, n * 10, 10)),
+                "End": list(range(5, n * 10 + 5, 10)),
+                "Strand": ["+"] * n,
+                "gene_id": [f"G{i}" for i in range(n)],
+                "gene_name": [f"g{i}" for i in range(n)],
+                "gene_type": ["protein_coding"] * n,
+            }
+        )
+        ex = GeneMaskExtractor(table)
+        with pytest.raises(ValueError, match="exceeding the ceiling"):
+            ex.extract("chr1", 0, n * 10 + 100)
+
+
+@pytest.mark.unit
+class TestDeriveGMax:
+
+    def test_picks_max_plus_headroom(self):
+        # 3 genes in window 1, 1 gene in window 2 → max=2 (GENE-A + GENE-B)
+        ex = GeneMaskExtractor(_toy_gene_table())
+        intervals = [("chr1", 1000, 2000), ("chr1", 0, 500)]
+        g_max = derive_g_max(ex, intervals, headroom=4)
+        assert g_max == 2 + 4
+
+    def test_propagates_extractor_ceiling_error(self):
+        """If a scanned window blows past the extractor's PAD ceiling,
+        the error fires during the scan — derive_g_max needs no own cap."""
+        n = PAD_NUM_GENES_CEILING + 1
+        table = pd.DataFrame(
+            {
+                "Chromosome": ["chr1"] * n,
+                "Start": list(range(0, n * 10, 10)),
+                "End": list(range(5, n * 10 + 5, 10)),
+                "Strand": ["+"] * n,
+                "gene_id": [f"G{i}" for i in range(n)],
+                "gene_name": [f"g{i}" for i in range(n)],
+                "gene_type": ["protein_coding"] * n,
+            }
+        )
+        ex = GeneMaskExtractor(table)
+        with pytest.raises(ValueError, match="exceeding the ceiling"):
+            derive_g_max(ex, [("chr1", 0, n * 10 + 100)])
+
+
+@pytest.mark.unit
+class TestLoadGeneTable:
+    """Tests against a minimal synthetic GTF written to a tempfile."""
+
+    @pytest.fixture
+    def gtf_path(self):
+        # GTF is 1-based inclusive in source format; pyranges converts to
+        # 0-based half-open on load. We just write valid GTF text and let
+        # pyranges do the conversion.
+        gtf_text = (
+            'chr1\tHAVANA\tgene\t1101\t1200\t.\t+\t.\t'
+            'gene_id "GENE-A"; gene_name "A"; gene_type "protein_coding";\n'
+            'chr1\tHAVANA\tgene\t1301\t1500\t.\t+\t.\t'
+            'gene_id "GENE-B"; gene_name "B"; gene_type "lncRNA";\n'
+            'chr1\tHAVANA\ttranscript\t1101\t1200\t.\t+\t.\t'
+            'gene_id "GENE-A"; transcript_id "TX-A";\n'
+        )
+        tmp = tempfile.NamedTemporaryFile(suffix=".gtf", mode="w", delete=False)
+        tmp.write(gtf_text)
+        tmp.close()
+        try:
+            yield tmp.name
+        finally:
+            os.unlink(tmp.name)
+
+    def test_load_filters_to_protein_coding(self, gtf_path):
+        df = load_gene_table(gtf_path, filter_protein_coding=True)
+        assert list(df["gene_id"]) == ["GENE-A"]
+        assert (df["gene_type"] == "protein_coding").all()
+
+    def test_load_without_filter_keeps_all_genes(self, gtf_path):
+        df = load_gene_table(gtf_path, filter_protein_coding=False)
+        assert sorted(df["gene_id"]) == ["GENE-A", "GENE-B"]
+
+    def test_load_drops_non_gene_rows(self, gtf_path):
+        df = load_gene_table(gtf_path, filter_protein_coding=False)
+        # Transcript row should not appear; we filter to Feature == 'gene'.
+        # gene_id is unique here (one row per gene), so 2 genes → 2 rows.
+        assert len(df) == 2
+
+    def test_load_coordinates_zero_based(self, gtf_path):
+        """pyranges converts 1-based inclusive (1101) → 0-based half-open (1100)."""
+        df = load_gene_table(gtf_path, filter_protein_coding=True)
+        assert df.iloc[0]["Start"] == 1100
+        assert df.iloc[0]["End"] == 1200

--- a/tests/unit/test_gene_lfc_loss.py
+++ b/tests/unit/test_gene_lfc_loss.py
@@ -13,6 +13,10 @@ from __future__ import annotations
 import pytest
 import torch
 
+from alphagenome_pytorch.extensions.finetuning.training import (
+    compute_finetuning_loss,
+)
+from alphagenome_pytorch.losses import gene_lfc_loss
 from alphagenome_pytorch.training import (
     AlphaGenomeLoss,
     _build_strand_channel_mask,
@@ -318,6 +322,116 @@ class TestPerHeadGating:
         # Forward without gene_mask → no gene LFC fires.
         loss_fn(outputs, targets, organism_index=torch.tensor([0]), masks=masks)
         assert calls == []
+
+
+@pytest.mark.unit
+class TestStandaloneVsMethod:
+
+    def test_alphagenomeloss_method_matches_standalone(self):
+        """The AlphaGenomeLoss method is now a thin wrapper around the
+        standalone losses.gene_lfc_loss; both must return identical values
+        for the same inputs."""
+        loss_fn = AlphaGenomeLoss(
+            gene_loss_weights={"rna_seq": 0.1},
+            track_strands={"rna_seq": "+-+-"},
+            gene_cross_track_weight=5.0,
+        )
+        torch.manual_seed(0)
+        B, S, C = 1, 64, 4
+        preds = torch.rand(B, S, C) + 0.5
+        targets = torch.rand(B, S, C) + 0.5
+        track_mask = torch.ones(B, 1, C, dtype=torch.bool)
+        gene_mask = torch.zeros(B, S, 2, 2, dtype=torch.bool)
+        gene_mask[:, 10:30, 0, 0] = True
+        gene_mask[:, 40:60, 1, 1] = True
+        strand_mask = loss_fn._get_strand_channel_mask("rna_seq")
+
+        loss_method, _ = loss_fn._compute_gene_lfc(
+            predictions=preds, targets=targets, targets_mask=track_mask,
+            gene_mask=gene_mask, strand_channel_mask=strand_mask,
+        )
+        loss_standalone, _ = gene_lfc_loss(
+            predictions=preds, targets=targets, targets_mask=track_mask,
+            gene_mask=gene_mask, strand_channel_mask=strand_mask,
+            gene_cross_track_weight=5.0,
+        )
+        assert torch.isclose(loss_method, loss_standalone)
+
+
+@pytest.mark.unit
+class TestComputeFinetuningLossGeneLFC:
+    """Verify compute_finetuning_loss adds the gene LFC term correctly."""
+
+    def _make_inputs(self, B=1, S=64, C=4, num_genes=2, seed=0):
+        torch.manual_seed(seed)
+        preds_dict = {1: torch.rand(B, S, C) + 0.5}
+        targets_dict = {1: torch.rand(B, S, C) + 0.5}
+        gene_mask = torch.zeros(B, S, 2, num_genes, dtype=torch.bool)
+        gene_mask[:, 10:30, 0, 0] = True
+        gene_mask[:, 40:60, 1, 1] = True
+        strand_mask = _build_strand_channel_mask("+-+-"[:C])
+        return preds_dict, targets_dict, gene_mask, strand_mask
+
+    def test_gene_lfc_off_when_weight_zero(self):
+        preds, targets, gene_mask, strand_mask = self._make_inputs()
+        loss_no_gene, dict_no_gene = compute_finetuning_loss(
+            predictions=preds, targets=targets,
+            resolution_weights={1: 1.0}, positional_weight=1.0,
+            device=torch.device("cpu"),
+        )
+        loss_with_zero, dict_with_zero = compute_finetuning_loss(
+            predictions=preds, targets=targets,
+            resolution_weights={1: 1.0}, positional_weight=1.0,
+            device=torch.device("cpu"),
+            gene_mask=gene_mask, gene_loss_weight=0.0,
+            strand_channel_mask=strand_mask,
+        )
+        # gene_loss_weight=0 must be exactly identical to "no gene config".
+        assert torch.isclose(loss_no_gene, loss_with_zero)
+        assert "loss_gene_lfc" not in dict_with_zero
+
+    def test_gene_lfc_increases_loss_when_enabled(self):
+        preds, targets, gene_mask, strand_mask = self._make_inputs()
+        loss_off, _ = compute_finetuning_loss(
+            predictions=preds, targets=targets,
+            resolution_weights={1: 1.0}, positional_weight=1.0,
+            device=torch.device("cpu"),
+        )
+        loss_on, dict_on = compute_finetuning_loss(
+            predictions=preds, targets=targets,
+            resolution_weights={1: 1.0}, positional_weight=1.0,
+            device=torch.device("cpu"),
+            gene_mask=gene_mask, gene_loss_weight=0.1,
+            strand_channel_mask=strand_mask,
+        )
+        assert loss_on.item() > loss_off.item()
+        assert "loss_gene_lfc" in dict_on
+        assert torch.isfinite(dict_on["loss_gene_lfc"])
+
+    def test_gene_lfc_only_at_resolution_1(self):
+        """When the only resolution available is 128, gene LFC must NOT fire
+        even if all params are set, because we gate on res == 1."""
+        torch.manual_seed(0)
+        B, S, C = 1, 8, 4  # 128 / 16 = 8 (S at 128bp)
+        preds = {128: torch.rand(B, S, C) + 0.5}
+        targets = {128: torch.rand(B, S, C) + 0.5}
+        # gene_mask shape uses raw seq length, but the gating checks res==1 only.
+        gene_mask = torch.zeros(B, 1024, 2, 1, dtype=torch.bool)
+        gene_mask[:, 100:200, 0, 0] = True
+        strand_mask = _build_strand_channel_mask("+-+-"[:C])
+
+        _, dict_on = compute_finetuning_loss(
+            predictions=preds, targets=targets,
+            resolution_weights={128: 1.0}, positional_weight=1.0,
+            device=torch.device("cpu"),
+            gene_mask=gene_mask, gene_loss_weight=0.1,
+            strand_channel_mask=strand_mask,
+        )
+        assert "loss_gene_lfc" not in dict_on
+
+
+@pytest.mark.unit
+class TestMissingStrandsValidation:
 
     def test_missing_track_strands_raises_when_gene_w_set(self):
         """If gene_loss_weights[head] > 0 but no track_strands provided,

--- a/tests/unit/test_gene_lfc_loss.py
+++ b/tests/unit/test_gene_lfc_loss.py
@@ -431,6 +431,67 @@ class TestComputeFinetuningLossGeneLFC:
 
 
 @pytest.mark.unit
+class TestSequenceParallelSlicing:
+    """Pin the contract used by train_epoch_sequence_parallel for slicing
+    gene_mask along S to per-rank shards. The implementation is inlined
+    inside the SP loop; this test mirrors that math and verifies that:
+      - Full-S mask split across W ranks reconstructs to the original.
+      - Each rank's slice has length S // W.
+      - gene_lfc_loss accepts the per-rank slice without shape errors.
+    """
+
+    def test_slice_reconstructs_full_mask(self):
+        torch.manual_seed(0)
+        B, S, G = 2, 1024, 3
+        world_size = 4
+        full_mask = torch.zeros(B, S, 2, G, dtype=torch.bool)
+        full_mask[:, 100:300, 0, 0] = True  # +-strand gene
+        full_mask[:, 500:700, 1, 1] = True  # --strand gene
+
+        slices = []
+        local_len = S // world_size
+        for rank in range(world_size):
+            slc = full_mask[:, rank * local_len:(rank + 1) * local_len, :, :]
+            assert slc.shape == (B, local_len, 2, G)
+            slices.append(slc)
+
+        reassembled = torch.cat(slices, dim=1)
+        assert torch.equal(reassembled, full_mask)
+
+    def test_per_rank_slice_runs_through_loss(self):
+        """A per-rank gene_mask slice (with matching local pred/target slice)
+        must run through gene_lfc_loss without shape errors."""
+        torch.manual_seed(0)
+        B, S, C, G = 1, 256, 4, 2
+        world_size = 4
+        rank = 1
+        local_len = S // world_size
+
+        preds = torch.rand(B, local_len, C) + 0.5
+        targets = torch.rand(B, local_len, C) + 0.5
+        track_mask = torch.ones(B, 1, C, dtype=torch.bool)
+
+        full_gene_mask = torch.zeros(B, S, 2, G, dtype=torch.bool)
+        # Place a gene that crosses the rank-1 shard.
+        full_gene_mask[:, 80:100, 0, 0] = True  # within rank 1's [64, 128) shard
+        full_gene_mask[:, 150:200, 1, 1] = True
+        local_gene_mask = full_gene_mask[
+            :, rank * local_len:(rank + 1) * local_len, :, :
+        ]
+        assert local_gene_mask.shape == (B, local_len, 2, G)
+
+        strand_mask = _build_strand_channel_mask("+-+-")
+        loss, aux = gene_lfc_loss(
+            predictions=preds,
+            targets=targets,
+            targets_mask=track_mask,
+            gene_mask=local_gene_mask,
+            strand_channel_mask=strand_mask,
+        )
+        assert torch.isfinite(loss)
+
+
+@pytest.mark.unit
 class TestMissingStrandsValidation:
 
     def test_missing_track_strands_raises_when_gene_w_set(self):

--- a/tests/unit/test_gene_lfc_loss.py
+++ b/tests/unit/test_gene_lfc_loss.py
@@ -1,0 +1,352 @@
+"""Unit tests for the gene LFC (Decima-style) cross-track training loss.
+
+Covers:
+  - `_build_strand_channel_mask` semantics (+/-/. and invalid chars).
+  - `AlphaGenomeLoss` config plumbing (`gene_loss_weights`, `track_strands`).
+  - `_compute_gene_lfc` math: zero loss at perfect prediction, positive loss
+    on mismatch, finite gradient, strand-channel filtering, and head-level
+    gating (only heads with non-zero `gene_loss_weights` consume `gene_mask`).
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from alphagenome_pytorch.training import (
+    AlphaGenomeLoss,
+    _build_strand_channel_mask,
+)
+
+
+@pytest.mark.unit
+class TestBuildStrandChannelMask:
+
+    def test_plus_minus(self):
+        mask = _build_strand_channel_mask(["+", "-", "+", "-"])
+        assert mask.shape == (2, 1, 4)
+        assert mask.dtype == torch.bool
+        # bucket 0 (positive genes): only + tracks
+        assert mask[0, 0].tolist() == [True, False, True, False]
+        # bucket 1 (negative genes): only - tracks
+        assert mask[1, 0].tolist() == [False, True, False, True]
+
+    def test_unstranded_dot_in_both_buckets(self):
+        mask = _build_strand_channel_mask(["+", ".", "-"])
+        assert mask[0, 0].tolist() == [True, True, False]   # + and . in bucket 0
+        assert mask[1, 0].tolist() == [False, True, True]   # - and . in bucket 1
+
+    def test_invalid_strand_raises(self):
+        with pytest.raises(ValueError, match="must be one of"):
+            _build_strand_channel_mask(["+", "?", "-"])
+
+    def test_string_input(self):
+        """Compact string form '+-+-..' iterates as one char per track."""
+        mask = _build_strand_channel_mask("+-+-")
+        assert mask.shape == (2, 1, 4)
+        assert mask[0, 0].tolist() == [True, False, True, False]
+
+
+@pytest.mark.unit
+class TestAlphaGenomeLossConfigPlumbing:
+
+    def test_defaults_empty_gene_config(self):
+        loss_fn = AlphaGenomeLoss()
+        assert loss_fn.gene_loss_weights == {}
+        assert loss_fn.gene_cross_track_weight == 5.0
+        assert loss_fn._strand_mask_heads == []
+
+    def test_register_track_strands(self):
+        loss_fn = AlphaGenomeLoss(
+            gene_loss_weights={"rna_seq": 0.1},
+            track_strands={"rna_seq": "+-+-"},
+        )
+        assert loss_fn.gene_loss_weights == {"rna_seq": 0.1}
+        mask = loss_fn._get_strand_channel_mask("rna_seq")
+        assert mask is not None
+        assert mask.shape == (2, 1, 4)
+        # head without strand registered → None
+        assert loss_fn._get_strand_channel_mask("atac") is None
+
+    def test_strand_mask_buffer_follows_device_dtype(self):
+        """Strand masks are buffers, so `.to(...)` moves them with the module."""
+        loss_fn = AlphaGenomeLoss(
+            gene_loss_weights={"rna_seq": 0.1},
+            track_strands={"rna_seq": "+-+-"},
+        )
+        # Convert to float dtype to verify buffer movement (bool can't be cast,
+        # but we verify the buffer is a registered buffer by listing them).
+        buffer_names = [name for name, _ in loss_fn.named_buffers()]
+        assert any("strand_channel_mask" in n for n in buffer_names)
+
+
+def _make_loss_fn(gene_w=0.1, num_tracks=4, strands="+-+-", head="rna_seq"):
+    return AlphaGenomeLoss(
+        heads=[head],
+        gene_loss_weights={head: gene_w},
+        track_strands={head: strands},
+        # Use main loss multinomial_resolution=1 so we don't need long S.
+        multinomial_resolution=1,
+        positional_weight=1.0,
+    )
+
+
+@pytest.mark.unit
+class TestComputeGeneLFCMath:
+
+    def _inputs(self, B=1, S=64, C=4, num_genes=2, seed=0):
+        torch.manual_seed(seed)
+        preds = torch.rand(B, S, C) + 0.5
+        targets = torch.rand(B, S, C) + 0.5
+        track_mask = torch.ones(B, 1, C, dtype=torch.bool)
+        # Two genes: gene 0 on + strand at positions [10, 30); gene 1 on -
+        # strand at [40, 60). Build [B, S, 2, G].
+        gene_mask = torch.zeros(B, S, 2, num_genes, dtype=torch.bool)
+        gene_mask[:, 10:30, 0, 0] = True
+        gene_mask[:, 40:60, 1, 1] = True
+        return preds, targets, track_mask, gene_mask
+
+    def test_perfect_prediction_zeroes_poisson_term(self):
+        """At pred==target, only the Poisson NLL on per-gene totals goes to
+        zero. The multinomial term reduces to the entropy of the per-gene
+        tissue distribution, which is non-zero for any non-degenerate target.
+        Test that:
+          - aux['gene_loss_total_count'] ≈ 0 (Poisson at optimum)
+          - aux['gene_loss_positional'] is finite and >= 0
+          - perturbing preds away from targets strictly increases total loss
+        """
+        loss_fn = _make_loss_fn(num_tracks=4)
+        preds, _, track_mask, gene_mask = self._inputs()
+        strand_mask = loss_fn._get_strand_channel_mask("rna_seq")
+
+        loss_perfect, aux = loss_fn._compute_gene_lfc(
+            predictions=preds,
+            targets=preds,
+            targets_mask=track_mask,
+            gene_mask=gene_mask,
+            strand_channel_mask=strand_mask,
+        )
+        assert aux["gene_loss_total_count"].item() < 1e-4, (
+            f"Poisson term should be ~0 at pred==target, "
+            f"got {aux['gene_loss_total_count'].item()}"
+        )
+        assert torch.isfinite(aux["gene_loss_positional"])
+        assert aux["gene_loss_positional"].item() >= 0
+
+        # Perturbing preds must strictly increase the total loss.
+        perturbed = preds.clone()
+        # Skew within the gene window so the cross-track distribution shifts
+        # away from the target distribution.
+        perturbed[:, 10:30, 0] *= 5.0  # bias track 0 (+ strand) much higher
+        loss_perturbed, _ = loss_fn._compute_gene_lfc(
+            predictions=perturbed,
+            targets=preds,
+            targets_mask=track_mask,
+            gene_mask=gene_mask,
+            strand_channel_mask=strand_mask,
+        )
+        assert loss_perturbed.item() > loss_perfect.item() + 0.01
+
+    def test_positive_loss_on_mismatch(self):
+        loss_fn = _make_loss_fn()
+        preds, targets, track_mask, gene_mask = self._inputs()
+        strand_mask = loss_fn._get_strand_channel_mask("rna_seq")
+
+        loss, _ = loss_fn._compute_gene_lfc(
+            predictions=preds,
+            targets=targets,
+            targets_mask=track_mask,
+            gene_mask=gene_mask,
+            strand_channel_mask=strand_mask,
+        )
+        assert torch.isfinite(loss)
+        assert loss.item() > 0
+
+    def test_finite_gradient(self):
+        loss_fn = _make_loss_fn()
+        preds, targets, track_mask, gene_mask = self._inputs()
+        preds = preds.clone().requires_grad_(True)
+        strand_mask = loss_fn._get_strand_channel_mask("rna_seq")
+
+        loss, _ = loss_fn._compute_gene_lfc(
+            predictions=preds,
+            targets=targets,
+            targets_mask=track_mask,
+            gene_mask=gene_mask,
+            strand_channel_mask=strand_mask,
+        )
+        loss.backward()
+        assert preds.grad is not None
+        assert torch.all(torch.isfinite(preds.grad))
+
+    def test_strand_filter_excludes_mismatched_tracks(self):
+        """A perfect-prediction setup should still give ~0 loss; if we then
+        change predictions only on tracks that the strand filter excludes
+        for ALL genes in the batch, the loss should be unchanged."""
+        # Tracks: [+, -, +, -]. Gene 0 is + strand, gene 1 is - strand.
+        # We construct a setup where every gene in the batch is + strand,
+        # so - tracks (idx 1, 3) are filtered out by the strand mask.
+        loss_fn = _make_loss_fn(num_tracks=4, strands="+-+-")
+        B, S, C = 1, 64, 4
+        torch.manual_seed(0)
+        preds = torch.rand(B, S, C) + 0.5
+        track_mask = torch.ones(B, 1, C, dtype=torch.bool)
+        # Single + strand gene on positions [10, 30). No - strand genes.
+        gene_mask = torch.zeros(B, S, 2, 1, dtype=torch.bool)
+        gene_mask[:, 10:30, 0, 0] = True
+        strand_mask = loss_fn._get_strand_channel_mask("rna_seq")
+
+        # Baseline: perfect prediction.
+        loss_baseline, _ = loss_fn._compute_gene_lfc(
+            predictions=preds,
+            targets=preds,
+            targets_mask=track_mask,
+            gene_mask=gene_mask,
+            strand_channel_mask=strand_mask,
+        )
+
+        # Perturb only track 1 (- strand). Since the only gene is + strand,
+        # this perturbation must be filtered out and the loss unchanged.
+        perturbed = preds.clone()
+        perturbed[:, 10:30, 1] += 100.0  # huge change on the - track
+        loss_perturbed, _ = loss_fn._compute_gene_lfc(
+            predictions=perturbed,
+            targets=preds,
+            targets_mask=track_mask,
+            gene_mask=gene_mask,
+            strand_channel_mask=strand_mask,
+        )
+        assert torch.isclose(loss_baseline, loss_perturbed, atol=1e-5), (
+            f"strand filter leaked: baseline={loss_baseline.item()}, "
+            f"perturbed={loss_perturbed.item()}"
+        )
+
+        # Sanity: perturbing track 0 (+ strand) MUST change the loss.
+        sanity = preds.clone()
+        sanity[:, 10:30, 0] += 100.0
+        loss_sanity, _ = loss_fn._compute_gene_lfc(
+            predictions=sanity,
+            targets=preds,
+            targets_mask=track_mask,
+            gene_mask=gene_mask,
+            strand_channel_mask=strand_mask,
+        )
+        assert loss_sanity.item() > loss_baseline.item() + 0.1
+
+
+@pytest.mark.unit
+class TestPerHeadGating:
+    """Verify _compute_head_loss only adds gene LFC where gene_loss_weights > 0."""
+
+    def _stub_head_loss(self, loss_fn, fixed_per_head_main_loss):
+        """Replace the multinomial branch with a stub returning a known scalar.
+
+        We can't easily run the full multinomial path in a unit test (it
+        needs a model with `.heads` for target scaling). Instead, we monkey-
+        patch _compute_head_loss to call _compute_gene_lfc directly when
+        gene_loss_weights[head] > 0, and otherwise return the stubbed main
+        loss. This isolates the gating decision.
+        """
+        original = loss_fn._compute_head_loss
+        gene_lfc_calls = []
+
+        def patched(head, output, target, mask, organism_index, gene_mask=None):
+            main = torch.tensor(fixed_per_head_main_loss[head], dtype=torch.float32)
+            gene_w = loss_fn.gene_loss_weights.get(head, 0.0)
+            if gene_w > 0 and gene_mask is not None:
+                strand_mask = loss_fn._get_strand_channel_mask(head)
+                gene_loss, _ = loss_fn._compute_gene_lfc(
+                    predictions=output,
+                    targets=target,
+                    targets_mask=mask,
+                    gene_mask=gene_mask,
+                    strand_channel_mask=strand_mask,
+                )
+                gene_lfc_calls.append(head)
+                return main + gene_w * gene_loss
+            return main
+
+        loss_fn._compute_head_loss = patched
+        return gene_lfc_calls
+
+    def test_gene_lfc_only_runs_for_configured_head(self):
+        loss_fn = AlphaGenomeLoss(
+            heads=["atac", "rna_seq"],
+            gene_loss_weights={"rna_seq": 0.1},
+            track_strands={"rna_seq": "+-+-"},
+        )
+        calls = self._stub_head_loss(loss_fn, {"atac": 1.0, "rna_seq": 1.0})
+
+        B, S, C = 1, 64, 4
+        torch.manual_seed(0)
+        outputs = {
+            "atac": torch.rand(B, S, C) + 0.5,
+            "rna_seq": torch.rand(B, S, C) + 0.5,
+        }
+        targets = {
+            "atac": torch.rand(B, S, C) + 0.5,
+            "rna_seq": torch.rand(B, S, C) + 0.5,
+        }
+        masks = {
+            "atac": torch.ones(B, 1, C, dtype=torch.bool),
+            "rna_seq": torch.ones(B, 1, C, dtype=torch.bool),
+        }
+        gene_mask = torch.zeros(B, S, 2, 1, dtype=torch.bool)
+        gene_mask[:, 10:30, 0, 0] = True
+
+        result = loss_fn(
+            outputs, targets, organism_index=torch.tensor([0]),
+            masks=masks, gene_mask=gene_mask,
+        )
+        # gene LFC must have been invoked exactly once, on rna_seq.
+        assert calls == ["rna_seq"]
+        assert torch.isfinite(result["loss"])
+
+    def test_no_gene_mask_means_no_gene_lfc(self):
+        loss_fn = AlphaGenomeLoss(
+            heads=["rna_seq"],
+            gene_loss_weights={"rna_seq": 0.1},
+            track_strands={"rna_seq": "+-+-"},
+        )
+        calls = self._stub_head_loss(loss_fn, {"rna_seq": 1.0})
+
+        B, S, C = 1, 64, 4
+        outputs = {"rna_seq": torch.rand(B, S, C) + 0.5}
+        targets = {"rna_seq": torch.rand(B, S, C) + 0.5}
+        masks = {"rna_seq": torch.ones(B, 1, C, dtype=torch.bool)}
+
+        # Forward without gene_mask → no gene LFC fires.
+        loss_fn(outputs, targets, organism_index=torch.tensor([0]), masks=masks)
+        assert calls == []
+
+    def test_missing_track_strands_raises_when_gene_w_set(self):
+        """If gene_loss_weights[head] > 0 but no track_strands provided,
+        the loss path must raise a clear error.
+
+        We need to exercise the real `_compute_head_loss` (not the stub),
+        which requires a tiny stand-in setup. The simplest way is to
+        construct AlphaGenomeLoss with a dummy "rna_seq"-named head that
+        falls through to multinomial loss, then call _compute_head_loss
+        directly.
+        """
+        loss_fn = AlphaGenomeLoss(
+            heads=["rna_seq"],
+            gene_loss_weights={"rna_seq": 0.1},
+            track_strands=None,  # NOT provided
+            multinomial_resolution=1,
+            positional_weight=1.0,
+        )
+
+        B, S, C = 1, 8, 2
+        output = {1: torch.rand(B, S, C) + 0.5}
+        target = {1: torch.rand(B, S, C) + 0.5}
+        mask = torch.ones(B, 1, C, dtype=torch.bool)
+        gene_mask = torch.zeros(B, S, 2, 1, dtype=torch.bool)
+        gene_mask[:, 2:6, 0, 0] = True
+
+        with pytest.raises(ValueError, match="track_strands were provided"):
+            loss_fn._compute_head_loss(
+                "rna_seq", output, target, mask,
+                organism_index=torch.tensor([0]),
+                gene_mask=gene_mask,
+            )

--- a/tests/unit/test_loss_head_weights.py
+++ b/tests/unit/test_loss_head_weights.py
@@ -53,7 +53,8 @@ class TestAggregationDivisor:
 
         # Replace _compute_head_loss with a stub that returns a known loss
         # per head, irrespective of input tensors.
-        def _stub(self, head, output, target, mask, organism_index):
+        def _stub(self, head, output, target, mask, organism_index,
+                  gene_mask=None):
             return torch.tensor(per_head_losses[head], dtype=torch.float32)
 
         loss_fn._compute_head_loss = _stub.__get__(loss_fn, AlphaGenomeLoss)


### PR DESCRIPTION
Port the upstream cross-track gene-level loss. When enabled, this term aggregates RNA-seq predictions and targets within annotated gene boundaries and computes a Poisson NLL on per-gene totals plus a multinomial NLL on the cross-tissue distribution per gene.

- Upstream commit: [google-deepmind/alphagenome_research@fd44ed0](https://github.com/google-deepmind/alphagenome_research/commit/fd44ed067e2e1e5cbdbfe263000585079d9f82d0)
- Paper reference: gene-level auxiliary loss for RNA-seq tracks inspired by Decima; weight 0.1, inner multinomial weight 5.0.

**Default-off and backward-compatible.** With `--gene-loss-weight 0.0` (the default), the loss calculation is identical to the current behavior.

## Gene LFC loss term

A new optional loss term that, for any training window, builds a per-gene mask, aggregates predictions/targets within each gene, and adds:

```
total += res_weights[1] * gene_loss_weight * (poisson_per_gene + 5.0 * multinomial_across_tissues)
```

at 1bp resolution, only for heads whose modality has a non-zero entry in `gene_loss_weights` (currently only rna_seq).

## Before / after — loss

`alphagenome_pytorch/losses.py` gains a new standalone function `gene_lfc_loss` (also exposed as a thin method on `AlphaGenomeLoss._compute_gene_lfc`). This ports upstream's `_compute_cross_track_loss`:

```python
gene_length = gene_mask.float().sum(dim=-3)                     # [B, 2, G]
y_true = einsum('bsc,bszg->bzgc', targets, gene_mask) / gene_len # [B, 2, G, C]
y_pred = einsum('bsc,bszg->bzgc', preds,   gene_mask) / gene_len

combined = (gene_len > 0) & track_avail & strand_channel_mask
total_pred = einsum('bzgc,bzgc->bzg', y_pred, combined)
total_true = einsum('bzgc,bzgc->bzg', y_true, combined)

loss = poisson_loss(total_true, total_pred) + 5.0 * multinomial_NLL(...)
```

## Before / after — data

Gene mask is built from a user-supplied GTF.

New module `extensions/finetuning/gene_annotation.py`:

- `load_gene_table(gtf_path)` — `pyranges.read_gtf().df`, filters to `Feature == 'gene'` and (by default) `gene_type == 'protein_coding'`.
- `GeneMaskExtractor(gene_table)` — `.extract(chrom, start, end)` returns `[S, 2, G]` strand-bucketed boolean mask + per-gene metadata, with an LRU cache.
- `derive_g_max(extractor, intervals)` — one-pass scan for tight per-dataset padding. 256 (matching upstream) retained as a ceiling.

Strand bucketing matches upstream: `+` → bucket 0, `−` → bucket 1, `.` (unstranded) → both buckets.

`GenomicDataset.__getitem__` now optionally returns a 3-tuple `(sequence, targets, gene_mask)` when an extractor is configured (2-tuple otherwise — keeps existing behavior). `MultimodalDataset` propagates `gene_mask` from whichever wrapped dataset has the extractor.

## Before / after — CLI

New flags in `scripts/finetune.py` (and inherited by `agt finetune` via the existing thin wrapper):

```bash
--gene-loss-weight FLOAT      # paper: 0.1; default 0.0 (off)
--gene-cross-track-weight FLOAT  # paper default: 5.0
--gtf PATH                    # required when --gene-loss-weight > 0
--track-strands STR           # one char per bigwig: '+', '-', or '.'
                              # e.g. '+-+-' for 4 alternating-strand tracks
```

YAML schema also supports `modalities.<head>.strand` for users with many tracks:

```yaml
modalities:
  rna_seq:
    bigwig: [rna_plus_1.bw, rna_minus_1.bw, rna_plus_2.bw, rna_minus_2.bw]
    strand: "+-+-"
gene_loss_weight: 0.1
gtf: gencode.v46.annotation.gtf
```

Validation at parse time:
- `--gene-loss-weight > 0` requires `--gtf`, `rna_seq` in `--modality`, and a strand string for rna_seq.
- Strand string length must equal the number of bigwigs for that modality.
- Each char must be one of `+`, `-`, `.`.

Example:

```bash
agt finetune --modality rna_seq \
  --bigwig rna_plus_1.bw rna_minus_1.bw rna_plus_2.bw rna_minus_2.bw \
  --track-strands '+-+-' \
  --genome hg38.fa --train-bed train.bed --val-bed val.bed \
  --pretrained-weights model.pth \
  --gtf gencode.v46.annotation.gtf \
  --gene-loss-weight 0.1
```

## Per-head gating

`gene_loss_weight` is stored as a `Dict[str, float]` keyed by head name. CLI scalar maps to `{'rna_seq': value}`. In a multi-modality run (`atac + rna_seq`), gene LFC fires only on rna_seq:

| Invocation | Result |
|---|---|
| `--modality rna_seq ... --gene-loss-weight 0.1 --gtf ...` | `{'rna_seq': 0.1}`, fires |
| `--modality atac rna_seq ... --gene-loss-weight 0.1 ...` | `{'rna_seq': 0.1}`, atac unaffected |
| `--modality atac ... --gene-loss-weight 0.1` | CLI error: rna_seq not present |
| Default (no flag) | `{}`, off everywhere |

