### PR TITLE
Add RMSBatchNorm training support (#44)

### DIFF
--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -365,6 +365,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=1024,
         help="Overlap for high-resolution (1bp) sequence splits. Low-resolution overlap is computed as overlap_highres // 128.",
     )
+    dist.add_argument(
+        "--sync-batchnorm",
+        action="store_true",
+        help="Sync RMSBatchNorm statistics across ranks (SyncBN). Recommended when "
+        "training the trunk (full fine-tuning / from scratch) under --sequence-parallel, "
+        "so batch stats cover the whole sequence rather than each rank's local slice.",
+    )
 
     # Logging arguments
     log = parser.add_argument_group("Logging")
@@ -977,6 +984,13 @@ def create_model(
     # Get head references from the underlying model before optional compile.
     model_module = unwrap_training_model(model)
     heads = {modality: model_module.heads[modality] for modality in heads}
+
+    # Enable SyncBN so RMSBatchNorm statistics cover the whole sequence under
+    # sequence parallelism (each rank otherwise only sees its local slice).
+    if args.sync_batchnorm:
+        from alphagenome_pytorch.layers import set_sync_batchnorm
+        n = set_sync_batchnorm(model_module, enabled=True)
+        print_rank0(f"SyncBN enabled on {n} RMSBatchNorm layers", rank)
 
     # Optionally compile
     if args.compile:

--- a/src/alphagenome_pytorch/layers.py
+++ b/src/alphagenome_pytorch/layers.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import torch.distributed as dist
 
 def gelu(x):
     """GELU using JAX's custom approximation: sigmoid(1.702 * x) * x
@@ -44,8 +45,14 @@ class Pool1d(nn.Module):
 class RMSBatchNorm(nn.Module):
     """RMS Batch Normalization supporting both channels-first and channels-last formats.
 
-    Normalizes over the channel dimension using stored running statistics.
-    Matches JAX: alphagenome_research.model.layers.RMSBatchNorm
+    Normalizes over the channel dimension by the per-channel second moment
+    (RMS, i.e. mean of x**2 with no mean subtraction).
+
+    In eval mode this uses the stored ``running_var`` buffer, matching JAX
+    (alphagenome_research.model.layers.RMSBatchNorm), which only ever runs
+    inference. In train mode it normalizes by the current batch second moment
+    and updates ``running_var`` via an exponential moving average, so the layer
+    can be trained from scratch.
 
     Args:
         num_features: Number of channels.
@@ -53,8 +60,19 @@ class RMSBatchNorm(nn.Module):
         eps: Small constant for numerical stability.
         channels_last: If True, expects (B, S, C) format. If False, expects (B, C, S).
                        Default False (channels-first, matching PyTorch conv conventions).
+        momentum: EMA factor for the running second moment in train mode.
+        track_running_stats: If False, train mode skips the running_var update
+                             (and from-scratch training is not supported).
+        sync_stats: If True, train mode computes the batch second moment across
+                    all ranks in process_group (SyncBN). Needed for correct,
+                    rank-invariant stats under sequence parallelism, where each
+                    rank otherwise only sees its local slice of the sequence.
+        process_group: Process group for sync_stats. None uses the default group.
     """
-    def __init__(self, num_features: int = 0, channels: int = 0, eps: float = 1e-5, channels_last: bool = False):
+    def __init__(self, num_features: int = 0, channels: int = 0, eps: float = 1e-5,
+                 channels_last: bool = False, momentum: float = 0.1,
+                 track_running_stats: bool = True, sync_stats: bool = False,
+                 process_group=None):
         super().__init__()
         num_features = num_features or channels
         if num_features == 0:
@@ -62,6 +80,10 @@ class RMSBatchNorm(nn.Module):
         self.num_features = num_features
         self.eps = eps
         self.channels_last = channels_last
+        self.momentum = momentum
+        self.track_running_stats = track_running_stats
+        self.sync_stats = sync_stats
+        self.process_group = process_group
 
         # Always store parameters as (C,) - standard PyTorch convention
         # Reshape for broadcasting happens in forward()
@@ -69,9 +91,36 @@ class RMSBatchNorm(nn.Module):
         self.bias = nn.Parameter(torch.zeros(num_features))
         self.register_buffer('running_var', torch.ones(num_features))
 
+    def _second_moment(self, x: torch.Tensor, dims) -> torch.Tensor:
+        """Per-channel second moment (mean of x**2), optionally synced across ranks."""
+        sq = x.float() ** 2
+        sync = (self.sync_stats and dist.is_available() and dist.is_initialized()
+                and dist.get_world_size(self.process_group) > 1)
+        if not sync:
+            return sq.mean(dim=dims)
+        # SyncBN: global mean = sum(x**2) over all ranks / total element count.
+        # The sum is reduced with a differentiable all-reduce so each rank's
+        # local activations receive gradient from every rank's normalization.
+        import torch.distributed.nn.functional as dist_fn
+        group = self.process_group if self.process_group is not None else dist.group.WORLD
+        sum_sq = dist_fn.all_reduce(sq.sum(dim=dims), op=dist.ReduceOp.SUM, group=group)
+        count = torch.tensor(sq.numel() / self.num_features, device=sq.device, dtype=sum_sq.dtype)
+        dist.all_reduce(count, op=dist.ReduceOp.SUM, group=group)
+        return sum_sq / count
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        if self.training and self.track_running_stats:
+            # Reduce over batch + sequence, keeping per-channel stats. Second
+            # moment only (no centering) to match the RMS / running_var semantics.
+            # JAX computes the statistic in float32 for stability.
+            dims = tuple(range(x.ndim - 1)) if self.channels_last else (0,) + tuple(range(2, x.ndim))
+            stat = self._second_moment(x, dims)
+            with torch.no_grad():
+                self.running_var.mul_(1 - self.momentum).add_(self.momentum * stat.detach())
+        else:
+            stat = self.running_var
         # JAX casts the inverse std dev to input dtype BEFORE multiplying by scale
-        inv = self.weight * torch.rsqrt(self.running_var + self.eps).to(x.dtype)
+        inv = self.weight * torch.rsqrt(stat + self.eps).to(x.dtype)
         if self.channels_last:
             # NLC format (B, S, C) - parameters broadcast from the right
             return x * inv + self.bias
@@ -126,3 +175,21 @@ class LayerNorm(nn.Module):
         if self.elementwise_affine:
             return x_norm * self.weight + self.bias
         return x_norm
+
+
+def set_sync_batchnorm(module: nn.Module, enabled: bool = True, process_group=None) -> int:
+    """Toggle cross-rank SyncBN on every RMSBatchNorm in a module tree.
+
+    Use when training the trunk (full fine-tuning or from-scratch) under
+    sequence parallelism, so batch statistics are computed over the whole
+    sequence rather than each rank's local slice. Returns the number of
+    RMSBatchNorm layers updated. No effect in eval mode or when the world
+    size is 1.
+    """
+    count = 0
+    for m in module.modules():
+        if isinstance(m, RMSBatchNorm):
+            m.sync_stats = enabled
+            m.process_group = process_group
+            count += 1
+    return count


### PR DESCRIPTION
## Summary

- Make `RMSBatchNorm` trainable: train mode normalizes by the current batch second moment (`mean(x²)`, no centering) and EMA-updates `running_var`, so the model can be trained from scratch or fully fine-tuned with the trunk unfrozen. The eval path is unchanged.
- Add opt-in `SyncBN` (`sync_stats` / `set_sync_batchnorm`) that computes the second moment across ranks with a differentiable all-reduce, for correct, rank-invariant statistics under sequence parallelism.
- Wire it into the finetune CLI via `--sync-batchnorm`.

## Background

The JAX reference (`alphagenome_research`) `RMSBatchNorm` is inference-only — it freezes the trunk and trains only new heads, so `running_var` is never updated there. Training-mode BN is a new extension.

## Details

- `RMSBatchNorm` gains `momentum`, `track_running_stats`, `sync_stats`, `process_group`. Train-mode gradients now flow through the normalizer.
- SyncBN reduces `sum(x²)` (differentiable) and `count` (plain) over the process group; falls back to local stats when dist is uninitialized or world size is 1. Eval is identical to before.
- `set_sync_batchnorm(module, enabled, process_group)` flips the flag on every `RMSBatchNorm` (analogous to `torch.nn.SyncBatchNorm.convert_sync_batchnorm`).

