### PR TITLE
Update evaluation suite

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -58,6 +58,24 @@ python scripts/finetune.py --mode lora \
 torchrun --nproc_per_node=4 scripts/finetune.py --mode lora ...
 ```
 
+### evaluate_checkpoint.py
+Evaluate fine-tuned checkpoints or native pretrained heads against held-out
+BigWig targets.
+
+```bash
+# Native/pretrained head metrics without a fine-tuned checkpoint
+python scripts/evaluate_checkpoint.py \
+    --native-only --metrics \
+    --pretrained-weights model_fold1.safetensors \
+    --modality atac --native-biosample K562 \
+    --genome hg38.fa \
+    --test-bed test.bed \
+    --bigwig K562_ATAC.bw \
+    --sequence-length 131072 \
+    --resolutions 128 \
+    --output-dir native_eval/
+```
+
 ## Data Preprocessing
 
 ### convert_bigwigs_to_mmap.py

--- a/scripts/compute_gene_metrics.py
+++ b/scripts/compute_gene_metrics.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python
-"""Evaluate a finetuned AlphaGenome RNA-seq checkpoint on fold test regions.
-
-The model always receives ``--sequence-length`` bases. Metrics may optionally
-be restricted to a centered scoring window after inference. For the Borzoi
-comparison, use a 1-Mbp model with ``--score-window-bp 196608``. For 131-kbp
-finetuning comparisons, omit ``--score-window-bp``.
+"""Evaluate an AlphaGenome checkpoint on exon-specific metrics.
 
 RNA profile Pearson follows the AlphaGenome paper by applying log(1 + x).
 Jensen-Shannon metrics use raw, non-negative profiles. Regional total-count
@@ -62,7 +57,7 @@ log = logging.getLogger(__name__)
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Evaluate a finetuned AlphaGenome RNA-seq checkpoint",
+        description="Evaluate an AlphaGenome checkpoint",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("--checkpoint", required=True)

--- a/scripts/compute_gene_metrics.py
+++ b/scripts/compute_gene_metrics.py
@@ -1,0 +1,821 @@
+#!/usr/bin/env python
+"""Evaluate a finetuned AlphaGenome RNA-seq checkpoint on fold test regions.
+
+The model always receives ``--sequence-length`` bases. Metrics may optionally
+be restricted to a centered scoring window after inference. For the Borzoi
+comparison, use a 1-Mbp model with ``--score-window-bp 196608``. For 131-kbp
+finetuning comparisons, omit ``--score-window-bp``.
+
+RNA profile Pearson follows the AlphaGenome paper by applying log(1 + x).
+Jensen-Shannon metrics use raw, non-negative profiles. Regional total-count
+metrics are computed from the cropped 1-bp arrays and are therefore identical
+for every reported display resolution.
+
+Example:
+
+    python scripts/compute_gene_metrics.py \
+        --checkpoint best_model.pth \
+        --pretrained-weights model_fold1.pth \
+        --genome GRCh38.fa \
+        --bigwig sample_forward.bw sample_reverse.bw \
+        --test-bed fold_1/test.bed \
+        --gtf-parquet gencode.v46.annotation.gtf.parquet \
+        --samples sample \
+        --sequence-length 1048576 \
+        --score-window-bp 196608 \
+        --gene-score-window-bp 196608 \
+        --bin-sizes 1,32 \
+        --output-dir evaluation/rna_seq
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from scipy import stats
+from torch.utils.data import DataLoader, Subset
+
+from alphagenome_pytorch.extensions.finetuning.datasets import GenomicDataset
+from alphagenome_pytorch.extensions.finetuning.evaluation import evaluate_split
+from alphagenome_pytorch.extensions.finetuning.training import collate_genomic
+
+from evaluate_checkpoint import (
+    build_metric_views,
+    center_crop_profiles,
+    compute_comparison_metrics,
+    load_finetuned_model,
+    _pearson_or_nan,
+    parse_metric_bin_sizes,
+)
+
+
+log = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Evaluate a finetuned AlphaGenome RNA-seq checkpoint",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--checkpoint", required=True)
+    parser.add_argument("--pretrained-weights", required=True)
+    parser.add_argument("--genome", required=True)
+    parser.add_argument(
+        "--bigwig", nargs="+", required=True,
+        help="RNA-seq coverage BigWigs in checkpoint track order",
+    )
+    parser.add_argument("--test-bed", required=True, help="fold_1 test BED")
+    parser.add_argument(
+        "--gtf-parquet", required=True,
+        help="Processed GTF parquet containing exon coordinates and gene metadata",
+    )
+    parser.add_argument(
+        "--samples", nargs="+", default=None,
+        help=(
+            "Sample names for interleaved forward/reverse track pairs. If omitted, "
+            "sample_0, sample_1, ... are used."
+        ),
+    )
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--sequence-length", type=int, default=131_072)
+    parser.add_argument(
+        "--score-window-bp", type=int, default=None,
+        help="Centered post-inference width for regional profile metrics",
+    )
+    parser.add_argument(
+        "--gene-score-window-bp", type=int, default=None,
+        help=(
+            "Centered post-inference width for TSS selection and gene exon-mean "
+            "metrics; omit to use the full inference interval"
+        ),
+    )
+    parser.add_argument("--source-resolution", type=int, default=1)
+    parser.add_argument("--bin-sizes", default="1,32")
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--max-regions", type=int, default=0)
+    parser.add_argument("--device", default=None)
+    parser.add_argument("--save-predictions", action="store_true")
+    return parser.parse_args()
+
+
+def _clean_json(value):
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (np.floating, np.integer)):
+        return value.item()
+    if isinstance(value, dict):
+        return {str(key): _clean_json(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_clean_json(item) for item in value]
+    return value
+
+
+def load_gtf(gtf_parquet: str) -> pd.DataFrame:
+    """Load columns needed by the official AlphaGenome gene-mask path."""
+    return pd.read_parquet(
+        gtf_parquet,
+        columns=[
+            "Chromosome", "Start", "End", "Strand", "Feature",
+            "gene_id", "gene_name", "gene_type", "transcript_id",
+        ],
+    )
+
+
+# Direct NumPy ports of the public AlphaGenome gene-mask implementation in
+# alphagenome/data/gene_annotation.py and
+# alphagenome_research/model/variant_scoring/gene_mask_extractor.py.
+def extract_tss(gtf: pd.DataFrame, feature: str = "transcript") -> pd.DataFrame:
+    """Extract strand-aware transcription start sites from a GTF DataFrame."""
+    tss = gtf[gtf.Feature == feature].copy()
+    tss["feature_start"] = tss.Start
+    tss["feature_end"] = tss.End
+    new_start = np.where(tss.Strand == "-", tss.End, tss.Start)
+    tss.Start = new_start
+    tss.End = new_start
+    return tss
+
+
+class _PositionExtractor:
+    """Extract rows whose position lies in a half-open genomic interval."""
+
+    def __init__(
+        self,
+        frame: pd.DataFrame,
+        position_column: str,
+        chromosome_column: str = "Chromosome",
+    ):
+        self._df_position = {
+            chromosome: (group, group[position_column].values)
+            for chromosome, group in frame.groupby(
+                chromosome_column, observed=False,
+            )
+        }
+        self._df_empty = frame.iloc[:0]
+
+    def extract(self, chromosome: str, start: int, end: int) -> pd.DataFrame:
+        if chromosome not in self._df_position:
+            return self._df_empty
+        frame, position = self._df_position[chromosome]
+        return frame[(position >= start) & (position < end)]
+
+
+class _ExonExtractor:
+    """Extract exon intervals for one transcript."""
+
+    def __init__(self, gtf: pd.DataFrame):
+        self._exons_by_transcript_id = gtf[gtf.Feature == "exon"][
+            ["Chromosome", "Start", "End", "Strand", "transcript_id"]
+        ].groupby("transcript_id", sort=False)
+
+    def extract(self, transcript_id: str) -> list[tuple[str, int, int, str]]:
+        try:
+            exons = self._exons_by_transcript_id.get_group(transcript_id)
+        except KeyError:
+            return []
+        return list(zip(
+            exons.Chromosome,
+            exons.Start.astype(int),
+            exons.End.astype(int),
+            exons.Strand,
+        ))
+
+
+class _ExonMaskExtractor:
+    """Generate a boolean exon mask for one transcript."""
+
+    def __init__(self, gtf: pd.DataFrame):
+        self._exon_extractor = _ExonExtractor(gtf)
+
+    def extract(
+        self,
+        chromosome: str,
+        start: int,
+        end: int,
+        transcript_id: str,
+    ) -> np.ndarray:
+        mask = np.zeros(end - start, dtype=bool)
+        for exon_chromosome, exon_start, exon_end, _ in (
+            self._exon_extractor.extract(transcript_id)
+        ):
+            if exon_chromosome != chromosome:
+                continue
+            if exon_start < end and exon_end > start:
+                relative_start = max(exon_start - start, 0)
+                relative_end = min(exon_end - start, end - start)
+                mask[relative_start:relative_end] = True
+        return mask
+
+
+class _OfficialGeneExonMaskExtractor:
+    """Port of GeneMaskExtractor(EXONS, INTERVAL_CONTAINED)."""
+
+    _GENE_COLUMNS = [
+        "Chromosome", "Start", "End", "Strand", "gene_id", "gene_name",
+        "gene_type",
+    ]
+
+    def __init__(self, gtf: pd.DataFrame):
+        self._exon_mask_extractor = _ExonMaskExtractor(gtf)
+        self._tss = _PositionExtractor(
+            extract_tss(gtf), position_column="Start",
+        )
+        self._gene_df = gtf[gtf.Feature == "gene"][self._GENE_COLUMNS].set_index(
+            "gene_id"
+        )
+
+    def extract(
+        self, chromosome: str, start: int, end: int,
+    ) -> tuple[np.ndarray, pd.DataFrame]:
+        transcript_subset = self._tss.extract(chromosome, start, end)
+        gene_masks: dict[str, np.ndarray] = {}
+
+        for row in transcript_subset.itertuples():
+            exon_mask = self._exon_mask_extractor.extract(
+                chromosome, start, end, row.transcript_id,
+            )
+            if (gene_mask := gene_masks.get(row.gene_id)) is not None:
+                gene_mask |= exon_mask
+            else:
+                gene_masks[row.gene_id] = exon_mask
+
+        unique_gene_ids = list(transcript_subset["gene_id"].unique())
+        if not unique_gene_ids:
+            return (
+                np.empty((end - start, 0), dtype=bool),
+                pd.DataFrame(columns=[
+                    "gene_id", "strand", "gene_name", "gene_type",
+                    "interval_start", "Chromosome", "Start", "End",
+                ]),
+            )
+        gene_metadata = self._gene_df.loc[unique_gene_ids]
+        mask = np.empty((end - start, len(unique_gene_ids)), dtype=bool)
+        for index, gene_id in enumerate(unique_gene_ids):
+            mask[:, index] = gene_masks[gene_id]
+
+        metadata = pd.DataFrame({
+            "gene_id": unique_gene_ids,
+            "strand": gene_metadata.Strand.values,
+            "gene_name": gene_metadata.gene_name.values,
+            "gene_type": gene_metadata.gene_type.values,
+            "interval_start": [start] * len(unique_gene_ids),
+            "Chromosome": gene_metadata.Chromosome.values,
+            "Start": gene_metadata.Start.values,
+            "End": gene_metadata.End.values,
+        }).reset_index(drop=True)
+        return mask, metadata
+
+
+def downsample_gene_mask(mask: np.ndarray, resolution: int) -> np.ndarray:
+    """Match GeneIntervalScorer's max pooling of masks at coarse resolution."""
+    if resolution == 1:
+        return mask
+    if mask.shape[0] % resolution:
+        raise ValueError(
+            f"Gene mask length {mask.shape[0]} is not divisible by {resolution}"
+        )
+    return mask.reshape(
+        mask.shape[0] // resolution, resolution, -1,
+    ).max(axis=1)
+
+
+def score_gene_interval_mean(tracks: np.ndarray, masks: np.ndarray) -> np.ndarray:
+    """Direct NumPy port of GeneIntervalScorer.MEAN."""
+    return np.einsum("lt,lg->gt", tracks, masks) / np.expand_dims(
+        masks.sum(axis=0), axis=-1,
+    )
+
+
+def assign_genes_to_nearest_center(
+    gtf: pd.DataFrame,
+    positions: list[tuple[str, int, int]],
+) -> dict[str, int]:
+    """Assign each TSS-selected gene to one overlapping evaluation interval.
+
+    AlphaGenome's extractor scores genes independently in every requested
+    interval. The fold-1 BED contains overlapping windows, so a dataset-level
+    correlation additionally needs a deterministic one-row-per-gene rule.
+    Among intervals containing a transcript TSS, use the interval whose center
+    is closest to any TSS for that gene (ties resolve to the earlier BED row).
+    """
+    tss_extractor = _PositionExtractor(
+        extract_tss(gtf), position_column="Start",
+    )
+    best: dict[str, tuple[float, int]] = {}
+    for interval_index, (chromosome, start, end) in enumerate(positions):
+        transcript_subset = tss_extractor.extract(chromosome, start, end)
+        if transcript_subset.empty:
+            continue
+        center = (start + end) / 2
+        distances = (transcript_subset["Start"] - center).abs()
+        for gene_id, distance in distances.groupby(
+            transcript_subset["gene_id"], sort=False,
+        ).min().items():
+            candidate = (float(distance), interval_index)
+            if gene_id not in best or candidate < best[gene_id]:
+                best[gene_id] = candidate
+    return {gene_id: interval_index for gene_id, (_, interval_index) in best.items()}
+
+
+def center_crop_genomic_positions(
+    positions: list[tuple[str, int, int]],
+    score_window_bp: int | None,
+    source_resolution: int = 1,
+) -> list[tuple[str, int, int]]:
+    """Return genomic coordinates matching a centered profile-array crop."""
+    if score_window_bp is None:
+        return positions
+    if (
+        score_window_bp <= 0
+        or source_resolution <= 0
+        or score_window_bp % source_resolution
+    ):
+        raise ValueError(
+            "gene_score_window_bp must be positive and divisible by "
+            "source_resolution"
+        )
+
+    cropped = []
+    for chromosome, start, end in positions:
+        available_bp = end - start
+        if score_window_bp > available_bp:
+            raise ValueError(
+                f"Requested {score_window_bp:,} bp gene scoring window, but "
+                f"interval {chromosome}:{start}-{end} spans only "
+                f"{available_bp:,} bp"
+            )
+        if available_bp % source_resolution:
+            raise ValueError(
+                f"Interval width {available_bp} is not divisible by source "
+                f"resolution {source_resolution}"
+            )
+        available_bins = available_bp // source_resolution
+        score_bins = score_window_bp // source_resolution
+        left_bins = (available_bins - score_bins) // 2
+        crop_start = start + left_bins * source_resolution
+        cropped.append((chromosome, crop_start, crop_start + score_window_bp))
+    return cropped
+
+
+def align_test_intervals_to_dataset(
+    test_bed: str,
+    dataset: GenomicDataset,
+) -> pd.DataFrame:
+    """Match original BED intervals to the windows retained by GenomicDataset."""
+    intervals = pd.read_csv(
+        test_bed,
+        sep="\t",
+        comment="#",
+        header=None,
+        usecols=[0, 1, 2],
+        names=["chrom", "start", "end"],
+    )
+    retained: list[dict] = []
+    position_index = 0
+    half_length = dataset.sequence_length // 2
+
+    for original_index, row in intervals.iterrows():
+        chrom = row["chrom"]
+        start, end = int(row["start"]), int(row["end"])
+        if chrom not in dataset._chrom_sizes:
+            continue
+        if end - start == dataset.sequence_length:
+            window_start, window_end = start, end
+        else:
+            center = (start + end) // 2
+            window_start = center - half_length
+            window_end = window_start + dataset.sequence_length
+        if window_start < 0 or window_end > dataset._chrom_sizes[chrom]:
+            continue
+
+        expected = (chrom, window_start, window_end)
+        if position_index >= len(dataset._positions_list):
+            raise ValueError("More valid BED intervals than GenomicDataset positions")
+        actual = dataset._positions_list[position_index]
+        if expected != actual:
+            raise ValueError(
+                f"BED/dataset interval mismatch at retained index {position_index}: "
+                f"expected {expected}, found {actual}"
+            )
+        retained.append({
+            "original_interval_idx": int(original_index),
+            "chrom": chrom,
+            "start": start,
+            "end": end,
+            "window_start": window_start,
+            "window_end": window_end,
+        })
+        position_index += 1
+
+    if position_index != len(dataset._positions_list):
+        raise ValueError(
+            f"Matched {position_index} intervals but dataset retained "
+            f"{len(dataset._positions_list)}"
+        )
+    return pd.DataFrame(retained)
+
+
+def collect_gene_expression_rows(
+    gtf: pd.DataFrame,
+    test_intervals: pd.DataFrame,
+    positions: list[tuple[str, int, int]],
+    prediction_views: dict[int, np.ndarray],
+    target_views: dict[int, np.ndarray],
+    bin_sizes: tuple[int, ...],
+    sample_names: list[str],
+) -> pd.DataFrame:
+    """Collect one official exon-mean expression row per gene and track."""
+    columns = [
+        "bin_size_bp", "gene_id", "gene_name", "chrom", "strand",
+        "interval_index", "original_interval_index", "track_index", "sample",
+        "pred_mean", "obs_mean", "pred_log1p_mean", "obs_log1p_mean",
+    ]
+    rows: list[dict] = []
+    gene_owner = assign_genes_to_nearest_center(gtf, positions)
+    mask_extractor = _OfficialGeneExonMaskExtractor(gtf)
+    for interval_index, (chrom, window_start, window_end) in enumerate(positions):
+        one_bp_masks, metadata = mask_extractor.extract(
+            chrom, window_start, window_end,
+        )
+        keep = metadata["gene_id"].map(gene_owner).eq(interval_index).to_numpy()
+        metadata = metadata.loc[keep].reset_index(drop=True)
+        one_bp_masks = one_bp_masks[:, keep]
+        if metadata.empty:
+            continue
+        for bin_size in bin_sizes:
+            masks = downsample_gene_mask(one_bp_masks, bin_size)
+            pred_means = score_gene_interval_mean(
+                prediction_views[bin_size][interval_index], masks,
+            )
+            target_means = score_gene_interval_mean(
+                target_views[bin_size][interval_index], masks,
+            )
+            for gene_index, gene in metadata.iterrows():
+                strand = gene["strand"]
+                track_indices = range(
+                    0 if strand == "+" else 1, len(sample_names) * 2, 2,
+                )
+                for track_index in track_indices:
+                    if track_index >= pred_means.shape[1]:
+                        continue
+                    rows.append({
+                        "bin_size_bp": bin_size,
+                        "gene_id": gene["gene_id"],
+                        "gene_name": gene["gene_name"],
+                        "chrom": chrom,
+                        "strand": strand,
+                        "interval_index": interval_index,
+                        "original_interval_index": int(
+                            test_intervals.iloc[interval_index][
+                                "original_interval_idx"
+                            ]
+                        ),
+                        "track_index": track_index,
+                        "sample": sample_names[track_index // 2],
+                        "pred_mean": float(pred_means[gene_index, track_index]),
+                        "obs_mean": float(target_means[gene_index, track_index]),
+                        "pred_log1p_mean": float(np.log1p(
+                            pred_means[gene_index, track_index]
+                        )),
+                        "obs_log1p_mean": float(np.log1p(
+                            target_means[gene_index, track_index]
+                        )),
+                    })
+    return pd.DataFrame(rows, columns=columns)
+
+
+def summarize_gene_expression(
+    rows: pd.DataFrame,
+    bin_sizes: tuple[int, ...],
+) -> tuple[dict[int, dict], pd.DataFrame]:
+    """Summarize log1p exon-mean expression across gene-track pairs."""
+    summary: dict[int, dict] = {}
+    per_track_rows: list[dict] = []
+    for bin_size in bin_sizes:
+        subset = rows[rows["bin_size_bp"] == bin_size]
+        pred = subset["pred_log1p_mean"].to_numpy(dtype=np.float64)
+        obs = subset["obs_log1p_mean"].to_numpy(dtype=np.float64)
+        summary[bin_size] = {
+            "pearson_r_log1p_exon_mean": _pearson_or_nan(pred, obs),
+            "spearman_r_log1p_exon_mean": float(stats.spearmanr(pred, obs)[0])
+            if len(pred) >= 2 else float("nan"),
+            "mse_log1p_exon_mean": float(np.mean(np.square(pred - obs)))
+            if len(pred) else float("nan"),
+            "mae_log1p_exon_mean": float(np.mean(np.abs(pred - obs)))
+            if len(pred) else float("nan"),
+            "n_gene_track_pairs": int(len(subset)),
+            "n_unique_genes": int(subset["gene_id"].nunique()),
+        }
+        track_pearsons: list[float] = []
+        for (track_index, sample), track_rows in subset.groupby(
+            ["track_index", "sample"], sort=True,
+        ):
+            track_pred = track_rows["pred_log1p_mean"].to_numpy(dtype=np.float64)
+            track_obs = track_rows["obs_log1p_mean"].to_numpy(dtype=np.float64)
+            track_pearson = _pearson_or_nan(track_pred, track_obs)
+            track_pearsons.append(track_pearson)
+            per_track_rows.append({
+                "bin_size_bp": bin_size,
+                "track_index": int(track_index),
+                "sample": sample,
+                "pearson_r_log1p_exon_mean": track_pearson,
+                "n_genes": len(track_rows),
+            })
+        finite_track_pearsons = np.asarray(track_pearsons, dtype=np.float64)
+        finite_track_pearsons = finite_track_pearsons[
+            np.isfinite(finite_track_pearsons)
+        ]
+        summary[bin_size]["pearson_r_mean_across_tracks"] = (
+            float(finite_track_pearsons.mean())
+            if finite_track_pearsons.size else float("nan")
+        )
+        summary[bin_size]["n_tracks_with_valid_pearson"] = int(
+            finite_track_pearsons.size
+        )
+    return summary, pd.DataFrame(per_track_rows)
+
+
+def _write_per_region_csv(
+    path: Path,
+    positions: list[tuple[str, int, int]],
+    metrics_by_bin: dict[int, dict],
+    pred_totals: np.ndarray,
+    target_totals: np.ndarray,
+) -> None:
+    with open(path, "w", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "bin_size_bp", "region_index", "chrom", "start", "end",
+                "profile_pearson_r", "js_divergence", "js_distance",
+                "pred_total", "target_total",
+            ],
+        )
+        writer.writeheader()
+        for bin_size, metrics in metrics_by_bin.items():
+            for index, (chrom, start, end) in enumerate(positions):
+                writer.writerow({
+                    "bin_size_bp": bin_size,
+                    "region_index": index,
+                    "chrom": chrom,
+                    "start": start,
+                    "end": end,
+                    "profile_pearson_r": metrics["profile_pearson_r_all"][index],
+                    "js_divergence": metrics["js_divergence_all"][index],
+                    "js_distance": metrics["js_distance_all"][index],
+                    # One total per region is expected for the usual single
+                    # RNA coverage track. Multiple tracks are summed here and
+                    # remain available individually in saved predictions.
+                    "pred_total": pred_totals[index].sum(),
+                    "target_total": target_totals[index].sum(),
+                })
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = parse_args()
+    try:
+        bin_sizes = parse_metric_bin_sizes(args.bin_sizes)
+    except ValueError as exc:
+        sys.exit(f"Error: {exc}")
+    assert bin_sizes is not None
+
+    if args.score_window_bp is not None and args.score_window_bp > args.sequence_length:
+        sys.exit(
+            "Error: --score-window-bp cannot exceed --sequence-length. "
+            "Do not request the Borzoi window for a 131-kbp checkpoint."
+        )
+    if (
+        args.gene_score_window_bp is not None
+        and args.gene_score_window_bp > args.sequence_length
+    ):
+        sys.exit(
+            "Error: --gene-score-window-bp cannot exceed --sequence-length."
+        )
+
+    device = torch.device(
+        args.device or ("cuda" if torch.cuda.is_available() else "cpu")
+    )
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    model, checkpoint_meta = load_finetuned_model(
+        args.checkpoint, args.pretrained_weights, device,
+    )
+    modality = checkpoint_meta["modality"]
+    if isinstance(modality, list):
+        if len(modality) != 1:
+            sys.exit(f"Error: expected one RNA modality, found {modality}")
+        modality = modality[0]
+    if modality not in {"rna_seq", "rna-seq", "rnaseq"}:
+        sys.exit(f"Error: checkpoint modality is {modality!r}, not RNA-seq")
+
+    resolutions = checkpoint_meta["resolutions"]
+    if isinstance(resolutions, dict):
+        resolutions = resolutions.get(modality, (args.source_resolution,))
+    resolutions = tuple(resolutions)
+    if args.source_resolution not in resolutions:
+        sys.exit(
+            f"Error: source resolution {args.source_resolution} is not in "
+            f"checkpoint resolutions {resolutions}"
+        )
+
+    dataset = GenomicDataset(
+        genome_fasta=args.genome,
+        bigwig_files=args.bigwig,
+        bed_file=args.test_bed,
+        resolutions=resolutions,
+        sequence_length=args.sequence_length,
+    )
+    test_intervals = align_test_intervals_to_dataset(args.test_bed, dataset)
+    if args.max_regions > 0 and len(dataset) > args.max_regions:
+        rng = np.random.default_rng(42)
+        indices = rng.choice(
+            len(dataset), args.max_regions, replace=False,
+        ).tolist()
+        positions = [dataset._positions_list[index] for index in indices]
+        test_intervals = test_intervals.iloc[indices].reset_index(drop=True)
+        evaluation_dataset = Subset(dataset, indices)
+    else:
+        positions = dataset._positions_list
+        test_intervals = test_intervals.reset_index(drop=True)
+        evaluation_dataset = dataset
+
+    if len(args.bigwig) % 2:
+        sys.exit(
+            "Error: gene-expression evaluation expects interleaved "
+            "forward/reverse BigWig track pairs"
+        )
+    n_samples = len(args.bigwig) // 2
+    sample_names = args.samples or [f"sample_{index}" for index in range(n_samples)]
+    if len(sample_names) != n_samples:
+        sys.exit(
+            f"Error: expected {n_samples} --samples values for {len(args.bigwig)} "
+            f"interleaved tracks, received {len(sample_names)}"
+        )
+
+    loader = DataLoader(
+        evaluation_dataset,
+        batch_size=args.batch_size,
+        shuffle=False,
+        num_workers=args.num_workers,
+        collate_fn=collate_genomic,
+    )
+    predictions, targets, loss = evaluate_split(
+        model, modality, loader, device, resolutions,
+    )
+    source = args.source_resolution
+    cropped_predictions, cropped_targets = center_crop_profiles(
+        predictions[source], targets[source], args.score_window_bp, source,
+    )
+    prediction_views, target_views = build_metric_views(
+        predictions[source],
+        targets[source],
+        source_resolution=source,
+        bin_sizes=bin_sizes,
+        score_window_bp=args.score_window_bp,
+        reduction="mean",
+    )
+    gene_prediction_views, gene_target_views = build_metric_views(
+        predictions[source],
+        targets[source],
+        source_resolution=source,
+        bin_sizes=bin_sizes,
+        score_window_bp=args.gene_score_window_bp,
+        reduction="mean",
+    )
+    gene_positions = center_crop_genomic_positions(
+        positions, args.gene_score_window_bp, source,
+    )
+
+    # Regional counts are defined from the cropped 1-bp signal, not from the
+    # mean-pooled display profiles.
+    count_metrics = compute_comparison_metrics(
+        cropped_predictions, cropped_targets, profile_transform="log1p",
+    )
+    pred_totals = cropped_predictions.sum(axis=1)
+    target_totals = cropped_targets.sum(axis=1)
+
+    metrics_by_bin: dict[int, dict] = {}
+    for bin_size in bin_sizes:
+        metrics = compute_comparison_metrics(
+            prediction_views[bin_size],
+            target_views[bin_size],
+            profile_transform="log1p",
+        )
+        for key in ("count_pearson_r", "count_pearson_r_raw", "count_pearson_r_log1p"):
+            metrics[key] = count_metrics[key]
+        metrics_by_bin[bin_size] = metrics
+        log.info(
+            "%dbp: profile r=%.4f, accumulated r=%.4f, log-count r=%.4f, "
+            "JS distance=%.4f",
+            bin_size,
+            metrics["profile_pearson_r_mean"],
+            metrics["track_pearson_r_accumulated_mean"],
+            metrics["count_pearson_r_log1p"],
+            metrics["js_distance_mean"],
+        )
+
+    gtf = load_gtf(args.gtf_parquet)
+    gene_rows = collect_gene_expression_rows(
+        gtf=gtf,
+        test_intervals=test_intervals,
+        positions=gene_positions,
+        prediction_views=gene_prediction_views,
+        target_views=gene_target_views,
+        bin_sizes=bin_sizes,
+        sample_names=sample_names,
+    )
+    gene_metrics, gene_metrics_per_track = summarize_gene_expression(
+        gene_rows, bin_sizes,
+    )
+    for bin_size, metrics in gene_metrics.items():
+        log.info(
+            "%dbp gene expression: Pearson r=%.4f across %d genes (%d pairs)",
+            bin_size,
+            metrics["pearson_r_log1p_exon_mean"],
+            metrics["n_unique_genes"],
+            metrics["n_gene_track_pairs"],
+        )
+
+    summary = {
+        "checkpoint": checkpoint_meta,
+        "evaluation": {
+            "modality": modality,
+            "test_bed": args.test_bed,
+            "fold": "fold_1 expected; determined by --test-bed",
+            "sequence_length_bp": args.sequence_length,
+            "score_window_bp": args.score_window_bp or args.sequence_length,
+            "source_resolution_bp": source,
+            "bin_sizes_bp": list(bin_sizes),
+            "profile_transform": "log1p",
+            "profile_pooling": "mean",
+            "count_source": "cropped_source_resolution_profile",
+            "gene_score_window_bp": (
+                args.gene_score_window_bp or args.sequence_length
+            ),
+            "gene_expression_window": (
+                "center_crop" if args.gene_score_window_bp is not None
+                else "full_inference_test_interval"
+            ),
+            "gene_selection": "official_transcript_tss",
+            "gene_interval_assignment": "nearest_interval_center_to_gene_tss",
+            "gene_mask_aggregation": "union_exon_mask_then_mean",
+            "gene_expression_transform": "log1p_mean_exonic_coverage",
+            "gtf_parquet": args.gtf_parquet,
+            "n_regions": len(positions),
+            "loss": loss,
+        },
+        "metrics": metrics_by_bin,
+        "gene_expression_metrics": gene_metrics,
+    }
+    with open(output_dir / "summary.json", "w") as handle:
+        json.dump(_clean_json(summary), handle, indent=2, default=str)
+    _write_per_region_csv(
+        output_dir / "metrics_per_region.csv",
+        positions,
+        metrics_by_bin,
+        pred_totals,
+        target_totals,
+    )
+    gene_rows.to_csv(output_dir / "gene_expression_per_gene.csv", index=False)
+    gene_metrics_per_track.to_csv(
+        output_dir / "gene_expression_metrics_per_track.csv", index=False,
+    )
+
+    if args.save_predictions:
+        prediction_dir = output_dir / "predictions"
+        prediction_dir.mkdir(exist_ok=True)
+        np.save(
+            prediction_dir / "predictions_scored_1bp.npy",
+            cropped_predictions.astype(np.float16),
+        )
+        np.save(
+            prediction_dir / "targets_scored_1bp.npy",
+            cropped_targets.astype(np.float16),
+        )
+        for bin_size in bin_sizes:
+            if bin_size == source:
+                continue
+            np.save(
+                prediction_dir / f"predictions_scored_{bin_size}bp.npy",
+                prediction_views[bin_size].astype(np.float16),
+            )
+            np.save(
+                prediction_dir / f"targets_scored_{bin_size}bp.npy",
+                target_views[bin_size].astype(np.float16),
+            )
+
+    log.info("Wrote RNA-seq evaluation to %s", output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compute_gene_metrics.py
+++ b/scripts/compute_gene_metrics.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python
-"""Evaluate an AlphaGenome checkpoint on exon-specific metrics.
+"""Evaluate an AlphaGenome checkpoint on RNA profile and gene metrics.
 
 RNA profile Pearson follows the AlphaGenome paper by applying log(1 + x).
 Jensen-Shannon metrics use raw, non-negative profiles. Regional total-count
 metrics are computed from the cropped 1-bp arrays and are therefore identical
 for every reported display resolution.
+
+Gene expression follows the AlphaGenome paper protocol: log1p of mean coverage
+over unioned GENCODE v46 exon bases, strand matching, one assignment per gene
+when at least 50% of its unique exon bases fall in a test interval, and raw plus
+quantile-normalized correlations across genes and across tracks.
 
 Example:
 
@@ -34,25 +39,21 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import torch
 from scipy import stats
-from torch.utils.data import DataLoader, Subset
-
-from alphagenome_pytorch.extensions.finetuning.datasets import GenomicDataset
-from alphagenome_pytorch.extensions.finetuning.evaluation import evaluate_split
-from alphagenome_pytorch.extensions.finetuning.training import collate_genomic
-
-from evaluate_checkpoint import (
-    build_metric_views,
-    center_crop_profiles,
-    compute_comparison_metrics,
-    load_finetuned_model,
-    _pearson_or_nan,
-    parse_metric_bin_sizes,
-)
 
 
 log = logging.getLogger(__name__)
+
+
+def _pearson_or_nan(x: np.ndarray, y: np.ndarray) -> float:
+    """Pearson correlation with the same finite/constant guards as ATAC eval."""
+    x = np.asarray(x, dtype=np.float64).reshape(-1)
+    y = np.asarray(y, dtype=np.float64).reshape(-1)
+    finite = np.isfinite(x) & np.isfinite(y)
+    x, y = x[finite], y[finite]
+    if x.size < 2 or np.std(x) <= 1e-10 or np.std(y) <= 1e-10:
+        return float("nan")
+    return float(stats.pearsonr(x, y)[0])
 
 
 def parse_args() -> argparse.Namespace:
@@ -70,7 +71,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--test-bed", required=True, help="fold_1 test BED")
     parser.add_argument(
         "--gtf-parquet", required=True,
-        help="Processed GTF parquet containing exon coordinates and gene metadata",
+        help=(
+            "GENCODE v46 GTF parquet containing exon coordinates and gene "
+            "metadata; the path must identify v46 or release_46"
+        ),
     )
     parser.add_argument(
         "--samples", nargs="+", default=None,
@@ -88,8 +92,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--gene-score-window-bp", type=int, default=None,
         help=(
-            "Centered post-inference width for TSS selection and gene exon-mean "
-            "metrics; omit to use the full inference interval"
+            "Centered post-inference test width for the paper's >=50%% exon "
+            "selection and exon-mean metrics; omit to use the full inference "
+            "interval"
         ),
     )
     parser.add_argument("--source-resolution", type=int, default=1)
@@ -114,8 +119,19 @@ def _clean_json(value):
     return value
 
 
+def validate_gencode_v46_path(path: str) -> None:
+    """Require annotation provenance identifying GENCODE release 46."""
+    normalized_path = str(Path(path)).lower().replace("-", "_")
+    if "v46" not in normalized_path and "release_46" not in normalized_path:
+        raise ValueError(
+            "AlphaGenome paper gene metrics require GENCODE v46; "
+            f"the annotation path does not identify v46: {path}"
+        )
+
+
 def load_gtf(gtf_parquet: str) -> pd.DataFrame:
-    """Load columns needed by the official AlphaGenome gene-mask path."""
+    """Load the GENCODE v46 columns needed for paper gene-expression metrics."""
+    validate_gencode_v46_path(gtf_parquet)
     return pd.read_parquet(
         gtf_parquet,
         columns=[
@@ -125,199 +141,186 @@ def load_gtf(gtf_parquet: str) -> pd.DataFrame:
     )
 
 
-# Direct NumPy ports of the public AlphaGenome gene-mask implementation in
-# alphagenome/data/gene_annotation.py and
-# alphagenome_research/model/variant_scoring/gene_mask_extractor.py.
-def extract_tss(gtf: pd.DataFrame, feature: str = "transcript") -> pd.DataFrame:
-    """Extract strand-aware transcription start sites from a GTF DataFrame."""
-    tss = gtf[gtf.Feature == feature].copy()
-    tss["feature_start"] = tss.Start
-    tss["feature_end"] = tss.End
-    new_start = np.where(tss.Strand == "-", tss.End, tss.Start)
-    tss.Start = new_start
-    tss.End = new_start
-    return tss
+def downsample_gene_mask_weights(mask: np.ndarray, resolution: int) -> np.ndarray:
+    """Count exact exonic bases per output bin for paper exon means.
 
-
-class _PositionExtractor:
-    """Extract rows whose position lies in a half-open genomic interval."""
-
-    def __init__(
-        self,
-        frame: pd.DataFrame,
-        position_column: str,
-        chromosome_column: str = "Chromosome",
-    ):
-        self._df_position = {
-            chromosome: (group, group[position_column].values)
-            for chromosome, group in frame.groupby(
-                chromosome_column, observed=False,
-            )
-        }
-        self._df_empty = frame.iloc[:0]
-
-    def extract(self, chromosome: str, start: int, end: int) -> pd.DataFrame:
-        if chromosome not in self._df_position:
-            return self._df_empty
-        frame, position = self._df_position[chromosome]
-        return frame[(position >= start) & (position < end)]
-
-
-class _ExonExtractor:
-    """Extract exon intervals for one transcript."""
-
-    def __init__(self, gtf: pd.DataFrame):
-        self._exons_by_transcript_id = gtf[gtf.Feature == "exon"][
-            ["Chromosome", "Start", "End", "Strand", "transcript_id"]
-        ].groupby("transcript_id", sort=False)
-
-    def extract(self, transcript_id: str) -> list[tuple[str, int, int, str]]:
-        try:
-            exons = self._exons_by_transcript_id.get_group(transcript_id)
-        except KeyError:
-            return []
-        return list(zip(
-            exons.Chromosome,
-            exons.Start.astype(int),
-            exons.End.astype(int),
-            exons.Strand,
-        ))
-
-
-class _ExonMaskExtractor:
-    """Generate a boolean exon mask for one transcript."""
-
-    def __init__(self, gtf: pd.DataFrame):
-        self._exon_extractor = _ExonExtractor(gtf)
-
-    def extract(
-        self,
-        chromosome: str,
-        start: int,
-        end: int,
-        transcript_id: str,
-    ) -> np.ndarray:
-        mask = np.zeros(end - start, dtype=bool)
-        for exon_chromosome, exon_start, exon_end, _ in (
-            self._exon_extractor.extract(transcript_id)
-        ):
-            if exon_chromosome != chromosome:
-                continue
-            if exon_start < end and exon_end > start:
-                relative_start = max(exon_start - start, 0)
-                relative_end = min(exon_end - start, end - start)
-                mask[relative_start:relative_end] = True
-        return mask
-
-
-class _OfficialGeneExonMaskExtractor:
-    """Port of GeneMaskExtractor(EXONS, INTERVAL_CONTAINED)."""
-
-    _GENE_COLUMNS = [
-        "Chromosome", "Start", "End", "Strand", "gene_id", "gene_name",
-        "gene_type",
-    ]
-
-    def __init__(self, gtf: pd.DataFrame):
-        self._exon_mask_extractor = _ExonMaskExtractor(gtf)
-        self._tss = _PositionExtractor(
-            extract_tss(gtf), position_column="Start",
-        )
-        self._gene_df = gtf[gtf.Feature == "gene"][self._GENE_COLUMNS].set_index(
-            "gene_id"
-        )
-
-    def extract(
-        self, chromosome: str, start: int, end: int,
-    ) -> tuple[np.ndarray, pd.DataFrame]:
-        transcript_subset = self._tss.extract(chromosome, start, end)
-        gene_masks: dict[str, np.ndarray] = {}
-
-        for row in transcript_subset.itertuples():
-            exon_mask = self._exon_mask_extractor.extract(
-                chromosome, start, end, row.transcript_id,
-            )
-            if (gene_mask := gene_masks.get(row.gene_id)) is not None:
-                gene_mask |= exon_mask
-            else:
-                gene_masks[row.gene_id] = exon_mask
-
-        unique_gene_ids = list(transcript_subset["gene_id"].unique())
-        if not unique_gene_ids:
-            return (
-                np.empty((end - start, 0), dtype=bool),
-                pd.DataFrame(columns=[
-                    "gene_id", "strand", "gene_name", "gene_type",
-                    "interval_start", "Chromosome", "Start", "End",
-                ]),
-            )
-        gene_metadata = self._gene_df.loc[unique_gene_ids]
-        mask = np.empty((end - start, len(unique_gene_ids)), dtype=bool)
-        for index, gene_id in enumerate(unique_gene_ids):
-            mask[:, index] = gene_masks[gene_id]
-
-        metadata = pd.DataFrame({
-            "gene_id": unique_gene_ids,
-            "strand": gene_metadata.Strand.values,
-            "gene_name": gene_metadata.gene_name.values,
-            "gene_type": gene_metadata.gene_type.values,
-            "interval_start": [start] * len(unique_gene_ids),
-            "Chromosome": gene_metadata.Chromosome.values,
-            "Start": gene_metadata.Start.values,
-            "End": gene_metadata.End.values,
-        }).reset_index(drop=True)
-        return mask, metadata
-
-
-def downsample_gene_mask(mask: np.ndarray, resolution: int) -> np.ndarray:
-    """Match GeneIntervalScorer's max pooling of masks at coarse resolution."""
+    Weighting a mean-pooled coarse prediction by this count is equivalent to
+    upsampling the prediction and averaging it over the original 1-bp mask.
+    """
     if resolution == 1:
-        return mask
+        return mask.astype(np.int64)
     if mask.shape[0] % resolution:
         raise ValueError(
             f"Gene mask length {mask.shape[0]} is not divisible by {resolution}"
         )
     return mask.reshape(
         mask.shape[0] // resolution, resolution, -1,
-    ).max(axis=1)
+    ).sum(axis=1)
 
 
 def score_gene_interval_mean(tracks: np.ndarray, masks: np.ndarray) -> np.ndarray:
-    """Direct NumPy port of GeneIntervalScorer.MEAN."""
+    """Mean coverage using boolean masks or per-bin exon-base weights."""
     return np.einsum("lt,lg->gt", tracks, masks) / np.expand_dims(
         masks.sum(axis=0), axis=-1,
     )
 
 
-def assign_genes_to_nearest_center(
-    gtf: pd.DataFrame,
-    positions: list[tuple[str, int, int]],
-) -> dict[str, int]:
-    """Assign each TSS-selected gene to one overlapping evaluation interval.
-
-    AlphaGenome's extractor scores genes independently in every requested
-    interval. The fold-1 BED contains overlapping windows, so a dataset-level
-    correlation additionally needs a deterministic one-row-per-gene rule.
-    Among intervals containing a transcript TSS, use the interval whose center
-    is closest to any TSS for that gene (ties resolve to the earlier BED row).
-    """
-    tss_extractor = _PositionExtractor(
-        extract_tss(gtf), position_column="Start",
-    )
-    best: dict[str, tuple[float, int]] = {}
-    for interval_index, (chromosome, start, end) in enumerate(positions):
-        transcript_subset = tss_extractor.extract(chromosome, start, end)
-        if transcript_subset.empty:
+def _merge_intervals(
+    intervals: list[tuple[int, int]],
+) -> tuple[tuple[int, int], ...]:
+    """Return the genomic union of half-open intervals."""
+    merged: list[list[int]] = []
+    for start, end in sorted(intervals):
+        if end <= start:
             continue
+        if not merged or start > merged[-1][1]:
+            merged.append([start, end])
+        else:
+            merged[-1][1] = max(merged[-1][1], end)
+    return tuple((start, end) for start, end in merged)
+
+
+def build_paper_gene_annotations(gtf: pd.DataFrame) -> pd.DataFrame:
+    """Build one GENCODE gene record with a union of all annotated exons.
+
+    GENCODE can contain overlapping exon records from multiple transcripts.
+    Treating the exon annotation as a genomic mask, as AlphaGenome's public
+    GeneIntervalScorer does, ensures every exonic base contributes once.
+    """
+    exons = gtf[gtf["Feature"] == "exon"].copy()
+    if exons.empty:
+        raise ValueError("GENCODE annotation contains no exon rows")
+
+    records: list[dict] = []
+    for gene_id, gene_exons in exons.groupby("gene_id", sort=False):
+        chromosomes = gene_exons["Chromosome"].dropna().unique()
+        strands = gene_exons["Strand"].dropna().unique()
+        if len(chromosomes) != 1 or len(strands) != 1:
+            raise ValueError(
+                f"Gene {gene_id!r} has inconsistent chromosome or strand "
+                "annotations"
+            )
+        intervals = _merge_intervals(list(zip(
+            gene_exons["Start"].astype(int),
+            gene_exons["End"].astype(int),
+        )))
+        exon_bp = sum(end - start for start, end in intervals)
+        if exon_bp == 0:
+            continue
+        first = gene_exons.iloc[0]
+        records.append({
+            "gene_id": gene_id,
+            "gene_name": first.get("gene_name", gene_id),
+            "gene_type": first.get("gene_type", None),
+            "chrom": chromosomes[0],
+            "strand": strands[0],
+            "exon_intervals": intervals,
+            "total_unique_exon_bp": exon_bp,
+            "exon_start": intervals[0][0],
+            "exon_end": intervals[-1][1],
+        })
+    return pd.DataFrame.from_records(records).set_index("gene_id", drop=False)
+
+
+def _exon_overlap_bp(
+    intervals: tuple[tuple[int, int], ...], start: int, end: int,
+) -> int:
+    return sum(
+        max(0, min(exon_end, end) - max(exon_start, start))
+        for exon_start, exon_end in intervals
+    )
+
+
+def assign_paper_genes_to_intervals(
+    gene_annotations: pd.DataFrame,
+    positions: list[tuple[str, int, int]],
+    minimum_exon_fraction: float = 0.5,
+) -> dict[str, dict]:
+    """Assign genes satisfying the paper's >=50% exon criterion exactly once.
+
+    The percentage is calculated over unique annotated exon bases. If
+    overlapping test intervals both qualify, use the interval containing the
+    greatest number of exon bases, then the closest interval center, then BED
+    order. The tie-break normally has no effect but makes deduplication stable.
+    """
+    if not 0 < minimum_exon_fraction <= 1:
+        raise ValueError("minimum_exon_fraction must be in (0, 1]")
+
+    candidates: dict[str, list[dict]] = {}
+    for interval_index, (chrom, start, end) in enumerate(positions):
+        chrom_genes = gene_annotations[
+            (gene_annotations["chrom"] == chrom)
+            & (gene_annotations["exon_start"] < end)
+            & (gene_annotations["exon_end"] > start)
+        ]
         center = (start + end) / 2
-        distances = (transcript_subset["Start"] - center).abs()
-        for gene_id, distance in distances.groupby(
-            transcript_subset["gene_id"], sort=False,
-        ).min().items():
-            candidate = (float(distance), interval_index)
-            if gene_id not in best or candidate < best[gene_id]:
-                best[gene_id] = candidate
-    return {gene_id: interval_index for gene_id, (_, interval_index) in best.items()}
+        for gene in chrom_genes.itertuples():
+            overlap_bp = _exon_overlap_bp(gene.exon_intervals, start, end)
+            fraction = overlap_bp / gene.total_unique_exon_bp
+            if fraction < minimum_exon_fraction:
+                continue
+            exon_center = (gene.exon_start + gene.exon_end) / 2
+            candidates.setdefault(gene.gene_id, []).append({
+                "interval_index": interval_index,
+                "exon_overlap_bp": overlap_bp,
+                "exon_fraction_in_interval": fraction,
+                "center_distance_bp": abs(exon_center - center),
+            })
+
+    assignments: dict[str, dict] = {}
+    for gene_id, gene_candidates in candidates.items():
+        best = min(gene_candidates, key=lambda item: (
+            -item["exon_overlap_bp"],
+            item["center_distance_bp"],
+            item["interval_index"],
+        ))
+        assignments[gene_id] = {
+            **best,
+            "n_qualifying_intervals": len(gene_candidates),
+        }
+    return assignments
+
+
+def build_interval_gene_masks(
+    gene_annotations: pd.DataFrame,
+    assignments: dict[str, dict],
+    interval_index: int,
+    chrom: str,
+    start: int,
+    end: int,
+) -> tuple[np.ndarray, pd.DataFrame]:
+    """Build union-exon masks for genes assigned to one scored interval."""
+    gene_ids = [
+        gene_id for gene_id, assignment in assignments.items()
+        if assignment["interval_index"] == interval_index
+    ]
+    mask = np.zeros((end - start, len(gene_ids)), dtype=bool)
+    metadata_rows: list[dict] = []
+    for gene_index, gene_id in enumerate(gene_ids):
+        gene = gene_annotations.loc[gene_id]
+        if gene["chrom"] != chrom:
+            raise ValueError(f"Assigned gene {gene_id!r} is on the wrong chromosome")
+        for exon_start, exon_end in gene["exon_intervals"]:
+            relative_start = max(exon_start, start) - start
+            relative_end = min(exon_end, end) - start
+            if relative_end > relative_start:
+                mask[relative_start:relative_end, gene_index] = True
+        assignment = assignments[gene_id]
+        metadata_rows.append({
+            "gene_id": gene_id,
+            "gene_name": gene["gene_name"],
+            "gene_type": gene["gene_type"],
+            "strand": gene["strand"],
+            "total_unique_exon_bp": int(gene["total_unique_exon_bp"]),
+            "scored_unique_exon_bp": int(mask[:, gene_index].sum()),
+            "exon_fraction_in_interval": float(
+                assignment["exon_fraction_in_interval"]
+            ),
+            "n_qualifying_intervals": int(
+                assignment["n_qualifying_intervals"]
+            ),
+        })
+    return mask, pd.DataFrame(metadata_rows)
 
 
 def center_crop_genomic_positions(
@@ -427,26 +430,30 @@ def collect_gene_expression_rows(
     bin_sizes: tuple[int, ...],
     sample_names: list[str],
 ) -> pd.DataFrame:
-    """Collect one official exon-mean expression row per gene and track."""
+    """Collect paper-protocol exon-mean expression per gene and sample."""
     columns = [
         "bin_size_bp", "gene_id", "gene_name", "chrom", "strand",
         "interval_index", "original_interval_index", "track_index", "sample",
+        "total_unique_exon_bp", "scored_unique_exon_bp",
+        "exon_fraction_in_interval", "n_qualifying_intervals",
         "pred_mean", "obs_mean", "pred_log1p_mean", "obs_log1p_mean",
     ]
     rows: list[dict] = []
-    gene_owner = assign_genes_to_nearest_center(gtf, positions)
-    mask_extractor = _OfficialGeneExonMaskExtractor(gtf)
+    gene_annotations = build_paper_gene_annotations(gtf)
+    assignments = assign_paper_genes_to_intervals(gene_annotations, positions)
     for interval_index, (chrom, window_start, window_end) in enumerate(positions):
-        one_bp_masks, metadata = mask_extractor.extract(
-            chrom, window_start, window_end,
+        one_bp_masks, metadata = build_interval_gene_masks(
+            gene_annotations=gene_annotations,
+            assignments=assignments,
+            interval_index=interval_index,
+            chrom=chrom,
+            start=window_start,
+            end=window_end,
         )
-        keep = metadata["gene_id"].map(gene_owner).eq(interval_index).to_numpy()
-        metadata = metadata.loc[keep].reset_index(drop=True)
-        one_bp_masks = one_bp_masks[:, keep]
         if metadata.empty:
             continue
         for bin_size in bin_sizes:
-            masks = downsample_gene_mask(one_bp_masks, bin_size)
+            masks = downsample_gene_mask_weights(one_bp_masks, bin_size)
             pred_means = score_gene_interval_mean(
                 prediction_views[bin_size][interval_index], masks,
             )
@@ -475,6 +482,18 @@ def collect_gene_expression_rows(
                         ),
                         "track_index": track_index,
                         "sample": sample_names[track_index // 2],
+                        "total_unique_exon_bp": int(
+                            gene["total_unique_exon_bp"]
+                        ),
+                        "scored_unique_exon_bp": int(
+                            gene["scored_unique_exon_bp"]
+                        ),
+                        "exon_fraction_in_interval": float(
+                            gene["exon_fraction_in_interval"]
+                        ),
+                        "n_qualifying_intervals": int(
+                            gene["n_qualifying_intervals"]
+                        ),
                         "pred_mean": float(pred_means[gene_index, track_index]),
                         "obs_mean": float(target_means[gene_index, track_index]),
                         "pred_log1p_mean": float(np.log1p(
@@ -487,55 +506,162 @@ def collect_gene_expression_rows(
     return pd.DataFrame(rows, columns=columns)
 
 
+def quantile_normalize_columns(values: np.ndarray) -> np.ndarray:
+    """Quantile-normalize a genes-by-tracks matrix across its track columns.
+
+    Predicted and observed matrices are normalized independently. Tied values
+    receive the mean reference quantile across all ranks occupied by the tie.
+    """
+    values = np.asarray(values, dtype=np.float64)
+    if values.ndim != 2:
+        raise ValueError("quantile normalization expects a 2D matrix")
+    if not np.isfinite(values).all():
+        raise ValueError("quantile normalization requires finite values")
+    if values.size == 0:
+        return values.copy()
+
+    sorted_values = np.sort(values, axis=0, kind="mergesort")
+    reference_quantiles = sorted_values.mean(axis=1)
+    normalized = np.empty_like(values)
+    for column_index in range(values.shape[1]):
+        column = values[:, column_index]
+        order = np.argsort(column, kind="mergesort")
+        sorted_column = column[order]
+        group_start = 0
+        while group_start < len(order):
+            group_end = group_start + 1
+            while (
+                group_end < len(order)
+                and sorted_column[group_end] == sorted_column[group_start]
+            ):
+                group_end += 1
+            normalized[order[group_start:group_end], column_index] = (
+                reference_quantiles[group_start:group_end].mean()
+            )
+            group_start = group_end
+    return normalized
+
+
+def _paper_expression_matrices(
+    subset: pd.DataFrame,
+) -> tuple[list[str], list[str], np.ndarray, np.ndarray]:
+    """Return aligned complete gene-by-sample log-expression matrices."""
+    if subset.duplicated(["gene_id", "sample"]).any():
+        duplicates = subset.loc[
+            subset.duplicated(["gene_id", "sample"], keep=False),
+            ["gene_id", "sample"],
+        ]
+        raise ValueError(
+            "Expected one strand-matched value per gene and sample; found "
+            f"duplicates including {duplicates.iloc[0].to_dict()}"
+        )
+
+    sample_order = list(dict.fromkeys(subset["sample"].tolist()))
+    pred = subset.pivot(index="gene_id", columns="sample", values="pred_log1p_mean")
+    obs = subset.pivot(index="gene_id", columns="sample", values="obs_log1p_mean")
+    gene_order = sorted(set(pred.index).intersection(obs.index))
+    pred = pred.reindex(index=gene_order, columns=sample_order)
+    obs = obs.reindex(index=gene_order, columns=sample_order)
+    complete = pred.notna().all(axis=1) & obs.notna().all(axis=1)
+    pred = pred.loc[complete]
+    obs = obs.loc[complete]
+    return (
+        pred.index.tolist(),
+        sample_order,
+        pred.to_numpy(dtype=np.float64),
+        obs.to_numpy(dtype=np.float64),
+    )
+
+
 def summarize_gene_expression(
     rows: pd.DataFrame,
     bin_sizes: tuple[int, ...],
-) -> tuple[dict[int, dict], pd.DataFrame]:
-    """Summarize log1p exon-mean expression across gene-track pairs."""
+) -> tuple[dict[int, dict], pd.DataFrame, pd.DataFrame]:
+    """Compute the three AlphaGenome paper gene-expression correlations."""
     summary: dict[int, dict] = {}
     per_track_rows: list[dict] = []
+    per_gene_rows: list[dict] = []
     for bin_size in bin_sizes:
         subset = rows[rows["bin_size_bp"] == bin_size]
-        pred = subset["pred_log1p_mean"].to_numpy(dtype=np.float64)
-        obs = subset["obs_log1p_mean"].to_numpy(dtype=np.float64)
-        summary[bin_size] = {
-            "pearson_r_log1p_exon_mean": _pearson_or_nan(pred, obs),
-            "spearman_r_log1p_exon_mean": float(stats.spearmanr(pred, obs)[0])
-            if len(pred) >= 2 else float("nan"),
-            "mse_log1p_exon_mean": float(np.mean(np.square(pred - obs)))
-            if len(pred) else float("nan"),
-            "mae_log1p_exon_mean": float(np.mean(np.abs(pred - obs)))
-            if len(pred) else float("nan"),
-            "n_gene_track_pairs": int(len(subset)),
-            "n_unique_genes": int(subset["gene_id"].nunique()),
-        }
-        track_pearsons: list[float] = []
-        for (track_index, sample), track_rows in subset.groupby(
-            ["track_index", "sample"], sort=True,
-        ):
-            track_pred = track_rows["pred_log1p_mean"].to_numpy(dtype=np.float64)
-            track_obs = track_rows["obs_log1p_mean"].to_numpy(dtype=np.float64)
-            track_pearson = _pearson_or_nan(track_pred, track_obs)
-            track_pearsons.append(track_pearson)
+        gene_ids, samples, pred, obs = _paper_expression_matrices(subset)
+
+        pred_quantile = quantile_normalize_columns(pred)
+        obs_quantile = quantile_normalize_columns(obs)
+        pred_normalized = pred_quantile - pred_quantile.mean(axis=1, keepdims=True)
+        obs_normalized = obs_quantile - obs_quantile.mean(axis=1, keepdims=True)
+
+        raw_across_genes: list[float] = []
+        normalized_across_genes: list[float] = []
+        for track_index, sample in enumerate(samples):
+            raw_pearson = _pearson_or_nan(pred[:, track_index], obs[:, track_index])
+            normalized_pearson = _pearson_or_nan(
+                pred_normalized[:, track_index],
+                obs_normalized[:, track_index],
+            )
+            raw_across_genes.append(raw_pearson)
+            normalized_across_genes.append(normalized_pearson)
             per_track_rows.append({
                 "bin_size_bp": bin_size,
-                "track_index": int(track_index),
                 "sample": sample,
-                "pearson_r_log1p_exon_mean": track_pearson,
-                "n_genes": len(track_rows),
+                "raw_pearson_r_across_genes": raw_pearson,
+                "normalized_pearson_r_across_genes": normalized_pearson,
+                "n_genes": len(gene_ids),
             })
-        finite_track_pearsons = np.asarray(track_pearsons, dtype=np.float64)
-        finite_track_pearsons = finite_track_pearsons[
-            np.isfinite(finite_track_pearsons)
+
+        normalized_across_tracks: list[float] = []
+        for gene_index, gene_id in enumerate(gene_ids):
+            pearson = _pearson_or_nan(
+                pred_normalized[gene_index], obs_normalized[gene_index],
+            )
+            normalized_across_tracks.append(pearson)
+            per_gene_rows.append({
+                "bin_size_bp": bin_size,
+                "gene_id": gene_id,
+                "normalized_pearson_r_across_tracks": pearson,
+                "n_tracks": len(samples),
+            })
+
+        raw_finite = np.asarray(raw_across_genes, dtype=np.float64)
+        raw_finite = raw_finite[np.isfinite(raw_finite)]
+        normalized_gene_finite = np.asarray(
+            normalized_across_genes, dtype=np.float64,
+        )
+        normalized_gene_finite = normalized_gene_finite[
+            np.isfinite(normalized_gene_finite)
         ]
-        summary[bin_size]["pearson_r_mean_across_tracks"] = (
-            float(finite_track_pearsons.mean())
-            if finite_track_pearsons.size else float("nan")
+        normalized_track_finite = np.asarray(
+            normalized_across_tracks, dtype=np.float64,
         )
-        summary[bin_size]["n_tracks_with_valid_pearson"] = int(
-            finite_track_pearsons.size
-        )
-    return summary, pd.DataFrame(per_track_rows)
+        normalized_track_finite = normalized_track_finite[
+            np.isfinite(normalized_track_finite)
+        ]
+        summary[bin_size] = {
+            "raw_pearson_r_mean_across_tracks": (
+                float(raw_finite.mean()) if raw_finite.size else float("nan")
+            ),
+            "normalized_pearson_r_mean_across_genes_by_track": (
+                float(normalized_gene_finite.mean())
+                if normalized_gene_finite.size else float("nan")
+            ),
+            "normalized_pearson_r_mean_across_tracks_by_gene": (
+                float(normalized_track_finite.mean())
+                if normalized_track_finite.size else float("nan")
+            ),
+            "n_genes": len(gene_ids),
+            "n_tracks": len(samples),
+            "n_raw_track_correlations": int(raw_finite.size),
+            "n_normalized_track_correlations": int(
+                normalized_gene_finite.size
+            ),
+            "n_normalized_gene_correlations": int(
+                normalized_track_finite.size
+            ),
+        }
+    return (
+        summary,
+        pd.DataFrame(per_track_rows),
+        pd.DataFrame(per_gene_rows),
+    )
 
 
 def _write_per_region_csv(
@@ -575,6 +701,23 @@ def _write_per_region_csv(
 
 
 def main() -> None:
+    # Keep model-framework imports out of module scope. Borzoi reuses the
+    # NumPy/Pandas gene-metric helpers from this file and must not load
+    # PyTorch's CUDA runtime into its TensorFlow process.
+    import torch
+    from torch.utils.data import DataLoader, Subset
+
+    from alphagenome_pytorch.extensions.finetuning.datasets import GenomicDataset
+    from alphagenome_pytorch.extensions.finetuning.evaluation import evaluate_split
+    from alphagenome_pytorch.extensions.finetuning.training import collate_genomic
+    from evaluate_checkpoint import (
+        build_metric_views,
+        center_crop_profiles,
+        compute_comparison_metrics,
+        load_finetuned_model,
+        parse_metric_bin_sizes,
+    )
+
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     args = parse_args()
     try:
@@ -677,7 +820,7 @@ def main() -> None:
         source_resolution=source,
         bin_sizes=bin_sizes,
         score_window_bp=args.score_window_bp,
-        reduction="mean",
+        reduction="sum",
     )
     gene_prediction_views, gene_target_views = build_metric_views(
         predictions[source],
@@ -729,16 +872,22 @@ def main() -> None:
         bin_sizes=bin_sizes,
         sample_names=sample_names,
     )
-    gene_metrics, gene_metrics_per_track = summarize_gene_expression(
-        gene_rows, bin_sizes,
-    )
+    (
+        gene_metrics,
+        gene_metrics_per_track,
+        gene_metrics_per_gene,
+    ) = summarize_gene_expression(gene_rows, bin_sizes)
     for bin_size, metrics in gene_metrics.items():
         log.info(
-            "%dbp gene expression: Pearson r=%.4f across %d genes (%d pairs)",
+            "%dbp gene expression: raw across-genes r=%.4f, normalized "
+            "across-genes r=%.4f, normalized across-tracks r=%.4f "
+            "(%d genes, %d tracks)",
             bin_size,
-            metrics["pearson_r_log1p_exon_mean"],
-            metrics["n_unique_genes"],
-            metrics["n_gene_track_pairs"],
+            metrics["raw_pearson_r_mean_across_tracks"],
+            metrics["normalized_pearson_r_mean_across_genes_by_track"],
+            metrics["normalized_pearson_r_mean_across_tracks_by_gene"],
+            metrics["n_genes"],
+            metrics["n_tracks"],
         )
 
     summary = {
@@ -752,7 +901,7 @@ def main() -> None:
             "source_resolution_bp": source,
             "bin_sizes_bp": list(bin_sizes),
             "profile_transform": "log1p",
-            "profile_pooling": "mean",
+            "profile_pooling": "sum",
             "count_source": "cropped_source_resolution_profile",
             "gene_score_window_bp": (
                 args.gene_score_window_bp or args.sequence_length
@@ -761,10 +910,25 @@ def main() -> None:
                 "center_crop" if args.gene_score_window_bp is not None
                 else "full_inference_test_interval"
             ),
-            "gene_selection": "official_transcript_tss",
-            "gene_interval_assignment": "nearest_interval_center_to_gene_tss",
-            "gene_mask_aggregation": "union_exon_mask_then_mean",
+            "gene_annotation": "GENCODE_v46_required",
+            "gene_selection": "at_least_50pct_unique_exon_bp_in_test_interval",
+            "gene_interval_assignment": (
+                "maximum_unique_exon_overlap_then_center_distance_then_bed_order"
+            ),
+            "gene_mask_aggregation": "union_all_annotated_exons_then_mean",
             "gene_expression_transform": "log1p_mean_exonic_coverage",
+            "gene_strand_matching": (
+                "forward_for_plus_reverse_for_minus_combined_per_sample"
+            ),
+            "gene_correlations": [
+                "raw_across_genes_per_track",
+                "quantile_normalized_gene_centered_across_genes_per_track",
+                "quantile_normalized_gene_centered_across_tracks_per_gene",
+            ],
+            "quantile_normalization": (
+                "predicted_and_observed_gene_by_track_matrices_independently_"
+                "normalized_across_track_columns"
+            ),
             "gtf_parquet": args.gtf_parquet,
             "n_regions": len(positions),
             "loss": loss,
@@ -784,6 +948,9 @@ def main() -> None:
     gene_rows.to_csv(output_dir / "gene_expression_per_gene.csv", index=False)
     gene_metrics_per_track.to_csv(
         output_dir / "gene_expression_metrics_per_track.csv", index=False,
+    )
+    gene_metrics_per_gene.to_csv(
+        output_dir / "gene_expression_metrics_per_gene.csv", index=False,
     )
 
     if args.save_predictions:

--- a/scripts/evaluate_checkpoint.py
+++ b/scripts/evaluate_checkpoint.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-"""Evaluate a fine-tuned AlphaGenome model.
+"""Evaluate AlphaGenome checkpoints.
 
 Supports three opt-in features (--metrics, --regions, --ism) and an optional
 native-head comparison layer (--native-biosample) that enriches all outputs.
@@ -7,22 +7,31 @@ native-head comparison layer (--native-biosample) that enriches all outputs.
 Usage examples:
 
     # Metrics only
-    python scripts/evaluate_finetuned.py \
+    python scripts/evaluate_checkpoint.py \
         --checkpoint best_model.pth \
         --pretrained-weights model_fold1.pth \
         --genome GRCh38.fa --bigwig signal.bw \
         --test-bed test.bed --output-dir eval/ --metrics
 
     # Metrics + native comparison
-    python scripts/evaluate_finetuned.py \
+    python scripts/evaluate_checkpoint.py \
         --checkpoint best_model.pth \
         --pretrained-weights model_fold1.pth \
         --genome GRCh38.fa --bigwig signal.bw \
         --test-bed test.bed --output-dir eval/ --metrics \
         --native-biosample "WTC11"
 
+    # Native/pretrained model metrics only
+    python scripts/evaluate_checkpoint.py \
+        --native-only --metrics \
+        --pretrained-weights model_fold1.pth \
+        --genome GRCh38.fa --bigwig signal.bw \
+        --test-bed test.bed --output-dir eval_native/ \
+        --modality atac --native-biosample "K562" \
+        --sequence-length 131072 --resolutions 128
+
     # Regions + ISM
-    python scripts/evaluate_finetuned.py \
+    python scripts/evaluate_checkpoint.py \
         --checkpoint best_model.pth \
         --pretrained-weights model_fold1.pth \
         --genome GRCh38.fa --bigwig signal.bw \
@@ -30,7 +39,7 @@ Usage examples:
         --regions --ism --ism-window-size 21
 
     # Everything
-    python scripts/evaluate_finetuned.py \
+    python scripts/evaluate_checkpoint.py \
         --checkpoint best_model.pth \
         --pretrained-weights model_fold1.pth \
         --genome GRCh38.fa --bigwig signal.bw \
@@ -57,342 +66,18 @@ from scipy import stats
 from torch.utils.data import DataLoader, Subset
 from tqdm import tqdm
 
-from alphagenome_pytorch import AlphaGenome
-from alphagenome_pytorch.extensions.finetuning.checkpointing import (
-    is_delta_checkpoint,
-    load_delta_checkpoint,
-    load_finetuned_model as _load_finetuned_model,
-)
 from alphagenome_pytorch.extensions.finetuning.datasets import GenomicDataset
-from alphagenome_pytorch.extensions.finetuning.heads import create_finetuning_head
+from alphagenome_pytorch.extensions.finetuning.evaluation import (
+    collect_targets,
+    compute_all_metrics,
+    evaluate_native_split,
+    evaluate_split,
+    load_finetuned_model,
+    load_native_model,
+)
 from alphagenome_pytorch.extensions.finetuning.training import collate_genomic
-from alphagenome_pytorch.extensions.finetuning.transfer import load_trunk
-from alphagenome_pytorch.losses import multinomial_loss
-from alphagenome_pytorch.named_outputs import TrackMetadataCatalog
 
 log = logging.getLogger(__name__)
-
-NUM_SEGMENTS = 8
-
-
-# =============================================================================
-# Model loading
-# =============================================================================
-
-
-def load_finetuned_model(
-    checkpoint_path: str,
-    pretrained_weights: str,
-    device: torch.device,
-) -> tuple[nn.Module, dict]:
-    """Load a finetuned model, auto-detecting checkpoint format.
-
-    Returns (model, metadata_dict).
-    metadata_dict always contains: modality, resolutions, track_names, epoch, val_loss.
-    """
-    log.info("Loading checkpoint: %s", Path(checkpoint_path).name)
-    model, meta = _load_finetuned_model(
-        checkpoint_path=checkpoint_path,
-        pretrained_weights=pretrained_weights,
-        device=device,
-        merge=True,
-    )
-    for p in model.parameters():
-        p.requires_grad = False
-    return model, meta
-
-
-def load_native_model(
-    pretrained_weights: str,
-    native_biosample: str | None,
-    native_track_index: int | None,
-    modality: str,
-    device: torch.device,
-) -> tuple[nn.Module, int, str]:
-    """Load pretrained model with all native heads and find matching track.
-
-    Returns (model, track_index, display_name).
-    """
-    log.info("Loading native model for comparison...")
-    model = AlphaGenome.from_pretrained(pretrained_weights, device=device)
-    model.eval()
-    for p in model.parameters():
-        p.requires_grad = False
-
-    catalog = TrackMetadataCatalog.load_builtin("human")
-    model.set_track_metadata_catalog(catalog)
-
-    if native_track_index is not None:
-        # Direct index — validate it exists
-        tracks = catalog.get_tracks(modality, organism=0)
-        if native_track_index >= len(tracks):
-            raise ValueError(
-                f"Track index {native_track_index} out of range for "
-                f"{modality} ({len(tracks)} tracks)"
-            )
-        track = tracks[native_track_index]
-        display_name = track.get("biosample_name") or track.track_name
-        log.info(
-            "Native track: index=%d, name=%s", native_track_index, display_name
-        )
-        return model, native_track_index, display_name
-
-    # Search by biosample name (substring, case-insensitive)
-    tracks = catalog.get_tracks(modality, organism=0)
-    query = native_biosample.lower()
-    matches = [
-        t for t in tracks
-        if not t.is_padding and query in (t.get("biosample_name") or "").lower()
-    ]
-
-    if not matches:
-        available = sorted({
-            t.get("biosample_name")
-            for t in tracks
-            if not t.is_padding and t.get("biosample_name")
-        })
-        raise ValueError(
-            f"No {modality} track found matching biosample '{native_biosample}'. "
-            f"Available biosamples ({len(available)}): {available[:20]}"
-        )
-
-    if len(matches) > 1:
-        log.warning(
-            "Multiple tracks match '%s': %s. Using first.",
-            native_biosample,
-            [(m.track_index, m.get("biosample_name")) for m in matches[:5]],
-        )
-
-    track = matches[0]
-    display_name = track.get("biosample_name") or track.track_name
-    log.info("Native track: index=%d, name=%s", track.track_index, display_name)
-    return model, track.track_index, display_name
-
-
-# =============================================================================
-# Inference
-# =============================================================================
-
-
-@torch.no_grad()
-def evaluate_split(
-    model: nn.Module,
-    modality: str,
-    loader: DataLoader,
-    device: torch.device,
-    resolutions: tuple[int, ...],
-    positional_weight: float = 5.0,
-) -> tuple[dict[int, np.ndarray], dict[int, np.ndarray], float]:
-    """Run finetuned model inference. Returns (preds, targets, avg_loss).
-
-    Predictions are in experimental space (unscaled).
-    """
-    model.eval()
-    head = model.heads[modality]
-
-    preds_by_res: dict[int, list[np.ndarray]] = {r: [] for r in resolutions}
-    targets_by_res: dict[int, list[np.ndarray]] = {r: [] for r in resolutions}
-    total_loss = 0.0
-    n_batches = 0
-
-    for sequences, targets_dict in tqdm(loader, desc="Evaluating (finetuned)"):
-        sequences = sequences.to(device)
-        organism_idx = torch.zeros(
-            sequences.shape[0], dtype=torch.long, device=device
-        )
-
-        with torch.autocast(
-            device_type=device.type, dtype=torch.bfloat16,
-            enabled=device.type == "cuda",
-        ):
-            outputs = model(
-                sequences, organism_idx,
-                embeddings_only=True, resolutions=resolutions,
-                channels_last=False,
-            )
-            embeddings_dict = {
-                res: outputs[f"embeddings_{res}bp"]
-                for res in resolutions
-                if f"embeddings_{res}bp" in outputs
-            }
-            scaled_preds = head(embeddings_dict, organism_idx, return_scaled=True)
-            exp_preds = head(embeddings_dict, organism_idx, return_scaled=False)
-
-        # Loss
-        loss = torch.tensor(0.0, device=device)
-        for res in resolutions:
-            if res not in scaled_preds or res not in targets_dict:
-                continue
-            pred = scaled_preds[res]
-            targets = targets_dict[res].to(device)
-            targets_scaled = head.scale(targets, organism_idx, resolution=res)
-            mask = torch.ones(
-                pred.shape[0], 1, pred.shape[-1],
-                dtype=torch.bool, device=device,
-            )
-            seq_len = pred.shape[-2]
-            mn_res = max(1, seq_len // NUM_SEGMENTS)
-            while mn_res > 1 and seq_len % mn_res != 0:
-                mn_res -= 1
-            ld = multinomial_loss(
-                y_pred=pred, y_true=targets_scaled, mask=mask,
-                multinomial_resolution=mn_res,
-                positional_weight=positional_weight,
-            )
-            loss = loss + ld["loss"]
-
-        total_loss += loss.item()
-        n_batches += 1
-
-        for res in resolutions:
-            if res in exp_preds:
-                preds_by_res[res].append(exp_preds[res].float().cpu().numpy())
-            if res in targets_dict:
-                targets_by_res[res].append(targets_dict[res].numpy())
-
-    all_preds = {r: np.concatenate(v, axis=0) for r, v in preds_by_res.items() if v}
-    all_targets = {
-        r: np.concatenate(v, axis=0) for r, v in targets_by_res.items() if v
-    }
-    avg_loss = total_loss / max(1, n_batches)
-    return all_preds, all_targets, avg_loss
-
-
-@torch.no_grad()
-def evaluate_native_split(
-    model: nn.Module,
-    modality: str,
-    track_index: int,
-    loader: DataLoader,
-    device: torch.device,
-    resolutions: tuple[int, ...],
-) -> dict[int, np.ndarray]:
-    """Run native model on same data, extract a single track.
-
-    Returns dict[resolution -> (N, seq_len, 1)] predictions.
-    """
-    model.eval()
-
-    preds_by_res: dict[int, list[np.ndarray]] = {r: [] for r in resolutions}
-
-    for sequences, _ in tqdm(loader, desc="Evaluating (native)"):
-        sequences = sequences.to(device)
-        organism_idx = torch.zeros(
-            sequences.shape[0], dtype=torch.long, device=device,
-        )
-
-        with torch.autocast(
-            device_type=device.type, dtype=torch.bfloat16,
-            enabled=device.type == "cuda",
-        ):
-            outputs = model(sequences, organism_idx)
-
-        if modality not in outputs:
-            continue
-        head_outputs = outputs[modality]  # dict[int, (B, S, T)] channels_last by default
-        for res in resolutions:
-            if res not in head_outputs:
-                continue
-            pred = head_outputs[res]
-            # Extract single track
-            pred_track = pred[:, :, track_index : track_index + 1]
-            preds_by_res[res].append(pred_track.float().cpu().numpy())
-
-    return {r: np.concatenate(v, axis=0) for r, v in preds_by_res.items() if v}
-
-
-# =============================================================================
-# Metrics
-# =============================================================================
-
-
-def jsd_per_region(
-    preds: np.ndarray, targets: np.ndarray, eps: float = 1e-8,
-) -> np.ndarray:
-    """Jensen-Shannon divergence per region between normalized profiles.
-
-    Args:
-        preds: (N, seq_len, n_tracks)
-        targets: (N, seq_len, n_tracks)
-
-    Returns:
-        (N, n_tracks) array of JSD values.
-    """
-    # Normalize along position axis to get probability distributions
-    p = targets / (targets.sum(axis=1, keepdims=True) + eps)
-    q = preds / (preds.sum(axis=1, keepdims=True) + eps)
-    m = 0.5 * (p + q)
-    kl_pm = np.sum(p * np.log((p + eps) / (m + eps)), axis=1)
-    kl_qm = np.sum(q * np.log((q + eps) / (m + eps)), axis=1)
-    return 0.5 * (kl_pm + kl_qm)
-
-
-def compute_all_metrics(
-    preds: np.ndarray, targets: np.ndarray,
-) -> dict[str, float | np.ndarray]:
-    """Compute comprehensive evaluation metrics.
-
-    Args:
-        preds: (N, seq_len, n_tracks)
-        targets: (N, seq_len, n_tracks)
-
-    Returns dict with:
-        profile_pearson_r_all (N,), profile_pearson_r_mean, profile_pearson_r_median,
-        count_pearson_r, jsd_all (N,), jsd_mean, jsd_median,
-        mse, spearman_global, n_regions
-    """
-    n_regions = preds.shape[0]
-
-    # Per-region profile Pearson r
-    profile_rs = []
-    for i in range(n_regions):
-        p = preds[i].flatten()
-        t = targets[i].flatten()
-        if np.std(t) > 1e-10 and np.std(p) > 1e-10:
-            r, _ = stats.pearsonr(p, t)
-            profile_rs.append(r)
-        else:
-            profile_rs.append(0.0)
-    profile_rs = np.array(profile_rs)
-
-    # Count Pearson r: sum signal per region, correlate all at once
-    pred_counts = preds.sum(axis=1).flatten()   # (N * n_tracks,)
-    target_counts = targets.sum(axis=1).flatten()
-    if np.std(pred_counts) > 1e-10 and np.std(target_counts) > 1e-10:
-        count_r = stats.pearsonr(pred_counts, target_counts)[0]
-    else:
-        count_r = 0.0
-
-    # JSD per region (average across tracks)
-    jsd_vals = jsd_per_region(preds, targets)  # (N, n_tracks)
-    jsd_per_reg = jsd_vals.mean(axis=1)  # (N,)
-
-    # Global metrics (subsample for speed)
-    p_flat = preds.flatten()
-    t_flat = targets.flatten()
-    if len(p_flat) > 2_000_000:
-        idx = np.random.default_rng(42).choice(
-            len(p_flat), 2_000_000, replace=False,
-        )
-        p_flat = p_flat[idx]
-        t_flat = t_flat[idx]
-
-    spearman_global = stats.spearmanr(p_flat, t_flat)[0]
-    mse = float(np.mean((preds - targets) ** 2))
-
-    return {
-        "profile_pearson_r_all": profile_rs,
-        "profile_pearson_r_mean": float(np.mean(profile_rs)),
-        "profile_pearson_r_median": float(np.median(profile_rs)),
-        "count_pearson_r": float(count_r),
-        "jsd_all": jsd_per_reg,
-        "jsd_mean": float(np.mean(jsd_per_reg)),
-        "jsd_median": float(np.median(jsd_per_reg)),
-        "mse": mse,
-        "spearman_global": float(spearman_global),
-        "n_regions": n_regions,
-    }
-
 
 # =============================================================================
 # Plotting
@@ -703,12 +388,13 @@ def format_summary_table(
     for res in resolutions:
         ft = ft_metrics.get(res) if ft_metrics else None
         nat = native_metrics.get(res) if native_metrics else None
-        if ft is None:
+        if ft is None and nat is None:
             continue
 
         lines.append(f"\n--- {res}bp resolution ---")
         header = f"{'Metric':<28}"
-        header += f"{'Finetuned':>12}"
+        if ft is not None:
+            header += f"{'Finetuned':>12}"
         if nat is not None:
             header += f"  {'Native(' + (native_display_name or '?') + ')':>20}"
         lines.append(header)
@@ -724,11 +410,18 @@ def format_summary_table(
             ("Spearman (global)", "spearman_global"),
         ]
         for label, key in rows:
-            line = f"{label:<28}{ft[key]:>12.4f}"
+            line = f"{label:<28}"
+            if ft is not None:
+                line += f"{ft[key]:>12.4f}"
             if nat is not None:
                 line += f"  {nat[key]:>20.4f}"
             lines.append(line)
-        lines.append(f"{'N regions':<28}{ft['n_regions']:>12d}")
+        line = f"{'N regions':<28}"
+        if ft is not None:
+            line += f"{ft['n_regions']:>12d}"
+        if nat is not None:
+            line += f"  {nat['n_regions']:>20d}"
+        lines.append(line)
 
     return "\n".join(lines)
 
@@ -775,12 +468,12 @@ def save_summary_json(
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
-        description="Evaluate fine-tuned AlphaGenome models",
+        description="Evaluate AlphaGenome checkpoints",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
     # Required
-    p.add_argument("--checkpoint", required=True, help="Finetuned checkpoint path")
+    p.add_argument("--checkpoint", help="Finetuned checkpoint path")
     p.add_argument(
         "--pretrained-weights", required=True,
         help="Pretrained trunk weights (e.g. model_fold1.pth)",
@@ -800,6 +493,13 @@ def parse_args() -> argparse.Namespace:
         "--ism", action="store_true",
         help="Run ISM on predefined regions (needs --regions-bed + --genome)",
     )
+    p.add_argument(
+        "--native-only", action="store_true",
+        help=(
+            "Evaluate the pretrained/native model directly. Requires --metrics, "
+            "--modality, and --native-biosample or --native-track-index."
+        ),
+    )
 
     # Data inputs
     p.add_argument("--genome", help="Reference genome FASTA")
@@ -816,8 +516,17 @@ def parse_args() -> argparse.Namespace:
         "--native-track-index", type=int,
         help="Direct track index for native head (alternative to --native-biosample)",
     )
+    p.add_argument(
+        "--modality",
+        help="Native head/modality to evaluate in --native-only mode (e.g. atac)",
+    )
 
     # Options
+    p.add_argument(
+        "--resolutions",
+        default=None,
+        help="Comma-separated resolutions for --native-only mode (default: 128)",
+    )
     p.add_argument("--sequence-length", type=int, default=131072)
     p.add_argument("--batch-size", type=int, default=4)
     p.add_argument("--num-workers", type=int, default=4)
@@ -828,6 +537,12 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--device", default=None, help="Device (default: auto)")
 
     return p.parse_args()
+
+
+def parse_resolutions(raw: str | None) -> tuple[int, ...]:
+    if raw is None:
+        return (128,)
+    return tuple(int(part.strip()) for part in raw.split(",") if part.strip())
 
 
 # =============================================================================
@@ -853,41 +568,69 @@ def main() -> None:
     log.info("Device: %s", device)
 
     # Determine which features to run
-    any_explicit = args.metrics or args.regions or args.ism
+    any_explicit = args.metrics or args.regions or args.ism or args.native_only
     run_metrics = args.metrics or (not any_explicit and args.test_bed is not None)
     run_regions = args.regions or (not any_explicit and args.regions_bed is not None)
     run_ism = args.ism  # Always explicit
+    want_native = bool(args.native_biosample or args.native_track_index is not None)
 
     # Validate inputs
+    if not args.native_only and not args.checkpoint:
+        sys.exit("Error: --checkpoint is required unless --native-only is set")
+    if args.native_only and not args.metrics:
+        sys.exit("Error: --native-only currently supports metrics only; pass --metrics")
+    if args.native_only and (run_regions or run_ism):
+        sys.exit("Error: --native-only does not support --regions or --ism")
+    if args.native_only and not args.modality:
+        sys.exit("Error: --native-only requires --modality")
+    if args.native_only and not want_native:
+        sys.exit("Error: --native-only requires --native-biosample or --native-track-index")
     if run_metrics and (not args.test_bed or not args.bigwig):
         sys.exit("Error: --metrics requires --test-bed and --bigwig")
+    if args.native_only and args.bigwig and len(args.bigwig) != 1:
+        sys.exit("Error: --native-only evaluates one native track; pass exactly one --bigwig")
     if run_regions and (not args.regions_bed or not args.bigwig):
         sys.exit("Error: --regions requires --regions-bed and --bigwig")
     if run_ism and (not args.regions_bed or not args.genome):
         sys.exit("Error: --ism requires --regions-bed and --genome")
 
-    want_native = bool(args.native_biosample or args.native_track_index is not None)
+    model = None
+    if args.native_only:
+        modality = args.modality
+        resolutions = parse_resolutions(args.resolutions)
+        track_names = []
+        ckpt_meta = {
+            "mode": "native_only",
+            "pretrained_weights": args.pretrained_weights,
+            "modality": modality,
+            "resolutions": resolutions,
+            "track_names": track_names,
+        }
+        log.info(
+            "Native-only modality: %s, Resolutions: %s",
+            modality, resolutions,
+        )
+    else:
+        # ---- Load finetuned model ----
+        model, ckpt_meta = load_finetuned_model(
+            args.checkpoint, args.pretrained_weights, device,
+        )
+        modality = ckpt_meta["modality"]
+        if isinstance(modality, list):
+            modality = modality[0]  # single-task evaluation
+        resolutions = tuple(ckpt_meta["resolutions"])
+        track_names = ckpt_meta["track_names"]
+        if isinstance(track_names, dict):
+            track_names = track_names.get(modality, [])
 
-    # ---- Load finetuned model ----
-    model, ckpt_meta = load_finetuned_model(
-        args.checkpoint, args.pretrained_weights, device,
-    )
-    modality = ckpt_meta["modality"]
-    if isinstance(modality, list):
-        modality = modality[0]  # single-task evaluation
-    resolutions = tuple(ckpt_meta["resolutions"])
-    track_names = ckpt_meta["track_names"]
-    if isinstance(track_names, dict):
-        track_names = track_names.get(modality, [])
-
-    log.info(
-        "Modality: %s, Tracks: %s, Resolutions: %s",
-        modality, track_names, resolutions,
-    )
-    log.info(
-        "Checkpoint epoch: %s, val_loss: %s",
-        ckpt_meta["epoch"], ckpt_meta["val_loss"],
-    )
+        log.info(
+            "Modality: %s, Tracks: %s, Resolutions: %s",
+            modality, track_names, resolutions,
+        )
+        log.info(
+            "Checkpoint epoch: %s, val_loss: %s",
+            ckpt_meta["epoch"], ckpt_meta["val_loss"],
+        )
 
     # ---- Optionally load native model ----
     native_model, native_track_idx, native_display_name = None, None, None
@@ -936,41 +679,49 @@ def main() -> None:
             collate_fn=collate_genomic,
         )
 
-        # Finetuned evaluation
-        ft_preds, targets, loss = evaluate_split(
-            model, modality, loader, device, resolutions,
-        )
-        log.info("Loss: %.4f", loss)
+        ft_preds: dict[int, np.ndarray] = {}
+        native_preds: dict[int, np.ndarray] = {}
+        targets: dict[int, np.ndarray]
 
-        for res in resolutions:
-            if res not in ft_preds:
-                continue
-            p, t = ft_preds[res], targets[res]
-            log.info("Resolution %dbp: preds %s, targets %s", res, p.shape, t.shape)
-
-            ft_m = compute_all_metrics(p, t)
-            ft_metrics_by_res[res] = ft_m
-
-            log.info("  Profile r (mean):  %.4f", ft_m["profile_pearson_r_mean"])
-            log.info("  Profile r (median):%.4f", ft_m["profile_pearson_r_median"])
-            log.info("  Count r:           %.4f", ft_m["count_pearson_r"])
-            log.info("  JSD (mean):        %.4f", ft_m["jsd_mean"])
-
-            # Scatter plots
-            plot_scatter(
-                p, t, metrics_dir / f"scatter_test_{res}bp.png",
-                title_suffix=f"(test, {res}bp)",
+        if args.native_only:
+            targets = collect_targets(loader, resolutions)
+        else:
+            # Finetuned evaluation
+            ft_preds, targets, loss = evaluate_split(
+                model, modality, loader, device, resolutions,
             )
-            plot_scatter_counts(
-                p, t, metrics_dir / f"scatter_counts_test_{res}bp.png",
-                title_suffix=f"(test, {res}bp)",
-            )
+            log.info("Loss: %.4f", loss)
+
+            for res in resolutions:
+                if res not in ft_preds:
+                    continue
+                p, t = ft_preds[res], targets[res]
+                log.info("Resolution %dbp: preds %s, targets %s", res, p.shape, t.shape)
+
+                ft_m = compute_all_metrics(p, t)
+                ft_metrics_by_res[res] = ft_m
+
+                log.info("  Profile r (mean):  %.4f", ft_m["profile_pearson_r_mean"])
+                log.info("  Profile r (median):%.4f", ft_m["profile_pearson_r_median"])
+                log.info("  Count r:           %.4f", ft_m["count_pearson_r"])
+                log.info("  JSD (mean):        %.4f", ft_m["jsd_mean"])
+
+                # Scatter plots
+                plot_scatter(
+                    p, t, metrics_dir / f"scatter_test_{res}bp.png",
+                    title_suffix=f"(test, {res}bp)",
+                )
+                plot_scatter_counts(
+                    p, t, metrics_dir / f"scatter_counts_test_{res}bp.png",
+                    title_suffix=f"(test, {res}bp)",
+                )
 
         # Native evaluation on same data
         if native_model is not None:
-            # Move finetuned model to CPU to free GPU memory
+            # Move finetuned model to CPU to free GPU memory.
             model_device = device
-            model.cpu()
+            if model is not None:
+                model.cpu()
             native_model = native_model.to(device)
 
             native_preds = evaluate_native_split(
@@ -994,13 +745,30 @@ def main() -> None:
 
             # Move models back
             native_model.cpu()
-            model = model.to(model_device)
+            if model is not None:
+                model = model.to(model_device)
 
         # Generate histogram plots (overlaid if native available)
         for res in resolutions:
             ft_m = ft_metrics_by_res.get(res)
             nat_m = native_metrics_by_res.get(res)
+            if ft_m is None and nat_m is None:
+                continue
             if ft_m is None:
+                plot_correlation_histogram(
+                    nat_m["profile_pearson_r_all"],
+                    metrics_dir / f"native_correlation_hist_test_{res}bp.png",
+                    xlabel="Pearson r (per region)",
+                    title=f"Native profile correlation distribution ({res}bp)",
+                    ft_label=f"Native ({native_display_name})" if native_display_name else "Native",
+                )
+                plot_correlation_histogram(
+                    nat_m["jsd_all"],
+                    metrics_dir / f"native_jsd_hist_test_{res}bp.png",
+                    xlabel="JSD (per region)",
+                    title=f"Native JSD distribution ({res}bp)",
+                    ft_label=f"Native ({native_display_name})" if native_display_name else "Native",
+                )
                 continue
 
             plot_correlation_histogram(

--- a/scripts/evaluate_checkpoint.py
+++ b/scripts/evaluate_checkpoint.py
@@ -66,18 +66,41 @@ from scipy import stats
 from torch.utils.data import DataLoader, Subset
 from tqdm import tqdm
 
+from alphagenome_pytorch.extensions.finetuning.checkpointing import (
+    load_finetuned_model as _load_finetuned_model,
+)
 from alphagenome_pytorch.extensions.finetuning.datasets import GenomicDataset
 from alphagenome_pytorch.extensions.finetuning.evaluation import (
     collect_targets,
     compute_all_metrics,
     evaluate_native_split,
     evaluate_split,
-    load_finetuned_model,
     load_native_model,
 )
 from alphagenome_pytorch.extensions.finetuning.training import collate_genomic
 
 log = logging.getLogger(__name__)
+
+
+def load_finetuned_model(
+    checkpoint_path: str, pretrained_weights: str, device: torch.device,
+) -> tuple[nn.Module, dict]:
+    """Load a finetuned checkpoint, auto-detecting delta/full/adapter format.
+
+    Full checkpoints embed their TransferConfig (lora/locon targets etc.) at
+    save time, so adapter checkpoints are self-describing -- no external
+    transfer config file is needed.
+    """
+    model, meta = _load_finetuned_model(
+        checkpoint_path=checkpoint_path,
+        pretrained_weights=pretrained_weights,
+        device=device,
+        merge=True,
+    )
+    for p in model.parameters():
+        p.requires_grad = False
+    return model, meta
+
 
 # =============================================================================
 # Plotting
@@ -618,7 +641,10 @@ def main() -> None:
         modality = ckpt_meta["modality"]
         if isinstance(modality, list):
             modality = modality[0]  # single-task evaluation
-        resolutions = tuple(ckpt_meta["resolutions"])
+        resolutions = ckpt_meta["resolutions"]
+        if isinstance(resolutions, dict):
+            resolutions = resolutions.get(modality, (1,))
+        resolutions = tuple(resolutions)
         track_names = ckpt_meta["track_names"]
         if isinstance(track_names, dict):
             track_names = track_names.get(modality, [])

--- a/scripts/evaluate_checkpoint.py
+++ b/scripts/evaluate_checkpoint.py
@@ -51,6 +51,7 @@ Usage examples:
 from __future__ import annotations
 
 import argparse
+from dataclasses import dataclass
 import json
 import logging
 import sys
@@ -72,7 +73,6 @@ from alphagenome_pytorch.extensions.finetuning.checkpointing import (
 from alphagenome_pytorch.extensions.finetuning.datasets import GenomicDataset
 from alphagenome_pytorch.extensions.finetuning.evaluation import (
     collect_targets,
-    compute_all_metrics,
     evaluate_native_split,
     evaluate_split,
     load_native_model,
@@ -168,6 +168,17 @@ def plot_correlation_histogram(
     native_label: str = "Native",
 ) -> None:
     """Histogram of per-region values, optionally overlaid with native."""
+    ft_values = np.asarray(ft_values)
+    ft_values = ft_values[np.isfinite(ft_values)]
+    if native_values is not None:
+        native_values = np.asarray(native_values)
+        native_values = native_values[np.isfinite(native_values)]
+    if ft_values.size == 0:
+        log.warning("Skipping %s because no finite values are available", out_path)
+        return
+    if native_values is not None and native_values.size == 0:
+        native_values = None
+
     fig, ax = plt.subplots(figsize=(7, 4))
 
     bins = np.linspace(
@@ -396,6 +407,262 @@ def run_ism_for_regions(
 
 
 # =============================================================================
+# Resolution-matched metrics
+# =============================================================================
+
+
+@dataclass
+class _PearsonRState:
+    """State to compute PearsonR correlation coefficient."""
+
+    xy_sum: np.ndarray
+    x_sum: np.ndarray
+    xx_sum: np.ndarray
+    y_sum: np.ndarray
+    yy_sum: np.ndarray
+    count: np.ndarray
+
+    def __add__(self, other: "_PearsonRState") -> "_PearsonRState":
+        return _PearsonRState(*(
+            getattr(self, field) + getattr(other, field)
+            for field in self.__dataclass_fields__
+        ))
+
+
+def _pearsonr_initialize() -> _PearsonRState:
+    """Initialize PearsonrState with zeros."""
+    return _PearsonRState(
+        # JAX uses float32 here under AlphaGenome's default x64-disabled
+        # configuration; make that implicit reference behavior explicit in
+        # this NumPy port.
+        xy_sum=np.zeros((), dtype=np.float32),
+        x_sum=np.zeros((), dtype=np.float32),
+        xx_sum=np.zeros((), dtype=np.float32),
+        y_sum=np.zeros((), dtype=np.float32),
+        yy_sum=np.zeros((), dtype=np.float32),
+        count=np.zeros((), dtype=np.float32),
+    )
+
+
+def _pearsonr_update(
+    x: np.ndarray,
+    y: np.ndarray,
+    axis: tuple[int, ...] | int | None = None,
+    mask: np.ndarray | None = None,
+) -> _PearsonRState:
+    """Construct PearsonrState by correlating two arrays."""
+    if mask is not None:
+        mask = np.asarray(mask, dtype=bool)
+    where = True if mask is None else mask
+    return _PearsonRState(
+        xy_sum=np.sum(x * y, axis=axis, where=where, dtype=np.float32),
+        x_sum=np.sum(x, axis=axis, where=where, dtype=np.float32),
+        xx_sum=np.sum(np.square(x), axis=axis, where=where, dtype=np.float32),
+        y_sum=np.sum(y, axis=axis, where=where, dtype=np.float32),
+        yy_sum=np.sum(np.square(y), axis=axis, where=where, dtype=np.float32),
+        count=np.sum(
+            np.ones_like(x), axis=axis, where=where, dtype=np.float32,
+        ),
+    )
+
+
+def _pearsonr_result(state: _PearsonRState) -> np.ndarray:
+    """Get PearsonR correlation coefficient."""
+    with np.errstate(invalid="ignore", divide="ignore"):
+        x_mean = state.x_sum / state.count
+        y_mean = state.y_sum / state.count
+
+        covariance = state.xy_sum - state.count * x_mean * y_mean
+
+        x_var = state.xx_sum - state.count * x_mean * x_mean
+        y_var = state.yy_sum - state.count * y_mean * y_mean
+        variance = x_var**0.5 * y_var**0.5
+        eps = np.finfo(variance.dtype).eps
+        return covariance / (variance + eps)
+
+
+def center_crop_profiles(
+    preds: np.ndarray,
+    targets: np.ndarray,
+    score_window_bp: int | None,
+    source_resolution: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Center-crop aligned arrays after full-context model inference."""
+    if preds.shape != targets.shape:
+        raise ValueError(
+            f"Prediction/target shape mismatch: {preds.shape} != {targets.shape}"
+        )
+    if preds.ndim != 3:
+        raise ValueError(f"Expected (regions, positions, tracks), got {preds.shape}")
+    if source_resolution <= 0:
+        raise ValueError("source_resolution must be positive")
+    if score_window_bp is None:
+        return preds, targets
+    if score_window_bp <= 0 or score_window_bp % source_resolution:
+        raise ValueError(
+            "score_window_bp must be positive and divisible by source_resolution"
+        )
+
+    width = score_window_bp // source_resolution
+    available = preds.shape[1]
+    if width > available:
+        raise ValueError(
+            f"Requested {score_window_bp:,} bp scoring window, but predictions "
+            f"cover only {available * source_resolution:,} bp. A 131-kbp model "
+            "cannot be scored over the 196,608-bp Borzoi window without tiling."
+        )
+    left = (available - width) // 2
+    right = left + width
+    return preds[:, left:right, :], targets[:, left:right, :]
+
+
+def pool_profiles(
+    values: np.ndarray, factor: int, reduction: str = "sum",
+) -> np.ndarray:
+    """Aggregate adjacent positions with a sum or mean reduction."""
+    if factor <= 0:
+        raise ValueError("Pooling factor must be positive")
+    if factor == 1:
+        return values
+    if values.shape[1] % factor:
+        raise ValueError(
+            f"Profile length {values.shape[1]} is not divisible by pooling factor {factor}"
+        )
+    n_regions, n_positions, n_tracks = values.shape
+    grouped = values.reshape(
+        n_regions, n_positions // factor, factor, n_tracks,
+    )
+    if reduction == "sum":
+        return grouped.sum(axis=2)
+    if reduction == "mean":
+        return grouped.mean(axis=2)
+    raise ValueError(f"Unknown pooling reduction: {reduction}")
+
+
+def build_metric_views(
+    preds: np.ndarray,
+    targets: np.ndarray,
+    *,
+    source_resolution: int,
+    bin_sizes: tuple[int, ...],
+    score_window_bp: int | None,
+    reduction: str = "sum",
+) -> tuple[dict[int, np.ndarray], dict[int, np.ndarray]]:
+    """Crop once, then construct aligned metric-resolution views."""
+    cropped_preds, cropped_targets = center_crop_profiles(
+        preds, targets, score_window_bp, source_resolution,
+    )
+    pred_views: dict[int, np.ndarray] = {}
+    target_views: dict[int, np.ndarray] = {}
+    for bin_size in bin_sizes:
+        if bin_size < source_resolution or bin_size % source_resolution:
+            raise ValueError(
+                f"Metric bin size {bin_size} must be a multiple of source "
+                f"resolution {source_resolution}"
+            )
+        factor = bin_size // source_resolution
+        pred_views[bin_size] = pool_profiles(cropped_preds, factor, reduction)
+        target_views[bin_size] = pool_profiles(cropped_targets, factor, reduction)
+    return pred_views, target_views
+
+
+def _pearson_or_nan(x: np.ndarray, y: np.ndarray) -> float:
+    x = np.asarray(x, dtype=np.float64).reshape(-1)
+    y = np.asarray(y, dtype=np.float64).reshape(-1)
+    finite = np.isfinite(x) & np.isfinite(y)
+    x, y = x[finite], y[finite]
+    if x.size < 2 or np.std(x) <= 1e-10 or np.std(y) <= 1e-10:
+        return float("nan")
+    return float(stats.pearsonr(x, y)[0])
+
+
+def compute_comparison_metrics(
+    preds: np.ndarray,
+    targets: np.ndarray,
+    *,
+    profile_transform: str = "none",
+) -> dict[str, float | int | np.ndarray]:
+    """Compute per-region profiles, regional counts, and profile JSD metrics."""
+    if preds.shape != targets.shape or preds.ndim != 3:
+        raise ValueError(
+            "preds and targets must have matching (regions, positions, tracks) shapes"
+        )
+    if np.any(preds < 0) or np.any(targets < 0):
+        raise ValueError("Jensen-Shannon metrics require non-negative profiles")
+
+    if profile_transform == "none":
+        profile_preds, profile_targets = preds, targets
+    elif profile_transform == "log1p":
+        profile_preds, profile_targets = np.log1p(preds), np.log1p(targets)
+    else:
+        raise ValueError(f"Unknown profile transform: {profile_transform}")
+
+    profile_rs = np.asarray([
+        _pearson_or_nan(profile_preds[i], profile_targets[i])
+        for i in range(preds.shape[0])
+    ])
+    pred_counts = preds.sum(axis=1).reshape(-1)
+    target_counts = targets.sum(axis=1).reshape(-1)
+    count_raw = _pearson_or_nan(pred_counts, target_counts)
+    count_log1p = _pearson_or_nan(np.log1p(pred_counts), np.log1p(target_counts))
+
+    eps = 1e-8
+    p = targets / (targets.sum(axis=1, keepdims=True) + eps)
+    q = preds / (preds.sum(axis=1, keepdims=True) + eps)
+    m = 0.5 * (p + q)
+    js_by_track = 0.5 * (
+        np.sum(p * np.log((p + eps) / (m + eps)), axis=1)
+        + np.sum(q * np.log((q + eps) / (m + eps)), axis=1)
+    )
+    js_divergence = np.mean(js_by_track, axis=1)
+    js_distance = np.sqrt(np.maximum(js_divergence, 0.0))
+
+    pearson_state = _pearsonr_initialize()
+    pearson_state += _pearsonr_update(
+        profile_targets, profile_preds, axis=(-2, -3),
+    )
+    track_pearson = _pearsonr_result(pearson_state)
+    counted_tracks = pearson_state.count > 0
+
+    flat_preds = profile_preds.reshape(-1)
+    flat_targets = profile_targets.reshape(-1)
+    if flat_preds.size > 2_000_000:
+        idx = np.random.default_rng(42).choice(
+            flat_preds.size, 2_000_000, replace=False,
+        )
+        flat_preds, flat_targets = flat_preds[idx], flat_targets[idx]
+
+    return {
+        "profile_transform": profile_transform,
+        "profile_pearson_r_all": profile_rs,
+        "profile_pearson_r_mean": float(np.nanmean(profile_rs)),
+        "profile_pearson_r_median": float(np.nanmedian(profile_rs)),
+        "profile_pearson_r_n_valid": int(np.isfinite(profile_rs).sum()),
+        "track_pearson_r_accumulated_all": track_pearson,
+        "track_pearson_r_accumulated_mean": float(
+            np.mean(track_pearson, where=counted_tracks)
+        ),
+        "track_pearson_r_accumulated_n_valid": int(counted_tracks.sum()),
+        "count_pearson_r": count_raw,
+        "count_pearson_r_raw": count_raw,
+        "count_pearson_r_log1p": count_log1p,
+        "jsd_all": js_divergence,
+        "jsd_mean": float(np.nanmean(js_divergence)),
+        "jsd_median": float(np.nanmedian(js_divergence)),
+        "js_divergence_all": js_divergence,
+        "js_divergence_mean": float(np.nanmean(js_divergence)),
+        "js_distance_all": js_distance,
+        "js_distance_mean": float(np.nanmean(js_distance)),
+        "js_distance_median": float(np.nanmedian(js_distance)),
+        "mse": float(np.mean(np.square(preds - targets))),
+        "spearman_global": float(stats.spearmanr(flat_preds, flat_targets)[0]),
+        "n_regions": int(preds.shape[0]),
+        "n_positions_per_region": int(preds.shape[1]),
+        "n_tracks": int(preds.shape[2]),
+    }
+
+
+# =============================================================================
 # Summary
 # =============================================================================
 
@@ -426,18 +693,26 @@ def format_summary_table(
         rows = [
             ("Profile r (mean)", "profile_pearson_r_mean"),
             ("Profile r (median)", "profile_pearson_r_median"),
-            ("Count r", "count_pearson_r"),
-            ("JSD (mean)", "jsd_mean"),
-            ("JSD (median)", "jsd_median"),
+            ("Track r (accumulated)", "track_pearson_r_accumulated_mean"),
+            ("Count r (raw)", "count_pearson_r_raw"),
+            ("Count r (log1p; paper)", "count_pearson_r_log1p"),
+            ("JS divergence (mean)", "js_divergence_mean"),
+            ("JS distance (mean; paper)", "js_distance_mean"),
             ("MSE", "mse"),
             ("Spearman (global)", "spearman_global"),
         ]
         for label, key in rows:
+            fallback = {
+                "count_pearson_r_raw": "count_pearson_r",
+                "js_divergence_mean": "jsd_mean",
+            }.get(key)
             line = f"{label:<28}"
             if ft is not None:
-                line += f"{ft[key]:>12.4f}"
+                value = ft.get(key, ft.get(fallback, float("nan")))
+                line += f"{value:>12.4f}"
             if nat is not None:
-                line += f"  {nat[key]:>20.4f}"
+                value = nat.get(key, nat.get(fallback, float("nan")))
+                line += f"  {value:>20.4f}"
             lines.append(line)
         line = f"{'N regions':<28}"
         if ft is not None:
@@ -456,6 +731,7 @@ def save_summary_json(
     native_info: dict | None,
     loss: float | None,
     out_path: Path,
+    evaluation_info: dict | None = None,
 ) -> None:
     """Save machine-readable JSON summary."""
     def _clean(m: dict) -> dict:
@@ -466,6 +742,8 @@ def save_summary_json(
         }
 
     data: dict = {"checkpoint": checkpoint_meta}
+    if evaluation_info:
+        data["evaluation"] = evaluation_info
     if loss is not None:
         data["loss"] = loss
 
@@ -550,11 +828,32 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Comma-separated resolutions for --native-only mode (default: 128)",
     )
+    p.add_argument(
+        "--metric-bin-sizes",
+        default=None,
+        help=(
+            "Comma-separated scoring resolutions derived from one model output "
+            "using count-preserving sum pooling (for example: 1,32). If omitted, "
+            "score each model output at its native resolution."
+        ),
+    )
+    p.add_argument(
+        "--metric-source-resolution", type=int, default=1,
+        help="Model output resolution from which --metric-bin-sizes are derived",
+    )
+    p.add_argument(
+        "--score-window-bp", type=int, default=None,
+        help=(
+            "Centered scoring width in bp, applied after full-context inference. "
+            "Use 196608 for the 1-Mbp AlphaGenome/Borzoi comparison; omit for "
+            "native 131-kbp finetuning comparisons."
+        ),
+    )
     p.add_argument("--sequence-length", type=int, default=131072)
     p.add_argument("--batch-size", type=int, default=4)
     p.add_argument("--num-workers", type=int, default=4)
-    p.add_argument("--max-regions", type=int, default=2000,
-                    help="Max regions for metrics (0=all)")
+    p.add_argument("--max-regions", type=int, default=0,
+                    help="Max regions for metrics (default: 0, evaluate all)")
     p.add_argument("--ism-window-size", type=int, default=21)
     p.add_argument("--save-predictions", action="store_true")
     p.add_argument("--device", default=None, help="Device (default: auto)")
@@ -568,6 +867,17 @@ def parse_resolutions(raw: str | None) -> tuple[int, ...]:
     return tuple(int(part.strip()) for part in raw.split(",") if part.strip())
 
 
+def parse_metric_bin_sizes(raw: str | None) -> tuple[int, ...] | None:
+    if raw is None:
+        return None
+    values = tuple(int(part.strip()) for part in raw.split(",") if part.strip())
+    if not values or any(value <= 0 for value in values):
+        raise ValueError("--metric-bin-sizes must contain positive integers")
+    if len(set(values)) != len(values):
+        raise ValueError("--metric-bin-sizes must not contain duplicates")
+    return values
+
+
 # =============================================================================
 # Main
 # =============================================================================
@@ -578,6 +888,10 @@ def main() -> None:
         level=logging.INFO, format="%(levelname)s: %(message)s",
     )
     args = parse_args()
+    try:
+        metric_bin_sizes = parse_metric_bin_sizes(args.metric_bin_sizes)
+    except ValueError as exc:
+        sys.exit(f"Error: {exc}")
 
     # Resolve device
     if args.device:
@@ -616,6 +930,11 @@ def main() -> None:
         sys.exit("Error: --regions requires --regions-bed and --bigwig")
     if run_ism and (not args.regions_bed or not args.genome):
         sys.exit("Error: --ism requires --regions-bed and --genome")
+    if args.score_window_bp is not None and args.score_window_bp > args.sequence_length:
+        sys.exit(
+            "Error: --score-window-bp cannot exceed --sequence-length. "
+            "Use 196608 only with the 1-Mbp model; score the 131-kbp model natively."
+        )
 
     model = None
     if args.native_only:
@@ -658,6 +977,12 @@ def main() -> None:
             ckpt_meta["epoch"], ckpt_meta["val_loss"],
         )
 
+    if metric_bin_sizes and args.metric_source_resolution not in resolutions:
+        sys.exit(
+            f"Error: --metric-source-resolution={args.metric_source_resolution} is "
+            f"not present in checkpoint/model resolutions {resolutions}"
+        )
+
     # ---- Optionally load native model ----
     native_model, native_track_idx, native_display_name = None, None, None
     if want_native:
@@ -669,6 +994,10 @@ def main() -> None:
     # ---- Feature: metrics ----
     ft_metrics_by_res: dict[int, dict] = {}
     native_metrics_by_res: dict[int, dict] = {}
+    metric_resolutions = metric_bin_sizes or resolutions
+    ft_metric_preds: dict[int, np.ndarray] = {}
+    native_metric_preds: dict[int, np.ndarray] = {}
+    metric_targets: dict[int, np.ndarray] = {}
     loss = None
 
     if run_metrics:
@@ -718,19 +1047,50 @@ def main() -> None:
             )
             log.info("Loss: %.4f", loss)
 
-            for res in resolutions:
-                if res not in ft_preds:
+        if metric_bin_sizes:
+            source = args.metric_source_resolution
+            source_preds = None if args.native_only else ft_preds[source]
+            source_targets = targets[source]
+            if source_preds is not None:
+                ft_metric_preds, metric_targets = build_metric_views(
+                    source_preds,
+                    source_targets,
+                    source_resolution=source,
+                    bin_sizes=metric_bin_sizes,
+                    score_window_bp=args.score_window_bp,
+                    reduction="sum",
+                )
+            else:
+                # Native-only mode has no finetuned predictions, but targets
+                # must undergo exactly the same crop and pooling operation.
+                metric_targets, _ = build_metric_views(
+                    source_targets,
+                    source_targets,
+                    source_resolution=source,
+                    bin_sizes=metric_bin_sizes,
+                    score_window_bp=args.score_window_bp,
+                    reduction="sum",
+                )
+        else:
+            ft_metric_preds = ft_preds
+            metric_targets = targets
+
+        if not args.native_only:
+            for res in metric_resolutions:
+                if res not in ft_metric_preds:
                     continue
-                p, t = ft_preds[res], targets[res]
+                p, t = ft_metric_preds[res], metric_targets[res]
                 log.info("Resolution %dbp: preds %s, targets %s", res, p.shape, t.shape)
 
-                ft_m = compute_all_metrics(p, t)
+                ft_m = compute_comparison_metrics(p, t, profile_transform="none")
                 ft_metrics_by_res[res] = ft_m
 
                 log.info("  Profile r (mean):  %.4f", ft_m["profile_pearson_r_mean"])
-                log.info("  Profile r (median):%.4f", ft_m["profile_pearson_r_median"])
-                log.info("  Count r:           %.4f", ft_m["count_pearson_r"])
-                log.info("  JSD (mean):        %.4f", ft_m["jsd_mean"])
+                log.info("  Track r (accum.):  %.4f", ft_m["track_pearson_r_accumulated_mean"])
+                log.info("  Count r (raw):     %.4f", ft_m["count_pearson_r_raw"])
+                log.info("  Count r (log1p):   %.4f", ft_m["count_pearson_r_log1p"])
+                log.info("  JS divergence:     %.4f", ft_m["js_divergence_mean"])
+                log.info("  JS distance:       %.4f", ft_m["js_distance_mean"])
 
                 # Scatter plots
                 plot_scatter(
@@ -755,12 +1115,27 @@ def main() -> None:
                 loader, device, resolutions,
             )
 
-            for res in resolutions:
-                if res not in native_preds or res not in targets:
+            if metric_bin_sizes:
+                source = args.metric_source_resolution
+                native_metric_preds, _ = build_metric_views(
+                    native_preds[source],
+                    targets[source],
+                    source_resolution=source,
+                    bin_sizes=metric_bin_sizes,
+                    score_window_bp=args.score_window_bp,
+                    reduction="sum",
+                )
+            else:
+                native_metric_preds = native_preds
+
+            for res in metric_resolutions:
+                if res not in native_metric_preds or res not in metric_targets:
                     continue
-                nat_p = native_preds[res]
-                t = targets[res]
-                nat_m = compute_all_metrics(nat_p, t)
+                nat_p = native_metric_preds[res]
+                t = metric_targets[res]
+                nat_m = compute_comparison_metrics(
+                    nat_p, t, profile_transform="none",
+                )
                 native_metrics_by_res[res] = nat_m
 
                 log.info(
@@ -775,7 +1150,7 @@ def main() -> None:
                 model = model.to(model_device)
 
         # Generate histogram plots (overlaid if native available)
-        for res in resolutions:
+        for res in metric_resolutions:
             ft_m = ft_metrics_by_res.get(res)
             nat_m = native_metrics_by_res.get(res)
             if ft_m is None and nat_m is None:
@@ -828,6 +1203,22 @@ def main() -> None:
                     np.save(pred_dir / f"test_targets_{res}bp.npy", targets[res].astype(np.float16))
                 if native_model is not None and res in native_preds:
                     np.save(pred_dir / f"native_preds_{res}bp.npy", native_preds[res].astype(np.float16))
+            if metric_bin_sizes:
+                for res in metric_resolutions:
+                    if res in ft_metric_preds:
+                        np.save(
+                            pred_dir / f"test_preds_scored_{res}bp.npy",
+                            ft_metric_preds[res].astype(np.float16),
+                        )
+                    np.save(
+                        pred_dir / f"test_targets_scored_{res}bp.npy",
+                        metric_targets[res].astype(np.float16),
+                    )
+                    if res in native_metric_preds:
+                        np.save(
+                            pred_dir / f"native_preds_scored_{res}bp.npy",
+                            native_metric_preds[res].astype(np.float16),
+                        )
 
     # ---- Feature: region exploration ----
     if run_regions:
@@ -924,7 +1315,7 @@ def main() -> None:
         ft_metrics_by_res if ft_metrics_by_res else None,
         native_metrics_by_res if native_metrics_by_res else None,
         native_display_name,
-        resolutions,
+        metric_resolutions,
     )
     if summary_text:
         print(summary_text)
@@ -948,6 +1339,16 @@ def main() -> None:
         },
         native_info, loss,
         out_dir / "summary.json",
+        evaluation_info={
+            "test_bed": args.test_bed,
+            "sequence_length_bp": args.sequence_length,
+            "score_window_bp": args.score_window_bp or args.sequence_length,
+            "metric_source_resolution_bp": args.metric_source_resolution,
+            "metric_bin_sizes_bp": list(metric_resolutions),
+            "pooling": "sum" if metric_bin_sizes else "native_model_output",
+            "profile_transform": "none",
+            "fold": "fold_1 expected; determined by --test-bed",
+        } if run_metrics else None,
     )
 
     log.info("Done. Output: %s", out_dir)

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -82,9 +82,9 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 
-# Workaround for torch.compile bug in quantization pattern matcher
 import torch._inductor.config
 torch._inductor.config.post_grad_fusion_options = {}
+torch._inductor.config.pattern_matcher = False
 
 import torch._dynamo
 torch._dynamo.config.suppress_errors = True

--- a/src/alphagenome_pytorch/extensions/finetuning/evaluation.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/evaluation.py
@@ -1,6 +1,6 @@
 """Shared evaluation primitives for fine-tuned AlphaGenome models.
 
-Consumed by scripts/evaluate_finetuned.py (per-model run), scripts/evaluate_matrix.py
+Consumed by scripts/evaluate_checkpoint.py (per-model run), scripts/evaluate_matrix.py
 (cross-model × cross-dataset matrix), and scripts/predict_locus.py (manuscript figure).
 Single inference + metrics code path keeps the three entry points consistent.
 """
@@ -365,6 +365,24 @@ def evaluate_native_split(
             preds_by_res[res].append(pred_track.float().cpu().numpy())
 
     return {r: np.concatenate(v, axis=0) for r, v in preds_by_res.items() if v}
+
+
+def collect_targets(
+    loader: DataLoader,
+    resolutions: tuple[int, ...],
+    progress_desc: str = "Collecting targets",
+) -> dict[int, np.ndarray]:
+    """Collect target arrays from a genomic loader without model inference.
+
+    This is used by native-only/pretrained evaluation, where the target BigWig
+    values are needed for metrics but no finetuned model is run.
+    """
+    targets_by_res: dict[int, list[np.ndarray]] = {r: [] for r in resolutions}
+    for _, targets_dict in tqdm(loader, desc=progress_desc):
+        for res in resolutions:
+            if res in targets_dict:
+                targets_by_res[res].append(targets_dict[res].numpy())
+    return {r: np.concatenate(v, axis=0) for r, v in targets_by_res.items() if v}
 
 
 # =============================================================================

--- a/tests/integration/test_evaluate_checkpoint.py
+++ b/tests/integration/test_evaluate_checkpoint.py
@@ -1,4 +1,4 @@
-"""Integration tests for scripts/evaluate_finetuned.py.
+"""Integration tests for scripts/evaluate_checkpoint.py.
 
 Tests the two inference entry points (`evaluate_split` and
 `evaluate_native_split`) against a real AlphaGenome model with random weights
@@ -15,6 +15,7 @@ and mock BigWig data. These tests guard against two historical bugs:
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
@@ -35,12 +36,12 @@ MODALITY = "atac"
 
 
 def _load_script_module():
-    """Load scripts/evaluate_finetuned.py as a module (it's not a package)."""
+    """Load scripts/evaluate_checkpoint.py as a module (it's not a package)."""
     script_path = (
-        Path(__file__).parent.parent.parent / "scripts" / "evaluate_finetuned.py"
+        Path(__file__).parent.parent.parent / "scripts" / "evaluate_checkpoint.py"
     )
     spec = importlib.util.spec_from_file_location(
-        "evaluate_finetuned_script", script_path
+        "evaluate_checkpoint_script", script_path
     )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -181,3 +182,78 @@ def test_evaluate_native_split_skips_missing_resolution(
     )
     assert 1 in preds
     assert 64 not in preds
+
+
+def test_parse_resolutions_defaults_to_128(script_module):
+    assert script_module.parse_resolutions(None) == (128,)
+    assert script_module.parse_resolutions("1,128") == (1, 128)
+
+
+def test_format_summary_table_supports_native_only(script_module):
+    native_metrics = {
+        128: {
+            "profile_pearson_r_mean": 0.25,
+            "profile_pearson_r_median": 0.20,
+            "count_pearson_r": 0.50,
+            "jsd_mean": 0.10,
+            "jsd_median": 0.08,
+            "mse": 1.25,
+            "spearman_global": 0.40,
+            "n_regions": 3,
+        }
+    }
+
+    summary = script_module.format_summary_table(
+        ft_metrics=None,
+        native_metrics=native_metrics,
+        native_display_name="K562",
+        resolutions=(128,),
+    )
+
+    assert "Native(K562)" in summary
+    assert "Finetuned" not in summary
+    assert "Profile r (mean)" in summary
+    assert "0.2500" in summary
+
+
+def test_native_only_requires_explicit_metrics(script_module, monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evaluate_checkpoint.py",
+            "--native-only",
+            "--pretrained-weights",
+            "model.safetensors",
+            "--output-dir",
+            str(tmp_path),
+            "--modality",
+            "atac",
+            "--native-biosample",
+            "K562",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="--native-only currently supports metrics"):
+        script_module.main()
+
+
+def test_native_only_requires_native_track_selector(script_module, monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "evaluate_checkpoint.py",
+            "--native-only",
+            "--metrics",
+            "--pretrained-weights",
+            "model.safetensors",
+            "--output-dir",
+            str(tmp_path),
+            "--modality",
+            "atac",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="--native-biosample or --native-track-index"):
+        script_module.main()

--- a/tests/integration/test_evaluate_checkpoint.py
+++ b/tests/integration/test_evaluate_checkpoint.py
@@ -19,6 +19,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
@@ -187,6 +188,92 @@ def test_evaluate_native_split_skips_missing_resolution(
 def test_parse_resolutions_defaults_to_128(script_module):
     assert script_module.parse_resolutions(None) == (128,)
     assert script_module.parse_resolutions("1,128") == (1, 128)
+
+
+def test_center_crop_and_sum_pool_metric_views(script_module):
+    values = np.arange(16, dtype=np.float64).reshape(1, 16, 1)
+    pred_views, target_views = script_module.build_metric_views(
+        values,
+        values,
+        source_resolution=1,
+        bin_sizes=(1, 4),
+        score_window_bp=8,
+        reduction="sum",
+    )
+
+    np.testing.assert_array_equal(pred_views[1][0, :, 0], np.arange(4, 12))
+    np.testing.assert_array_equal(pred_views[4][0, :, 0], [22, 38])
+    np.testing.assert_array_equal(pred_views[4], target_views[4])
+
+
+def test_borzoi_window_rejected_for_131kb_predictions(script_module):
+    values = np.zeros((1, 131_072, 1), dtype=np.float32)
+    with pytest.raises(ValueError, match="cannot be scored over the 196,608-bp"):
+        script_module.center_crop_profiles(values, values, 196_608, 1)
+
+
+def test_comparison_metrics_expose_paper_and_requested_variants(script_module):
+    targets = np.asarray([
+        [[0.0], [1.0], [2.0], [3.0]],
+        [[1.0], [2.0], [3.0], [4.0]],
+    ])
+    metrics = script_module.compute_comparison_metrics(targets, targets)
+
+    assert metrics["profile_pearson_r_mean"] == pytest.approx(1.0)
+    assert metrics["track_pearson_r_accumulated_mean"] == pytest.approx(1.0)
+    assert metrics["count_pearson_r_raw"] == pytest.approx(1.0)
+    assert metrics["count_pearson_r_log1p"] == pytest.approx(1.0)
+    assert metrics["js_divergence_mean"] == pytest.approx(0.0)
+    assert metrics["js_distance_mean"] == pytest.approx(0.0)
+
+
+def test_profile_accumulator_matches_alphagenome_research_formula(script_module):
+    x = np.asarray([
+        [[1.0, 4.0], [2.0, 4.0]],
+        [[3.0, 4.0], [5.0, 4.0]],
+    ], dtype=np.float32)
+    y = np.asarray([
+        [[2.0, 7.0], [1.0, 7.0]],
+        [[4.0, 7.0], [8.0, 7.0]],
+    ], dtype=np.float32)
+
+    state = script_module._pearsonr_initialize()
+    state += script_module._pearsonr_update(x[:1], y[:1], axis=(-2, -3))
+    state += script_module._pearsonr_update(x[1:], y[1:], axis=(-2, -3))
+    actual = script_module._pearsonr_result(state)
+
+    # Direct NumPy transcription of alphagenome_research/evals/
+    # regression_metrics.py::_pearsonr_update/_pearsonr_result.
+    axes = (0, 1)
+    count = np.sum(np.ones_like(x), axis=axes, dtype=np.float32)
+    x_sum = np.sum(x, axis=axes, dtype=np.float32)
+    y_sum = np.sum(y, axis=axes, dtype=np.float32)
+    x_mean = x_sum / count
+    y_mean = y_sum / count
+    covariance = (
+        np.sum(x * y, axis=axes, dtype=np.float32)
+        - count * x_mean * y_mean
+    )
+    x_variance = (
+        np.sum(np.square(x), axis=axes, dtype=np.float32)
+        - count * np.square(x_mean)
+    )
+    y_variance = (
+        np.sum(np.square(y), axis=axes, dtype=np.float32)
+        - count * np.square(y_mean)
+    )
+    denominator = np.sqrt(x_variance) * np.sqrt(y_variance)
+    expected = covariance / (denominator + np.finfo(denominator.dtype).eps)
+
+    np.testing.assert_array_equal(actual, expected)
+    assert actual[1] == 0.0  # Reference epsilon behavior for constant tracks.
+
+
+def test_parse_metric_bin_sizes(script_module):
+    assert script_module.parse_metric_bin_sizes(None) is None
+    assert script_module.parse_metric_bin_sizes("1,32") == (1, 32)
+    with pytest.raises(ValueError, match="duplicates"):
+        script_module.parse_metric_bin_sizes("1,1")
 
 
 def test_format_summary_table_supports_native_only(script_module):

--- a/tests/unit/test_compute_gene_metrics.py
+++ b/tests/unit/test_compute_gene_metrics.py
@@ -1,0 +1,148 @@
+"""Tests for scripts/compute_gene_metrics.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+def _load_script_module():
+    scripts_dir = Path(__file__).parent.parent.parent / "scripts"
+    sys.path.insert(0, str(scripts_dir))
+    spec = importlib.util.spec_from_file_location(
+        "compute_gene_metrics_script",
+        scripts_dir / "compute_gene_metrics.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script_module():
+    return _load_script_module()
+
+
+def test_gene_expression_rows_use_exon_means_and_matching_strand(script_module):
+    columns = [
+        "Chromosome", "Start", "End", "Strand", "Feature", "gene_id",
+        "gene_name", "gene_type", "transcript_id",
+    ]
+    gtf = pd.DataFrame([
+        ["chr1", 0, 4, "+", "gene", "plus", "PLUS", "pc", None],
+        ["chr1", 0, 4, "+", "transcript", "plus", "PLUS", "pc", "tx_plus"],
+        ["chr1", 0, 4, "+", "exon", "plus", "PLUS", "pc", "tx_plus"],
+        ["chr1", 4, 8, "-", "gene", "minus", "MINUS", "pc", None],
+        ["chr1", 4, 7, "-", "transcript", "minus", "MINUS", "pc", "tx_minus"],
+        ["chr1", 4, 8, "-", "exon", "minus", "MINUS", "pc", "tx_minus"],
+    ], columns=columns)
+    intervals = pd.DataFrame([{
+        "original_interval_idx": 7,
+        "chrom": "chr1",
+        "start": 0,
+        "end": 8,
+        "window_start": 0,
+        "window_end": 8,
+    }])
+    one_bp = np.asarray([[
+        [1.0, 10.0], [2.0, 20.0], [3.0, 30.0], [4.0, 40.0],
+        [5.0, 50.0], [6.0, 60.0], [7.0, 70.0], [8.0, 80.0],
+    ]])
+    two_bp = one_bp.reshape(1, 4, 2, 2).mean(axis=2)
+
+    rows = script_module.collect_gene_expression_rows(
+        gtf=gtf,
+        test_intervals=intervals,
+        positions=[("chr1", 0, 8)],
+        prediction_views={1: one_bp, 2: two_bp},
+        target_views={1: one_bp, 2: two_bp},
+        bin_sizes=(1, 2),
+        sample_names=["sample"],
+    )
+
+    assert len(rows) == 4
+    plus_1bp = rows[(rows["gene_id"] == "plus") & (rows["bin_size_bp"] == 1)].iloc[0]
+    minus_1bp = rows[(rows["gene_id"] == "minus") & (rows["bin_size_bp"] == 1)].iloc[0]
+    assert plus_1bp["track_index"] == 0
+    assert plus_1bp["pred_mean"] == pytest.approx(2.5)
+    assert minus_1bp["track_index"] == 1
+    assert minus_1bp["pred_mean"] == pytest.approx(65.0)
+    assert plus_1bp["pred_log1p_mean"] == pytest.approx(np.log1p(2.5))
+
+    summary, per_track = script_module.summarize_gene_expression(rows, (1, 2))
+    assert summary[1]["pearson_r_log1p_exon_mean"] == pytest.approx(1.0)
+    assert summary[1]["n_unique_genes"] == 2
+    assert len(per_track) == 4
+
+
+def test_gene_assignment_uses_nearest_interval_center_once(script_module):
+    columns = [
+        "Chromosome", "Start", "End", "Strand", "Feature", "gene_id",
+        "gene_name", "gene_type", "transcript_id",
+    ]
+    gtf = pd.DataFrame([
+        ["chr1", 6, 8, "+", "transcript", "shared", "SHARED", "pc", "tx1"],
+        ["chr1", 10, 11, "+", "transcript", "second", "SECOND", "pc", "tx2"],
+    ], columns=columns)
+    positions = [("chr1", 0, 10), ("chr1", 2, 12)]
+
+    assignments = script_module.assign_genes_to_nearest_center(gtf, positions)
+    # The first gene is eligible in both windows. Its center distance ties, so
+    # BED order deterministically selects the first window.
+    assert assignments["shared"] == 0
+    # Half-open containment excludes TSS=10 from [0, 10).
+    assert assignments["second"] == 1
+
+
+def test_center_crop_genomic_positions_matches_profile_crop(script_module):
+    positions = [("chr1", 100, 1100), ("chr2", 200, 1200)]
+
+    assert script_module.center_crop_genomic_positions(
+        positions, 200,
+    ) == [("chr1", 500, 700), ("chr2", 600, 800)]
+    assert script_module.center_crop_genomic_positions(positions, None) is positions
+
+    # Match center_crop_profiles when an odd number of source bins is removed.
+    assert script_module.center_crop_genomic_positions(
+        [("chr1", 0, 10)], 4, source_resolution=2,
+    ) == [("chr1", 2, 6)]
+
+    with pytest.raises(ValueError, match="spans only"):
+        script_module.center_crop_genomic_positions(positions, 1001)
+
+
+def test_official_gene_selection_uses_transcript_tss(script_module):
+    columns = [
+        "Chromosome", "Start", "End", "Strand", "Feature", "gene_id",
+        "gene_name", "gene_type", "transcript_id",
+    ]
+    gtf = pd.DataFrame([
+        ["chr1", 0, 20, "+", "gene", "inside", "INSIDE", "pc", None],
+        ["chr1", 2, 12, "+", "transcript", "inside", "INSIDE", "pc", "tx1"],
+        ["chr1", 2, 5, "+", "exon", "inside", "INSIDE", "pc", "tx1"],
+        ["chr1", 4, 7, "+", "exon", "inside", "INSIDE", "pc", "tx1"],
+        ["chr1", 0, 20, "+", "gene", "outside", "OUTSIDE", "pc", None],
+        ["chr1", 12, 18, "+", "transcript", "outside", "OUTSIDE", "pc", "tx2"],
+        ["chr1", 6, 8, "+", "exon", "outside", "OUTSIDE", "pc", "tx2"],
+    ], columns=columns)
+
+    extractor = script_module._OfficialGeneExonMaskExtractor(gtf)
+    mask, metadata = extractor.extract("chr1", 0, 8)
+    assert metadata["gene_id"].tolist() == ["inside"]
+
+    # Overlapping exon rows are combined as a boolean union: positions 2..6
+    # are counted once, matching the official GeneIntervalScorer mask.
+    profile = np.arange(8, dtype=np.float64)[:, None]
+    mean = script_module.score_gene_interval_mean(profile, mask)
+    assert mean[0, 0] == pytest.approx(np.mean(np.arange(2, 7)))
+
+    # AlphaGenome max-pools a gene mask when the output resolution is coarse.
+    pooled_mask = script_module.downsample_gene_mask(mask, 2)
+    np.testing.assert_array_equal(
+        pooled_mask[:, 0], np.asarray([False, True, True, True]),
+    )

--- a/tests/unit/test_compute_gene_metrics.py
+++ b/tests/unit/test_compute_gene_metrics.py
@@ -74,29 +74,13 @@ def test_gene_expression_rows_use_exon_means_and_matching_strand(script_module):
     assert minus_1bp["pred_mean"] == pytest.approx(65.0)
     assert plus_1bp["pred_log1p_mean"] == pytest.approx(np.log1p(2.5))
 
-    summary, per_track = script_module.summarize_gene_expression(rows, (1, 2))
-    assert summary[1]["pearson_r_log1p_exon_mean"] == pytest.approx(1.0)
-    assert summary[1]["n_unique_genes"] == 2
-    assert len(per_track) == 4
-
-
-def test_gene_assignment_uses_nearest_interval_center_once(script_module):
-    columns = [
-        "Chromosome", "Start", "End", "Strand", "Feature", "gene_id",
-        "gene_name", "gene_type", "transcript_id",
-    ]
-    gtf = pd.DataFrame([
-        ["chr1", 6, 8, "+", "transcript", "shared", "SHARED", "pc", "tx1"],
-        ["chr1", 10, 11, "+", "transcript", "second", "SECOND", "pc", "tx2"],
-    ], columns=columns)
-    positions = [("chr1", 0, 10), ("chr1", 2, 12)]
-
-    assignments = script_module.assign_genes_to_nearest_center(gtf, positions)
-    # The first gene is eligible in both windows. Its center distance ties, so
-    # BED order deterministically selects the first window.
-    assert assignments["shared"] == 0
-    # Half-open containment excludes TSS=10 from [0, 10).
-    assert assignments["second"] == 1
+    summary, per_track, per_gene = script_module.summarize_gene_expression(
+        rows, (1, 2),
+    )
+    assert summary[1]["raw_pearson_r_mean_across_tracks"] == pytest.approx(1.0)
+    assert summary[1]["n_genes"] == 2
+    assert len(per_track) == 2
+    assert len(per_gene) == 4
 
 
 def test_center_crop_genomic_positions_matches_profile_crop(script_module):
@@ -116,33 +100,96 @@ def test_center_crop_genomic_positions_matches_profile_crop(script_module):
         script_module.center_crop_genomic_positions(positions, 1001)
 
 
-def test_official_gene_selection_uses_transcript_tss(script_module):
+def test_exon_base_weights_preserve_partial_coarse_bins(script_module):
+    mask = np.zeros((8, 1), dtype=bool)
+    mask[2:7, 0] = True
+    profile = np.arange(8, dtype=np.float64)[:, None]
+    mean = script_module.score_gene_interval_mean(profile, mask)
+    assert mean[0, 0] == pytest.approx(np.mean(np.arange(2, 7)))
+
+    weighted_mask = script_module.downsample_gene_mask_weights(mask, 2)
+    np.testing.assert_array_equal(
+        weighted_mask[:, 0], np.asarray([0, 2, 2, 1]),
+    )
+
+
+def test_paper_gene_selection_uses_unique_exon_bases(script_module):
     columns = [
         "Chromosome", "Start", "End", "Strand", "Feature", "gene_id",
         "gene_name", "gene_type", "transcript_id",
     ]
     gtf = pd.DataFrame([
-        ["chr1", 0, 20, "+", "gene", "inside", "INSIDE", "pc", None],
-        ["chr1", 2, 12, "+", "transcript", "inside", "INSIDE", "pc", "tx1"],
-        ["chr1", 2, 5, "+", "exon", "inside", "INSIDE", "pc", "tx1"],
-        ["chr1", 4, 7, "+", "exon", "inside", "INSIDE", "pc", "tx1"],
-        ["chr1", 0, 20, "+", "gene", "outside", "OUTSIDE", "pc", None],
-        ["chr1", 12, 18, "+", "transcript", "outside", "OUTSIDE", "pc", "tx2"],
-        ["chr1", 6, 8, "+", "exon", "outside", "OUTSIDE", "pc", "tx2"],
+        # The two overlapping exon annotations have a 15-bp union. The [5, 10)
+        # interval contains only 5/15 unique exon bases and must not qualify;
+        # counting the overlapping annotations twice would incorrectly give 50%.
+        ["chr1", 0, 10, "+", "exon", "overlap", "OVERLAP", "pc", "tx1"],
+        ["chr1", 5, 15, "+", "exon", "overlap", "OVERLAP", "pc", "tx2"],
+        ["chr1", 20, 30, "+", "exon", "assigned", "ASSIGNED", "pc", "tx3"],
     ], columns=columns)
+    annotations = script_module.build_paper_gene_annotations(gtf)
+    assert annotations.loc["overlap", "total_unique_exon_bp"] == 15
 
-    extractor = script_module._OfficialGeneExonMaskExtractor(gtf)
-    mask, metadata = extractor.extract("chr1", 0, 8)
-    assert metadata["gene_id"].tolist() == ["inside"]
-
-    # Overlapping exon rows are combined as a boolean union: positions 2..6
-    # are counted once, matching the official GeneIntervalScorer mask.
-    profile = np.arange(8, dtype=np.float64)[:, None]
-    mean = script_module.score_gene_interval_mean(profile, mask)
-    assert mean[0, 0] == pytest.approx(np.mean(np.arange(2, 7)))
-
-    # AlphaGenome max-pools a gene mask when the output resolution is coarse.
-    pooled_mask = script_module.downsample_gene_mask(mask, 2)
-    np.testing.assert_array_equal(
-        pooled_mask[:, 0], np.asarray([False, True, True, True]),
+    positions = [("chr1", 5, 10), ("chr1", 20, 26), ("chr1", 22, 30)]
+    assignments = script_module.assign_paper_genes_to_intervals(
+        annotations, positions,
     )
+    assert "overlap" not in assignments
+    assert assignments["assigned"]["interval_index"] == 2
+    assert assignments["assigned"]["n_qualifying_intervals"] == 2
+
+    mask, metadata = script_module.build_interval_gene_masks(
+        annotations, assignments, 2, "chr1", 22, 30,
+    )
+    assert metadata["gene_id"].tolist() == ["assigned"]
+    assert mask[:, 0].sum() == 8
+    assert metadata.iloc[0]["exon_fraction_in_interval"] == pytest.approx(0.8)
+
+
+def test_paper_correlations_combine_strands_by_sample(script_module):
+    values = {
+        "gene1": (0.0, 3.0),
+        "gene2": (1.0, 1.0),
+        "gene3": (3.0, 0.0),
+    }
+    rows = []
+    for gene_index, (gene_id, sample_values) in enumerate(values.items()):
+        strand = "+" if gene_index % 2 == 0 else "-"
+        for sample_index, value in enumerate(sample_values):
+            rows.append({
+                "bin_size_bp": 1,
+                "gene_id": gene_id,
+                "sample": f"sample{sample_index}",
+                # Plus and minus rows originate from different physical tracks,
+                # but are one strand-matched biological track in the paper.
+                "track_index": 2 * sample_index + (strand == "-"),
+                "pred_log1p_mean": value,
+                "obs_log1p_mean": value,
+            })
+
+    summary, per_track, per_gene = script_module.summarize_gene_expression(
+        pd.DataFrame(rows), (1,),
+    )
+    metrics = summary[1]
+    assert metrics["raw_pearson_r_mean_across_tracks"] == pytest.approx(1.0)
+    assert metrics[
+        "normalized_pearson_r_mean_across_genes_by_track"
+    ] == pytest.approx(1.0)
+    assert metrics[
+        "normalized_pearson_r_mean_across_tracks_by_gene"
+    ] == pytest.approx(1.0)
+    assert len(per_track) == 2
+    assert metrics["n_normalized_gene_correlations"] == 2
+    assert len(per_gene) == 3
+
+
+def test_quantile_normalization_averages_tied_ranks(script_module):
+    values = np.asarray([
+        [0.0, 2.0],
+        [0.0, 1.0],
+        [2.0, 0.0],
+    ])
+    normalized = script_module.quantile_normalize_columns(values)
+    # Reference quantiles are [0, 0.5, 2]. The tied zeros in column 0 occupy
+    # the first two ranks and both receive their mean, 0.25.
+    np.testing.assert_allclose(normalized[:, 0], [0.25, 0.25, 2.0])
+    np.testing.assert_allclose(normalized[:, 1], [2.0, 0.5, 0.0])


### PR DESCRIPTION
1. Support native checkpoint evaluation against bw targets, including profile Pearson, accumulated Pearson, total-count Pearson, JSD, regional plots, and optional center cropping of test intervals
2. Deduplicate native and finetuned checkpoint loading in the evaluation script by importing the shared checkpoint-loading implementation
3. Add `compute_gene_metrics.py` for RNA-seq evaluation using AlphaGenome-compatible TSS selection, unioned exon masks, strand-matched exon-mean expression, optional center cropping, and gene-level log1p correlation metrics