### PR TITLE
Add variant score quantile calibration

### DIFF
--- a/scripts/convert_calibration_to_parquet.py
+++ b/scripts/convert_calibration_to_parquet.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+"""Convert upstream variant-score calibration protobuf to a bundled parquet.
+
+This reads the precomputed ``calibration_scores.pb`` 
+(the fixed null distribution of variant scores over 348,126 common chr22 gnomAD v3 SNPs,
+see original at gs:///alphagenome/data/hg38/calibration_scores.pb,
+added in https://github.com/google-deepmind/alphagenome_research/commit/dad09dd)
+and writes ``src/alphagenome_pytorch/data/variant_quantile_calibration_<organism>.parquet``,
+which is shipped as package data and loaded at runtime 
+by ``alphagenome_pytorch.variant_scoring.calibration.Calibration``.
+
+Only the human (hg38) calibration currently exists upstream.
+
+Protobuf bindings
+-----------------
+Parsing the ``.pb`` uses the generated ``calibration_scores_pb2`` bindings, which
+depend on ``alphagenome``'s ``dna_model.proto``. 
+
+Example:
+    python scripts/convert_calibration_to_parquet.py \
+        --pb calibration_scores.pb \
+        --alphagenome-src /path/to/alphagenome/src \
+        --upstream-src /path/to/alphagenome_research/src \
+        --metadata src/alphagenome_pytorch/data/track_metadata_human.parquet \
+        --output src/alphagenome_pytorch/data/variant_quantile_calibration_human.parquet
+
+Output schema (one parquet, long format)
+-----------------------------------------
+Columns: ``scorer_key`` (upstream canonical scorer string), ``output_type`` (our
+output-type value, e.g. ``"atac"``), ``row_type`` (``"quantiles"`` or
+``"probabilities"``), ``track_index`` (0..T-1 for quantiles, -1 for probabilities;
+track indices align to the first T tracks of the scorer's head), ``is_signed``,
+``values`` (list<float32> of length Q).
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+# Strand enum (dna_model.proto) -> our metadata convention.
+_STRAND = {0: ".", 1: "+", 2: "-", 3: "."}
+
+
+def _load_pb2(alphagenome_src: Path, upstream_src: Path):
+    """Compile and import calibration_scores_pb2 from upstream proto sources."""
+    try:
+        return importlib.import_module(
+            "alphagenome_research.protos.calibration_scores_pb2"
+        )
+    except Exception:  # noqa: BLE001 - fall through to on-the-fly compilation
+        pass
+
+    out_dir = Path(tempfile.mkdtemp(prefix="ag_calib_pb2_"))
+    protos = [
+        upstream_src / "alphagenome_research/protos/calibration_scores.proto",
+        alphagenome_src / "alphagenome/protos/dna_model.proto",
+        alphagenome_src / "alphagenome/protos/tensor.proto",
+    ]
+    cmd = [
+        sys.executable, "-m", "grpc_tools.protoc",
+        f"--proto_path={upstream_src}",
+        f"--proto_path={alphagenome_src}",
+        f"--python_out={out_dir}",
+        *[str(p) for p in protos],
+    ]
+    subprocess.run(cmd, check=True)
+    sys.path.insert(0, str(out_dir))
+    return importlib.import_module(
+        "alphagenome_research.protos.calibration_scores_pb2"
+    )
+
+
+def _ontology_curie(ontology_term) -> str:
+    enum = ontology_term.DESCRIPTOR.fields_by_name["ontology_type"].enum_type
+    name = enum.values_by_number[ontology_term.ontology_type].name
+    prefix = name.replace("ONTOLOGY_TYPE_", "")
+    return f"{prefix}:{ontology_term.id:07d}" if prefix else ""
+
+
+def _calib_track_keys(calibration) -> list[tuple[str, str]]:
+    return [
+        (m.name, _STRAND[m.strand])
+        for m in calibration.tracks_metadata.metadata
+    ]
+
+
+def _detect_output_type(
+    track_keys: list[tuple[str, str]],
+    metadata: pd.DataFrame,
+) -> str:
+    """Find the output_type whose first len(track_keys) tracks match exactly."""
+    T = len(track_keys)
+    for output_type, group in metadata.groupby("output_type"):
+        group = group.sort_values("track_index")
+        our_keys = list(zip(group["track_name"], group["strand"]))
+        if len(our_keys) >= T and our_keys[:T] == track_keys:
+            return str(output_type)
+    raise ValueError(
+        f"No output_type prefix-matches the {T} calibration tracks "
+        f"(first track: {track_keys[0] if track_keys else 'n/a'})."
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--pb", required=True, type=Path, help="calibration_scores.pb")
+    parser.add_argument("--metadata", required=True, type=Path,
+                        help="track_metadata_<organism>.parquet (track alignment)")
+    parser.add_argument("--output", required=True, type=Path, help="output parquet")
+    parser.add_argument("--alphagenome-src", type=Path,
+                        help="alphagenome src dir (for proto compilation)")
+    parser.add_argument("--upstream-src", type=Path,
+                        help="alphagenome_research src dir (for proto compilation)")
+    parser.add_argument("--compression", default="zstd")
+    parser.add_argument("--compression-level", type=int, default=19)
+    args = parser.parse_args()
+
+    cpb = _load_pb2(args.alphagenome_src, args.upstream_src)
+    metadata = pd.read_parquet(args.metadata)
+
+    calibration_scores = cpb.CalibrationScores.FromString(args.pb.read_bytes())
+    rows = []
+    for scorer_key in sorted(calibration_scores.scorer_to_calibration.keys()):
+        cal = calibration_scores.scorer_to_calibration[scorer_key]
+        probabilities = np.asarray(cal.quantile_probabilities, dtype=np.float32)
+        Q = probabilities.shape[0]
+        track_keys = _calib_track_keys(cal)
+        T = len(track_keys)
+        quantiles = np.asarray(cal.quantiles, dtype=np.float32).reshape(T, Q)
+        output_type = _detect_output_type(track_keys, metadata)
+        is_signed = bool(probabilities.min() < 0)
+
+        rows.append({
+            "scorer_key": scorer_key,
+            "output_type": output_type,
+            "row_type": "probabilities",
+            "track_index": -1,
+            "is_signed": is_signed,
+            "values": probabilities,
+        })
+        for track_index in range(T):
+            rows.append({
+                "scorer_key": scorer_key,
+                "output_type": output_type,
+                "row_type": "quantiles",
+                "track_index": track_index,
+                "is_signed": is_signed,
+                "values": quantiles[track_index],
+            })
+        print(f"  {scorer_key[:60]:60s} T={T:5d} Q={Q} -> {output_type}")
+
+    df = pd.DataFrame(rows)
+    df["track_index"] = df["track_index"].astype(np.int32)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    table = pa.Table.from_pandas(df, preserve_index=False)
+    pq.write_table(
+        table,
+        args.output,
+        compression=args.compression,
+        compression_level=args.compression_level,
+    )
+    size_mb = args.output.stat().st_size / 1e6
+    print(f"\nWrote {len(df)} rows for {df.scorer_key.nunique()} scorers "
+          f"-> {args.output} ({size_mb:.1f} MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/alphagenome_pytorch/variant_scoring/README.md
+++ b/src/alphagenome_pytorch/variant_scoring/README.md
@@ -413,7 +413,8 @@ The tidy DataFrame has one row per track with columns:
 - `gene_id`, `gene_name`, `gene_type`, `gene_strand` (if applicable)
 - `scorer`, `output_type`, `is_signed`
 - `track_index`, `track_name`, `track_strand`
-- `raw_score`, `quantile_score`
+- `raw_score` (always), `quantile_score` (only when calibration is enabled — see
+  [Quantile Scores](#quantile-scores))
 - Extended metadata: `ontology_curie`, `gtex_tissue`, `biosample_name`, etc.
 
 ### AnnData Output
@@ -428,6 +429,37 @@ adata = scores_to_anndata(scores, track_metadata=metadata_dict)
 # adata.obs: variant/gene metadata
 # adata.var: track metadata
 ```
+
+### Quantile Scores
+
+Raw variant scores are hard to compare across tracks and scorers. *Quantile scores*
+calibrate each raw per-track score against a fixed null distribution of scores over a
+background set of common variants (348,126 MAF>0.01 chr22 gnomAD v3 SNPs), answering
+"how extreme is this effect relative to common variation?" Signed scorers map to
+roughly `[-1, +1]` (sign = direction), unsigned scorers to `[0, 1]`. Variants with
+`|quantile| > 0.99` are high-confidence functional candidates and correlate well with
+measured eQTL effect sizes (Avsec et al. 2026, Extended Data Fig. 5).
+
+The calibration table is precomputed by DeepMind and bundled as package data
+(`data/variant_quantile_calibration_human.parquet`, human only). Enable it by passing
+`calibration` when constructing the model (or per call):
+
+```python
+scoring_model = VariantScoringModel(model, fasta_path=..., calibration='human')
+# or: scoring_model.score_variant(interval, variant, scorers, calibration='human')
+
+scores = scoring_model.score_variant(interval, variant, scorers=recommended)
+df = scoring_model.tidy_scores(scores)
+df[df['quantile_score'].abs() > 0.99]   # high-confidence hits
+```
+
+When enabled, each `VariantScore` gains a `quantile_scores` tensor (NaN for tracks or
+scorers without calibration), `tidy_scores`/`scores_to_dataframe` add a `quantile_score`
+column, and `scores_to_anndata` adds a `quantiles` layer (matching the official API).
+Without `calibration`, output is unchanged (raw scores only).
+
+The bundled parquet is regenerated from the upstream protobuf with
+`scripts/convert_calibration_to_parquet.py` (a one-time developer tool).
 
 ### Track Metadata
 

--- a/src/alphagenome_pytorch/variant_scoring/__init__.py
+++ b/src/alphagenome_pytorch/variant_scoring/__init__.py
@@ -51,6 +51,9 @@ from .types import (
     Width,
 )
 
+# Quantile calibration
+from .calibration import Calibration, ScorerCalibration
+
 # Aggregation functions
 from .aggregations import align_alternate, compute_aggregation, create_center_mask
 
@@ -105,6 +108,9 @@ __all__ = [
     'scores_to_dataframe',
     'tidy_scores',
     'Width',
+    # Calibration
+    'Calibration',
+    'ScorerCalibration',
     # Aggregations
     'align_alternate',
     'compute_aggregation',

--- a/src/alphagenome_pytorch/variant_scoring/calibration.py
+++ b/src/alphagenome_pytorch/variant_scoring/calibration.py
@@ -1,0 +1,224 @@
+"""Variant-score quantile calibration.
+
+Transforms raw variant scores into *quantile scores* by comparing each raw
+per-track score against a fixed null distribution of scores computed over a
+background set of common variants (348,126 MAF>0.01 chr22 gnomAD v3 SNPs).
+
+The quantile score answers "how extreme is this variant's effect relative to
+common variation?" For signed scorers it lies in roughly [-1, +1] (sign = effect
+direction); for unsigned scorers in [0, 1]. Variants with |quantile| near 1 are
+high-confidence functional candidates (see Avsec et al. 2026, Extended Data Fig. 5).
+
+The null distribution itself is precomputed by DeepMind and shipped as a bundled
+parquet (``data/variant_quantile_calibration_human.parquet``), converted once from
+the upstream ``calibration_scores.pb`` via
+``scripts/convert_calibration_to_parquet.py``. Only human calibration exists upstream.
+
+The transform mirrors ``alphagenome_research`` commit ``dad09dd11``: for each track,
+``searchsorted`` the raw score into that track's sorted quantile breakpoints and map
+the resulting index to a quantile probability, breaking ties uniformly at random on
+tracks with duplicated breakpoints.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+
+import numpy as np
+
+try:
+    import torch
+except ImportError:  # pragma: no cover - torch is a hard dep in practice
+    torch = None
+
+
+@dataclasses.dataclass(frozen=True)
+class ScorerCalibration:
+    """Per-scorer calibration table.
+
+    Attributes:
+        quantiles: ``(T, Q)`` float32 array of sorted quantile breakpoints, one row
+            per calibrated track. Tracks are aligned to the *first* ``T`` output
+            tracks of the scorer's head (the named human tracks).
+        probabilities: ``(Q,)`` float32 array of quantile probabilities mapped to by
+            each breakpoint (signed scorers span ~[-1, 1], unsigned ~[0, 1]).
+        dup_mask: ``(T,)`` bool array; True where a track has duplicated breakpoints
+            (requires random tie-breaking).
+        is_signed: Whether this scorer's quantiles are directional.
+        output_type: The scorer's output type value (e.g. ``"atac"``), for reference.
+    """
+
+    quantiles: np.ndarray
+    probabilities: np.ndarray
+    dup_mask: np.ndarray
+    is_signed: bool
+    output_type: str
+
+    @property
+    def num_tracks(self) -> int:
+        return int(self.quantiles.shape[0])
+
+
+class Calibration:
+    """Collection of per-scorer calibration tables, keyed by scorer name.
+
+    Keys are the upstream canonical scorer strings (e.g.
+    ``"CenterMaskScorer(requested_output=ATAC, width=501, aggregation_type=DIFF_LOG2_SUM)"``),
+    matching ``BaseVariantScorer.calibration_key``.
+    """
+
+    def __init__(
+        self,
+        scorers: dict[str, ScorerCalibration],
+        *,
+        seed: int = 42,
+    ):
+        self._scorers = scorers
+        self._seed = seed
+
+    def has_scorer(self, scorer_key: str | None) -> bool:
+        """Whether calibration data exists for the given scorer key."""
+        return scorer_key is not None and scorer_key in self._scorers
+
+    def scorer_keys(self) -> list[str]:
+        return list(self._scorers.keys())
+
+    def __len__(self) -> int:
+        return len(self._scorers)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._scorers
+
+    def quantile_scores(
+        self,
+        scorer_key: str,
+        raw_scores,
+        *,
+        break_quantile_ties: bool = True,
+        seed: int | None = None,
+    ):
+        """Compute quantile scores for a single variant's per-track raw scores.
+
+        Args:
+            scorer_key: Upstream canonical scorer key (see ``has_scorer``).
+            raw_scores: 1-D tensor/array of per-track raw scores, length = the
+                scorer's output track count. Tracks beyond the calibrated set (and
+                NaN inputs) yield NaN quantile scores.
+            break_quantile_ties: When True (default, matching the API), tracks with
+                duplicated quantile breakpoints have ties broken uniformly at random
+                within the tied run. Set False for a fully deterministic mapping
+                (uses the left edge of the run), independent of ``seed``.
+            seed: Optional override for the random tie-break RNG (defaults to the
+                instance seed for reproducibility). Ignored when
+                ``break_quantile_ties`` is False.
+
+        Returns:
+            Quantile scores matching the input type (torch tensor or numpy array)
+            and shape.
+        """
+        cal = self._scorers.get(scorer_key)
+        if cal is None:
+            raise KeyError(f"No calibration data for scorer: {scorer_key!r}")
+
+        is_torch = torch is not None and torch.is_tensor(raw_scores)
+        if is_torch:
+            raw_np = raw_scores.detach().float().cpu().numpy()
+        else:
+            raw_np = np.asarray(raw_scores, dtype=np.float32)
+
+        flat = raw_np.reshape(-1)
+        out = np.full(flat.shape[0], np.nan, dtype=np.float32)
+
+        rng = np.random.default_rng(self._seed if seed is None else seed)
+        probs = cal.probabilities
+        last = probs.shape[0] - 1
+        n = min(flat.shape[0], cal.num_tracks)
+
+        for i in range(n):
+            value = flat[i]
+            if np.isnan(value):
+                continue
+            breakpoints = cal.quantiles[i]
+            idx = int(np.searchsorted(breakpoints, value, side="left"))
+            if break_quantile_ties and cal.dup_mask[i]:
+                end = int(np.searchsorted(breakpoints, value, side="right"))
+                # Uniformly pick within the tied run [idx, end]; equals idx when no tie.
+                idx = int(rng.integers(idx, end, endpoint=True))
+            if idx > last:
+                idx = last
+            out[i] = probs[idx]
+
+        result = out.reshape(raw_np.shape)
+        if is_torch:
+            return torch.from_numpy(result).to(raw_scores.device)
+        return result
+
+    # ------------------------------------------------------------------ loading
+
+    @classmethod
+    def load(cls, path: str | Path, *, seed: int = 42) -> "Calibration":
+        """Load calibration from a parquet file produced by the converter."""
+        import pandas as pd
+
+        df = pd.read_parquet(path)
+        scorers: dict[str, ScorerCalibration] = {}
+        for scorer_key, group in df.groupby("scorer_key", sort=False):
+            prob_rows = group[group["row_type"] == "probabilities"]
+            quant_rows = group[group["row_type"] == "quantiles"].sort_values(
+                "track_index"
+            )
+            if prob_rows.empty or quant_rows.empty:
+                raise ValueError(
+                    f"Malformed calibration for scorer {scorer_key!r}: "
+                    "missing probabilities or quantiles rows."
+                )
+            probabilities = np.asarray(
+                prob_rows.iloc[0]["values"], dtype=np.float32
+            )
+            quantiles = np.stack(
+                [np.asarray(v, dtype=np.float32) for v in quant_rows["values"]],
+                axis=0,
+            )
+            dup_mask = np.any(np.diff(quantiles, axis=1) == 0, axis=1)
+            scorers[str(scorer_key)] = ScorerCalibration(
+                quantiles=quantiles,
+                probabilities=probabilities,
+                dup_mask=dup_mask,
+                is_signed=bool(quant_rows.iloc[0]["is_signed"]),
+                output_type=str(quant_rows.iloc[0]["output_type"]),
+            )
+        return cls(scorers, seed=seed)
+
+    @classmethod
+    def from_package(
+        cls,
+        organism: str = "human",
+        *,
+        seed: int = 42,
+    ) -> "Calibration":
+        """Load the calibration bundled in the package data directory.
+
+        Only ``human`` calibration exists upstream.
+        """
+        filename = f"variant_quantile_calibration_{organism}.parquet"
+
+        # Prefer importlib.resources (mirrors named_outputs.OutputMetadata loading).
+        try:
+            import importlib.resources as resources
+
+            files = resources.files("alphagenome_pytorch.data")
+            resource = files.joinpath(filename)
+            if hasattr(resource, "is_file") and resource.is_file():
+                return cls.load(str(resource), seed=seed)
+        except (TypeError, AttributeError, ModuleNotFoundError):
+            pass
+
+        fallback = Path(__file__).resolve().parent.parent / "data" / filename
+        if fallback.exists():
+            return cls.load(fallback, seed=seed)
+
+        raise FileNotFoundError(
+            f"Bundled calibration not found: {filename}. "
+            "Run scripts/convert_calibration_to_parquet.py to generate it."
+        )

--- a/src/alphagenome_pytorch/variant_scoring/inference.py
+++ b/src/alphagenome_pytorch/variant_scoring/inference.py
@@ -19,6 +19,7 @@ from .types import Interval, OutputType, TrackMetadata, Variant, VariantScore, t
 
 if TYPE_CHECKING:
     from ..model import AlphaGenome
+    from .calibration import Calibration
 
 
 class VariantScoringModel:
@@ -80,6 +81,7 @@ class VariantScoringModel:
         polya_path: str | Path | None = None,
         device: str | torch.device | None = None,
         default_organism: str | int | None = 'human',
+        calibration: 'Calibration | str | Path | None' = None,
     ):
         """Initialize variant scoring wrapper.
 
@@ -93,6 +95,11 @@ class VariantScoringModel:
                 If None, PolyadenylationScorer will use peak detection fallback.
             device: Device to run inference on. If None, uses model's device.
             default_organism: Default organism to use for scoring ('human', 'mouse', or index).
+            calibration: Optional variant-score quantile calibration. Pass a
+                ``Calibration`` instance, an organism name (e.g. ``"human"``) to load
+                the bundled table, or a path to a calibration parquet. When set,
+                scoring also attaches per-track quantile scores. Defaults to None
+                (raw scores only).
         """
         self.model = model
         
@@ -133,6 +140,9 @@ class VariantScoringModel:
         self._gene_annotation: GeneAnnotation | None = None
         if gtf_path is not None:
             self._gene_annotation = GeneAnnotation(gtf_path)
+
+        # Initialize quantile calibration if provided
+        self._calibration: 'Calibration | None' = self._resolve_calibration(calibration)
 
         # Initialize polyA annotation if path provided
         self._polya_annotation: 'PolyAAnnotation | None' = None
@@ -194,6 +204,39 @@ class VariantScoringModel:
     def polya_annotation(self) -> 'PolyAAnnotation | None':
         """PolyA annotation for PolyadenylationScorer."""
         return self._polya_annotation
+
+    @property
+    def calibration(self) -> 'Calibration | None':
+        """Variant-score quantile calibration, if configured."""
+        return self._calibration
+
+    @staticmethod
+    def _resolve_calibration(
+        calibration: 'Calibration | str | Path | None',
+    ) -> 'Calibration | None':
+        """Coerce the constructor argument into a Calibration (or None)."""
+        if calibration is None:
+            return None
+        from .calibration import Calibration
+
+        if isinstance(calibration, Calibration):
+            return calibration
+        # Organism name (e.g. "human") -> bundled table; otherwise treat as a path.
+        if isinstance(calibration, str) and calibration in ("human", "mouse"):
+            return Calibration.from_package(calibration)
+        return Calibration.load(calibration)
+
+    def _apply_calibration(
+        self,
+        score_result: 'VariantScore | list[VariantScore]',
+        calibration: 'Calibration',
+    ) -> None:
+        """Attach quantile scores to a scorer's result in place."""
+        items = score_result if isinstance(score_result, list) else [score_result]
+        for item in items:
+            key = item.scorer.calibration_key
+            if calibration.has_scorer(key):
+                item.quantile_scores = calibration.quantile_scores(key, item.scores)
 
     @property
     def track_metadata(self) -> dict[OutputType, list[TrackMetadata]]:
@@ -517,6 +560,7 @@ class VariantScoringModel:
         organism: str | int | None = None,
         gene_annotation: GeneAnnotation | None = None,
         to_cpu: bool = False,
+        calibration: 'Calibration | str | Path | None' = None,
     ) -> list[VariantScore | list[VariantScore]]:
         """Score a single variant with multiple scorers.
 
@@ -527,11 +571,20 @@ class VariantScoringModel:
             organism: 'human', 'mouse', or index. Uses default_organism if None.
             gene_annotation: Optional GeneAnnotation.
             to_cpu: If True, move scores to CPU and clear GPU cache.
+            calibration: Optional quantile calibration overriding the instance
+                calibration. Accepts a ``Calibration``, an organism name
+                (e.g. ``"human"``), or a path to a calibration parquet. When
+                available, per-track quantile scores are attached to each result
+                (uncalibrated tracks/scorers get NaN/none).
 
         Returns:
             List of VariantScore objects
         """
         organism_index = self._resolve_organism_index(organism)
+        if calibration is None:
+            calibration = getattr(self, "_calibration", None)
+        else:
+            calibration = self._resolve_calibration(calibration)
 
         # Check if we need unified splicing pass
         unified_splicing = any(s.name == "SpliceJunctionScorer()" for s in scorers)
@@ -583,6 +636,9 @@ class VariantScoringModel:
                     if hasattr(s, 'scores') and torch.is_tensor(s.scores):
                         s.scores = s.scores.to(dtype=torch.float32, device='cpu')
 
+            if calibration is not None:
+                self._apply_calibration(score_result, calibration)
+
             scores.append(score_result)
 
         if to_cpu:
@@ -600,6 +656,7 @@ class VariantScoringModel:
         gene_annotation: GeneAnnotation | None = None,
         to_cpu: bool = False,
         progress: bool = True,
+        calibration: 'Calibration | str | Path | None' = None,
     ) -> list[list[VariantScore | list[VariantScore]]]:
         """Score multiple variants with multiple scorers.
 
@@ -629,6 +686,10 @@ class VariantScoringModel:
         if gene_annotation is None:
             gene_annotation = self._gene_annotation
 
+        # Resolve calibration once (avoids reloading a bundled table per variant)
+        if calibration is not None:
+            calibration = self._resolve_calibration(calibration)
+
         # Set up progress bar
         if progress:
             try:
@@ -652,6 +713,7 @@ class VariantScoringModel:
                 organism=organism,
                 gene_annotation=gene_annotation,
                 to_cpu=to_cpu,
+                calibration=calibration,
             )
             results.append(scores)
 

--- a/src/alphagenome_pytorch/variant_scoring/scorers/base.py
+++ b/src/alphagenome_pytorch/variant_scoring/scorers/base.py
@@ -51,6 +51,17 @@ class BaseVariantScorer(ABC):
         """Whether scores are directional (can be negative)."""
         pass
 
+    @property
+    def calibration_key(self) -> str | None:
+        """Upstream canonical scorer name used to look up quantile calibration.
+
+        Quantile calibration tables (see ``variant_scoring.calibration``) are keyed
+        by the upstream AlphaGenome scorer string, which differs from this port's
+        ``name``. Subclasses that have calibration data override this to return the
+        matching key; returns ``None`` when no calibration is available.
+        """
+        return None
+
     @abstractmethod
     def score(
         self,

--- a/src/alphagenome_pytorch/variant_scoring/scorers/center_mask.py
+++ b/src/alphagenome_pytorch/variant_scoring/scorers/center_mask.py
@@ -147,6 +147,15 @@ class CenterMaskScorer(BaseVariantScorer):
     def is_signed(self) -> bool:
         return self._aggregation_type.is_signed()
 
+    @property
+    def calibration_key(self) -> str | None:
+        return (
+            f"CenterMaskScorer("
+            f"requested_output={self._requested_output.name}, "
+            f"width={self._width}, "
+            f"aggregation_type={self._aggregation_type.name})"
+        )
+
     def score(
         self,
         ref_outputs: dict[str, Any],

--- a/src/alphagenome_pytorch/variant_scoring/scorers/contact_map.py
+++ b/src/alphagenome_pytorch/variant_scoring/scorers/contact_map.py
@@ -58,6 +58,10 @@ class ContactMapScorer(BaseVariantScorer):
         return "ContactMapScorer()"
 
     @property
+    def calibration_key(self) -> str | None:
+        return "ContactMapScorer()"
+
+    @property
     def requested_output(self) -> OutputType:
         return OutputType.CONTACT_MAPS
 

--- a/src/alphagenome_pytorch/variant_scoring/scorers/gene_mask.py
+++ b/src/alphagenome_pytorch/variant_scoring/scorers/gene_mask.py
@@ -121,6 +121,10 @@ class GeneMaskLFCScorer(BaseVariantScorer):
     def is_signed(self) -> bool:
         return True
 
+    @property
+    def calibration_key(self) -> str | None:
+        return f"GeneMaskLFCScorer(requested_output={self._requested_output.name})"
+
     def score(
         self,
         ref_outputs: dict[str, Any],
@@ -327,6 +331,10 @@ class GeneMaskActiveScorer(BaseVariantScorer):
     @property
     def is_signed(self) -> bool:
         return False
+
+    @property
+    def calibration_key(self) -> str | None:
+        return f"GeneMaskActiveScorer(requested_output={self._requested_output.name})"
 
     def score(
         self,

--- a/src/alphagenome_pytorch/variant_scoring/scorers/polyadenylation.py
+++ b/src/alphagenome_pytorch/variant_scoring/scorers/polyadenylation.py
@@ -157,6 +157,10 @@ class PolyadenylationScorer(BaseVariantScorer):
         return "PolyadenylationScorer()"
 
     @property
+    def calibration_key(self) -> str | None:
+        return "PolyadenylationScorer()"
+
+    @property
     def requested_output(self) -> OutputType:
         return OutputType.RNA_SEQ
 

--- a/src/alphagenome_pytorch/variant_scoring/scorers/splicing.py
+++ b/src/alphagenome_pytorch/variant_scoring/scorers/splicing.py
@@ -82,6 +82,14 @@ class GeneMaskSplicingScorer(BaseVariantScorer):
     def is_signed(self) -> bool:
         return False
 
+    @property
+    def calibration_key(self) -> str | None:
+        return (
+            f"GeneMaskSplicingScorer("
+            f"requested_output={self._requested_output.name}, "
+            f"width={self._width})"
+        )
+
     def score(
         self,
         ref_outputs: dict[str, Any],
@@ -272,6 +280,10 @@ class SpliceJunctionScorer(BaseVariantScorer):
 
     @property
     def name(self) -> str:
+        return "SpliceJunctionScorer()"
+
+    @property
+    def calibration_key(self) -> str | None:
         return "SpliceJunctionScorer()"
 
     @property

--- a/src/alphagenome_pytorch/variant_scoring/types.py
+++ b/src/alphagenome_pytorch/variant_scoring/types.py
@@ -346,6 +346,7 @@ class VariantScore:
     gene_strand: str | None = None
     junction_start: int | None = None
     junction_end: int | None = None
+    quantile_scores: torch.Tensor | None = None  # (num_tracks,), NaN where uncalibrated
 
     @property
     def scorer_name(self) -> str:
@@ -377,6 +378,11 @@ class VariantScore:
             'junction_Start': self.junction_start,
             'junction_End': self.junction_end,
             'scores': self.scores.float().cpu().numpy(),
+            'quantile_scores': (
+                self.quantile_scores.float().cpu().numpy()
+                if self.quantile_scores is not None
+                else None
+            ),
         }
 
 
@@ -414,9 +420,12 @@ def scores_to_dataframe(
     for score in flat_scores:
         base = score.to_dict()
         track_scores = base.pop('scores')
+        quantile_scores = base.pop('quantile_scores')
 
         for i, s in enumerate(track_scores):
             row = {**base, 'track_index': i, 'raw_score': float(s)}
+            if quantile_scores is not None:
+                row['quantile_score'] = float(quantile_scores[i])
             rows.append(row)
 
     return pd.DataFrame(rows)
@@ -562,6 +571,11 @@ def tidy_scores(
         num_tracks = score.scores.shape[0]
         output_type = score.output_type
         track_scores = score.scores.float().cpu().numpy()
+        quantile_scores = (
+            score.quantile_scores.float().cpu().numpy()
+            if score.quantile_scores is not None
+            else None
+        )
 
         # Get track metadata for this output type if available
         output_track_meta = None
@@ -583,6 +597,8 @@ def tidy_scores(
                 'track_index': track_idx,
                 'raw_score': float(track_scores[track_idx]),
             }
+            if quantile_scores is not None:
+                row['quantile_score'] = float(quantile_scores[track_idx])
 
             # Add track metadata if available
             if output_track_meta is not None and track_idx < len(output_track_meta):
@@ -617,9 +633,12 @@ def tidy_scores(
         'track_name', 'track_strand', 
         'Assay title', 'ontology_curie', 
         'biosample_name', 'biosample_type', 
-        'transcription_factor', 'histone_mark', 'gtex_tissue', 
+        'transcription_factor', 'histone_mark', 'gtex_tissue',
         'raw_score'
     ]
+    # quantile_score only appears when calibration was applied; keep it next to raw_score.
+    if 'quantile_score' in df.columns:
+        requested_cols.append('quantile_score')
     for col in requested_cols:
         if col not in df.columns:
             df[col] = None
@@ -748,6 +767,8 @@ def scores_to_anndata(
     # Build observation (variant/gene) metadata and score matrix
     obs_data = []
     X_rows = []
+    quantile_rows = []
+    any_quantiles = any(s.quantile_scores is not None for s in flat_scores)
 
     for score in flat_scores:
         # Extract scores as numpy array
@@ -757,6 +778,14 @@ def scores_to_anndata(
             scores_np = np.asarray(score.scores)
 
         X_rows.append(scores_np)
+
+        if any_quantiles:
+            if score.quantile_scores is not None:
+                q = score.quantile_scores
+                q_np = q.float().cpu().numpy() if torch.is_tensor(q) else np.asarray(q)
+            else:
+                q_np = np.full(scores_np.shape, np.nan, dtype=np.float32)
+            quantile_rows.append(q_np)
 
         # Build obs row
         obs_row = {
@@ -821,6 +850,10 @@ def scores_to_anndata(
         obs=obs,
         var=var,
     )
+
+    # Add quantile scores as a layer (matches the official API output format)
+    if any_quantiles:
+        adata.layers['quantiles'] = np.stack(quantile_rows, axis=0).astype(np.float32)
 
     # Add scorer info to uns
     if flat_scores:

--- a/tests/integration/test_all_19_scorers.py
+++ b/tests/integration/test_all_19_scorers.py
@@ -1259,3 +1259,164 @@ class TestAllScorersComprehensive:
             f"Found {unexpected_failures} unexpected failures! "
             f"See test output for details."
         )
+
+
+# =============================================================================
+# Quantile-score parity vs API
+# =============================================================================
+
+
+def match_quantiles_by_track_name(
+    pt_quantiles: np.ndarray,
+    pt_track_metadata: list,
+    api_adata: 'anndata.AnnData',
+) -> tuple[np.ndarray, np.ndarray, int]:
+    """Align PyTorch and API quantile scores by track name (+strand).
+
+    Mirrors ``match_scores_by_track_name`` but reads the API's
+    ``layers['quantiles']`` instead of ``X``, and drops any pair where either
+    side is non-finite (uncalibrated tracks carry NaN).
+    """
+    if "quantiles" not in api_adata.layers:
+        return np.array([]), np.array([]), 0
+
+    api_q = np.asarray(api_adata.layers["quantiles"]).reshape(-1)
+
+    if "name" in api_adata.var:
+        api_track_names = api_adata.var["name"].tolist()
+    else:
+        api_track_names = list(api_adata.var.index)
+    api_strands = api_adata.var["strand"].tolist() if "strand" in api_adata.var else []
+
+    key_to_idx, name_to_idx = {}, {}
+    for i, meta in enumerate(pt_track_metadata):
+        if hasattr(meta, "track_name"):
+            name_to_idx[meta.track_name] = i
+            key_to_idx[f"{meta.track_name}|{getattr(meta, 'track_strand', '.')}"] = i
+
+    aligned_pt, aligned_api = [], []
+    for ai, name in enumerate(api_track_names):
+        idx = None
+        if api_strands:
+            idx = key_to_idx.get(f"{name}|{api_strands[ai]}")
+        if idx is None:
+            idx = name_to_idx.get(name)
+        if idx is not None and idx < len(pt_quantiles) and ai < len(api_q):
+            aligned_pt.append(pt_quantiles[idx])
+            aligned_api.append(api_q[ai])
+
+    apt = np.asarray(aligned_pt, dtype=np.float64)
+    aapi = np.asarray(aligned_api, dtype=np.float64)
+    finite = np.isfinite(apt) & np.isfinite(aapi)
+    return apt[finite], aapi[finite], int(finite.sum())
+
+
+@pytest.mark.integration
+@pytest.mark.api
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+class TestQuantileScoresVsAPI:
+    """Quantile-score parity against the API for signed CenterMask scorers.
+
+    Quantiles are *opt-in* (pass ``calibration="human"``). Because they use the
+    same calibration table we converted from the API's protobuf, this test
+    validates the end-to-end quantile path — in particular that our model emits
+    tracks in the API's calibration order (a misalignment would assign quantiles
+    to the wrong tracks and only this test would catch it) and that raw-score
+    agreement propagates into quantile agreement.
+
+    Comparison uses Pearson correlation (ordering/alignment), a robust median
+    |quantile diff| gate (magnitude), and a coarse fraction-within-tolerance
+    backstop — not exact equality: quantiles are discretized to 999 levels, our
+    raw scores differ from the API's by ~1%, and tracks with duplicated breakpoints
+    are tie-broken at random with an independent seed. Restricted to the low-tie
+    signed scorers (ATAC/DNASE/CAGE/PROCAP); fully-tied scorers (CHIP-TF/Histone)
+    and per-gene/junction scorers are intentionally out of scope here.
+    """
+
+    # Correlation is the strong ordering/alignment gate (quantile is a deterministic
+    # monotone transform of the raw score per track, and raw scores agree to ~1%,
+    # so cross-track correlation should be very high).
+    QUANTILE_CORR_THRESHOLD = 0.95
+    # Primary magnitude gate: the *median* per-track |quantile diff| must be tiny.
+    # Median ignores the minority of large flips caused by ±1 saturation and steep
+    # regions of the calibration CDF amplifying the ~1% raw-score gap, so it is both
+    # tighter and not hostage to that heavy tail. Signed quantiles span [-1, 1].
+    QUANTILE_MEDIAN_ATOL = 0.02
+    # Coarse gross-error backstop only (median above is the real magnitude gate):
+    # most tracks must land within QUANTILE_ATOL of the API quantile.
+    QUANTILE_FRAC_CLOSE = 0.75
+    QUANTILE_ATOL = 0.15
+
+    @pytest.mark.parametrize(
+        "output_type,width,test_id",
+        [
+            (OutputType.ATAC, 501, "quantile_atac_diff_log2_sum"),
+            (OutputType.DNASE, 501, "quantile_dnase_diff_log2_sum"),
+            (OutputType.CAGE, 501, "quantile_cage_diff_log2_sum"),
+            (OutputType.PROCAP, 501, "quantile_procap_diff_log2_sum"),
+        ],
+    )
+    def test_quantiles_match_api(
+        self,
+        cached_api_scores,
+        pytorch_scoring_model,
+        test_variant,
+        test_interval,
+        output_type,
+        width,
+        test_id,
+    ):
+        pt_scorer = CenterMaskScorer(
+            requested_output=output_type,
+            width=width,
+            aggregation_type=AggregationType.DIFF_LOG2_SUM,
+        )
+
+        # Opt-in to quantile scoring via the bundled human calibration table.
+        pt_scores = pytorch_scoring_model.score_variant(
+            interval=test_interval,
+            variant=test_variant,
+            scorers=[pt_scorer],
+            organism="human",
+            to_cpu=True,
+            calibration="human",
+        )
+        pt_quantiles = pt_scores[0].quantile_scores
+        assert pt_quantiles is not None, "calibration='human' did not attach quantiles"
+        pt_quantiles = pt_quantiles.numpy()
+
+        api_adata = find_matching_api_scorer(pt_scorer, cached_api_scores)
+        assert api_adata is not None, f"No matching API scorer for {test_id}"
+        if "quantiles" not in api_adata.layers:
+            pytest.skip("API cache has no 'quantiles' layer; re-fetch to enable.")
+
+        pt_meta = pytorch_scoring_model.get_track_metadata("human").get(output_type, [])
+        aligned_pt, aligned_api, n_matched = match_quantiles_by_track_name(
+            pt_quantiles, pt_meta, api_adata
+        )
+        assert n_matched > 0, f"{test_id}: no calibrated tracks aligned"
+
+        abs_diff = np.abs(aligned_pt - aligned_api)
+        corr = float(np.corrcoef(aligned_pt, aligned_api)[0, 1])
+        median_abs = float(np.median(abs_diff))
+        frac_close = float(np.mean(abs_diff <= self.QUANTILE_ATOL))
+        sign_agree = float(np.mean(np.sign(aligned_pt) == np.sign(aligned_api)))
+
+        print(f"\n[{test_id}] matched={n_matched} corr={corr:.4f} "
+              f"median_abs={median_abs:.4f} frac_close={frac_close:.3f} "
+              f"sign_agree={sign_agree:.3f} "
+              f"pt_range=[{aligned_pt.min():.3f},{aligned_pt.max():.3f}] "
+              f"api_range=[{aligned_api.min():.3f},{aligned_api.max():.3f}]")
+
+        assert corr >= self.QUANTILE_CORR_THRESHOLD, (
+            f"{test_id}: quantile correlation {corr:.4f} "
+            f"< {self.QUANTILE_CORR_THRESHOLD}"
+        )
+        assert median_abs <= self.QUANTILE_MEDIAN_ATOL, (
+            f"{test_id}: median |quantile diff| {median_abs:.4f} "
+            f"> {self.QUANTILE_MEDIAN_ATOL}"
+        )
+        assert frac_close >= self.QUANTILE_FRAC_CLOSE, (
+            f"{test_id}: only {frac_close:.1%} of quantiles within "
+            f"{self.QUANTILE_ATOL} (need {self.QUANTILE_FRAC_CLOSE:.0%})"
+        )

--- a/tests/unit/test_variant_quantile_calibration.py
+++ b/tests/unit/test_variant_quantile_calibration.py
@@ -1,0 +1,336 @@
+"""Unit tests for variant-score quantile calibration."""
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from alphagenome_pytorch.variant_scoring import (
+    AggregationType,
+    Calibration,
+    CenterMaskScorer,
+    ContactMapScorer,
+    GeneMaskActiveScorer,
+    GeneMaskLFCScorer,
+    GeneMaskSplicingScorer,
+    OutputType,
+    PolyadenylationScorer,
+    ScorerCalibration,
+    SpliceJunctionScorer,
+    VariantScore,
+    VariantScoringModel,
+    scores_to_anndata,
+    scores_to_dataframe,
+    tidy_scores,
+)
+from alphagenome_pytorch.variant_scoring.types import Interval, Variant
+
+_KEY = "FakeScorer()"
+
+
+def _make_calibration(seed: int = 42) -> Calibration:
+    """Two-track calibration: track 0 unique breakpoints, track 1 with a tie plateau."""
+    probabilities = np.linspace(-1.0, 1.0, 5).astype(np.float32)  # [-1,-.5,0,.5,1]
+    quantiles = np.array(
+        [
+            [0.0, 1.0, 2.0, 3.0, 4.0],  # strictly increasing
+            [0.0, 5.0, 5.0, 5.0, 9.0],  # duplicated plateau at 5.0
+        ],
+        dtype=np.float32,
+    )
+    dup_mask = np.any(np.diff(quantiles, axis=1) == 0, axis=1)
+    sc = ScorerCalibration(
+        quantiles=quantiles,
+        probabilities=probabilities,
+        dup_mask=dup_mask,
+        is_signed=True,
+        output_type="atac",
+    )
+    return Calibration({_KEY: sc}, seed=seed)
+
+
+# --------------------------------------------------------------------------- core
+
+@pytest.mark.unit
+def test_has_scorer_and_keys():
+    cal = _make_calibration()
+    assert cal.has_scorer(_KEY)
+    assert not cal.has_scorer("missing")
+    assert not cal.has_scorer(None)
+    assert cal.scorer_keys() == [_KEY]
+    assert len(cal) == 1
+
+
+@pytest.mark.unit
+def test_quantile_transform_monotone_and_bounds():
+    cal = _make_calibration()
+    # Track 0: searchsorted(left) maps value -> probability bin.
+    raw = np.array([-100.0, 0.0, 1.5, 4.0, 100.0, 0.0], dtype=np.float32)[:2]
+    # Use a 2-track input (only track 0 and 1 calibrated).
+    q = cal.quantile_scores(_KEY, np.array([1.5, 0.0], dtype=np.float32))
+    # track0: 1.5 -> searchsorted([0,1,2,3,4],1.5,'left')=2 -> prob[2]=0.0
+    assert q[0] == pytest.approx(0.0)
+
+    # Below min -> idx 0 -> prob[0] = -1; above max -> clamp -> prob[-1] = +1
+    lo = cal.quantile_scores(_KEY, np.array([-100.0, -100.0], dtype=np.float32))
+    hi = cal.quantile_scores(_KEY, np.array([100.0, 100.0], dtype=np.float32))
+    assert lo[0] == pytest.approx(-1.0)
+    assert hi[0] == pytest.approx(1.0)
+
+    # Monotone nondecreasing on track 0.
+    vals = np.linspace(-1, 5, 40, dtype=np.float32)
+    qs = [float(cal.quantile_scores(_KEY, np.array([v, 0.0], np.float32))[0]) for v in vals]
+    assert all(b >= a - 1e-6 for a, b in zip(qs, qs[1:]))
+
+
+@pytest.mark.unit
+def test_uncalibrated_tracks_and_nan_passthrough():
+    cal = _make_calibration()
+    # Input longer than the 2 calibrated tracks: extras must be NaN.
+    raw = np.array([1.5, 0.0, 3.3, 7.7], dtype=np.float32)
+    q = cal.quantile_scores(_KEY, raw)
+    assert not np.isnan(q[0]) and not np.isnan(q[1])
+    assert np.isnan(q[2]) and np.isnan(q[3])
+
+    # NaN input -> NaN output, calibrated neighbours unaffected.
+    q2 = cal.quantile_scores(_KEY, np.array([np.nan, 0.0], dtype=np.float32))
+    assert np.isnan(q2[0])
+    assert not np.isnan(q2[1])
+
+
+@pytest.mark.unit
+def test_tie_break_is_seeded_and_within_plateau():
+    # Track 1 has a plateau [5,5,5]; value 5.0 -> left=1, right=4 -> idx in {1,2,3,4}.
+    cal_a = _make_calibration(seed=7)
+    cal_b = _make_calibration(seed=7)
+    cal_c = _make_calibration(seed=8)
+    val = np.array([0.0, 5.0], dtype=np.float32)
+    qa = float(cal_a.quantile_scores(_KEY, val)[1])
+    qb = float(cal_b.quantile_scores(_KEY, val)[1])
+    assert qa == qb  # same seed -> deterministic
+    probs = cal_a._scorers[_KEY].probabilities
+    assert qa in set(float(p) for p in probs[1:5])  # within the tied run
+    # Per-call seed override also works and is reproducible.
+    q_seeded = float(cal_c.quantile_scores(_KEY, val, seed=7)[1])
+    assert q_seeded == qa
+
+
+@pytest.mark.unit
+def test_break_quantile_ties_false_is_deterministic():
+    # Track 1 plateau [5,5,5]; value 5.0. With ties off -> always the left edge
+    # (searchsorted side='left' -> idx 1 -> prob[1]), regardless of seed.
+    val = np.array([0.0, 5.0], dtype=np.float32)
+    cal = _make_calibration(seed=7)
+    left_prob = float(cal._scorers[_KEY].probabilities[1])
+    q1 = float(cal.quantile_scores(_KEY, val, break_quantile_ties=False, seed=1)[1])
+    q2 = float(cal.quantile_scores(_KEY, val, break_quantile_ties=False, seed=999)[1])
+    assert q1 == q2 == left_prob
+    # Non-tied track 0 is unaffected by the flag.
+    on = float(cal.quantile_scores(_KEY, val, break_quantile_ties=True, seed=1)[0])
+    off = float(cal.quantile_scores(_KEY, val, break_quantile_ties=False)[0])
+    assert on == off
+
+
+@pytest.mark.unit
+def test_input_type_preserved():
+    cal = _make_calibration()
+    raw_np = np.array([1.5, 0.0], dtype=np.float32)
+    out_np = cal.quantile_scores(_KEY, raw_np)
+    assert isinstance(out_np, np.ndarray) and out_np.shape == (2,)
+
+    out_t = cal.quantile_scores(_KEY, torch.tensor([1.5, 0.0]))
+    assert torch.is_tensor(out_t) and out_t.shape == (2,)
+
+
+@pytest.mark.unit
+def test_unknown_scorer_raises():
+    cal = _make_calibration()
+    with pytest.raises(KeyError):
+        cal.quantile_scores("nope", np.zeros(2, dtype=np.float32))
+
+
+# ----------------------------------------------------------------------- parquet
+
+@pytest.mark.unit
+def test_parquet_round_trip(tmp_path):
+    cal = _make_calibration()
+    sc = cal._scorers[_KEY]
+    rows = [{
+        "scorer_key": _KEY, "output_type": "atac", "row_type": "probabilities",
+        "track_index": -1, "is_signed": True, "values": sc.probabilities,
+    }]
+    for i in range(sc.num_tracks):
+        rows.append({
+            "scorer_key": _KEY, "output_type": "atac", "row_type": "quantiles",
+            "track_index": i, "is_signed": True, "values": sc.quantiles[i],
+        })
+    path = tmp_path / "calib.parquet"
+    pd.DataFrame(rows).to_parquet(path, index=False)
+
+    loaded = Calibration.load(path)
+    assert loaded.has_scorer(_KEY)
+    lsc = loaded._scorers[_KEY]
+    np.testing.assert_array_equal(lsc.quantiles, sc.quantiles)
+    np.testing.assert_array_equal(lsc.probabilities, sc.probabilities)
+    np.testing.assert_array_equal(lsc.dup_mask, sc.dup_mask)
+    assert lsc.is_signed and lsc.output_type == "atac"
+
+
+# --------------------------------------------------------------- bundled package
+
+# All recommended scorer configurations and the output types they cover.
+_RECOMMENDED = [
+    CenterMaskScorer(OutputType.ATAC, 501, AggregationType.DIFF_LOG2_SUM),
+    CenterMaskScorer(OutputType.ATAC, 501, AggregationType.ACTIVE_SUM),
+    CenterMaskScorer(OutputType.DNASE, 501, AggregationType.DIFF_LOG2_SUM),
+    CenterMaskScorer(OutputType.CAGE, 501, AggregationType.DIFF_LOG2_SUM),
+    CenterMaskScorer(OutputType.PROCAP, 501, AggregationType.DIFF_LOG2_SUM),
+    CenterMaskScorer(OutputType.CHIP_TF, 501, AggregationType.DIFF_LOG2_SUM),
+    CenterMaskScorer(OutputType.CHIP_HISTONE, 2001, AggregationType.DIFF_LOG2_SUM),
+    GeneMaskLFCScorer(OutputType.RNA_SEQ),
+    GeneMaskActiveScorer(OutputType.RNA_SEQ),
+    GeneMaskSplicingScorer(OutputType.SPLICE_SITES, None),
+    GeneMaskSplicingScorer(OutputType.SPLICE_SITE_USAGE, None),
+    SpliceJunctionScorer(),
+    ContactMapScorer(),
+    PolyadenylationScorer(),
+]
+
+
+@pytest.mark.unit
+def test_bundled_calibration_loads():
+    cal = Calibration.from_package("human")
+    assert len(cal) == 19
+    atac = cal._scorers[
+        "CenterMaskScorer(requested_output=ATAC, width=501, aggregation_type=DIFF_LOG2_SUM)"
+    ]
+    assert atac.quantiles.shape == (167, 999)
+    assert atac.probabilities.shape == (999,)
+    assert atac.is_signed
+
+
+@pytest.mark.unit
+def test_recommended_scorer_keys_present_in_bundle():
+    cal = Calibration.from_package("human")
+    bundled = set(cal.scorer_keys())
+    for scorer in _RECOMMENDED:
+        assert scorer.calibration_key in bundled, scorer.calibration_key
+
+
+@pytest.mark.unit
+def test_bundled_quantiles_in_expected_range():
+    cal = Calibration.from_package("human")
+    key = "GeneMaskLFCScorer(requested_output=RNA_SEQ)"
+    sc = cal._scorers[key]
+    # rna_seq head has 768 tracks; only the first 667 are calibrated.
+    raw = torch.zeros(768)
+    raw[0] = 1e6
+    raw[1] = -1e6
+    q = cal.quantile_scores(key, raw)
+    # Extremes map to the largest/smallest quantile probabilities (~+/-1).
+    assert float(q[0]) == pytest.approx(float(sc.probabilities.max()))
+    assert float(q[1]) == pytest.approx(float(sc.probabilities.min()))
+    assert float(q[0]) > 0.99 and float(q[1]) < -0.99
+    assert torch.isnan(q[700])  # uncalibrated track
+
+
+# ------------------------------------------------------------------- wire-through
+
+def _variant_score(scores, quantile_scores=None):
+    scorer = CenterMaskScorer(OutputType.ATAC, 501, AggregationType.DIFF_LOG2_SUM)
+    return VariantScore(
+        variant=Variant("chr22", 100, "A", "C"),
+        interval=Interval("chr22", 0, 200),
+        scorer=scorer,
+        scores=torch.as_tensor(scores, dtype=torch.float32),
+        quantile_scores=(
+            None if quantile_scores is None
+            else torch.as_tensor(quantile_scores, dtype=torch.float32)
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_tidy_scores_emits_quantile_column_only_when_present():
+    with_q = tidy_scores([_variant_score([1.0, 2.0], [0.3, -0.7])])
+    assert "quantile_score" in with_q.columns
+    assert with_q["quantile_score"].tolist() == pytest.approx([0.3, -0.7])
+    # quantile_score column sits next to raw_score.
+    cols = list(with_q.columns)
+    assert cols.index("quantile_score") == cols.index("raw_score") + 1
+
+    without_q = tidy_scores([_variant_score([1.0, 2.0])])
+    assert "quantile_score" not in without_q.columns
+
+
+@pytest.mark.unit
+def test_scores_to_dataframe_emits_quantile_column():
+    df = scores_to_dataframe([_variant_score([1.0, 2.0], [0.3, -0.7])])
+    assert df["quantile_score"].tolist() == pytest.approx([0.3, -0.7])
+    df_none = scores_to_dataframe([_variant_score([1.0, 2.0])])
+    assert "quantile_score" not in df_none.columns
+
+
+@pytest.mark.unit
+def test_scores_to_anndata_quantile_layer():
+    adata = scores_to_anndata([_variant_score([1.0, 2.0], [0.3, -0.7])])
+    assert "quantiles" in adata.layers
+    np.testing.assert_allclose(adata.layers["quantiles"][0], [0.3, -0.7], atol=1e-6)
+    adata_none = scores_to_anndata([_variant_score([1.0, 2.0])])
+    assert "quantiles" not in adata_none.layers
+
+
+# --------------------------------------------------------------- model integration
+
+class _DummyModel(torch.nn.Module):
+    num_organisms = 2
+
+
+class _FakeScorer:
+    """Duck-typed scorer whose calibration_key matches a stub calibration."""
+
+    name = "FakeScorer()"
+    calibration_key = _KEY
+    required_heads = frozenset({"atac"})
+
+    def score(self, ref_outputs, alt_outputs, variant, interval, organism_index, **kwargs):
+        return VariantScore(
+            variant=variant, interval=interval, scorer=self,
+            scores=alt_outputs["atac"] - ref_outputs["atac"],
+        )
+
+
+@pytest.mark.unit
+def test_score_variant_attaches_quantiles(monkeypatch):
+    cal = _make_calibration()
+    model = VariantScoringModel(_DummyModel(), calibration=cal)
+    assert model.calibration is cal
+
+    interval = Interval("chr22", 0, 8)
+    variant = Variant("chr22", 4, "A", "C")
+
+    def fake_predict(self, *a, **k):
+        ref = {"atac": torch.tensor([0.0, 0.0])}
+        alt = {"atac": torch.tensor([1.5, 5.0])}  # -> track0 bin, track1 plateau
+        return ref, alt
+
+    monkeypatch.setattr(VariantScoringModel, "predict_variant", fake_predict)
+
+    [result] = model.score_variant(interval, variant, scorers=[_FakeScorer()])
+    assert result.quantile_scores is not None
+    assert float(result.quantile_scores[0]) == pytest.approx(0.0)  # 1.5 -> prob bin 2
+
+
+@pytest.mark.unit
+def test_calibration_none_leaves_quantiles_unset(monkeypatch):
+    model = VariantScoringModel(_DummyModel())  # no calibration
+    assert model.calibration is None
+
+    def fake_predict(self, *a, **k):
+        return {"atac": torch.tensor([0.0, 0.0])}, {"atac": torch.tensor([1.5, 5.0])}
+
+    monkeypatch.setattr(VariantScoringModel, "predict_variant", fake_predict)
+    [result] = model.score_variant(
+        Interval("chr22", 0, 8), Variant("chr22", 4, "A", "C"), scorers=[_FakeScorer()]
+    )
+    assert result.quantile_scores is None


### PR DESCRIPTION
Port quantile scoring from https://github.com/google-deepmind/alphagenome_research/commit/dad09dd: `variant_scoring/calibration.py`, bundled hg38 calibration parquet file (converted from upstream `calibration_scores.pb`), per-scorer `calibration_key`, and quantile_score wire-through in score_variant / tidy_scores / AnnData.

Quantile calibration is opt-in.