### PR TITLE
Add signal aggregation and exon masking for RNA-seq

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,12 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: project.toml
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          # python -m pip install --upgrade pip
           # Install CPU-only PyTorch to avoid downloading CUDA/NVIDIA drivers
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           # Install alphagenome_research

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -303,5 +303,5 @@ Next Steps
 ----------
 
 - :doc:`full_chromosome_prediction` - Genome-wide predictions as BigWig files
-- :doc:`finetuning` - Transfer learning on your own genomic tracks
+- :doc:`finetuning/index` - Transfer learning on your own genomic tracks
 - :doc:`api/model` - Full API reference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,16 @@ inference = [
     "pyfaidx",
     "tqdm",
 ]
+# Whole-chromosome gene-count / AnnData export (predict_full_chromosome.py --anndata):
+# adds pandas (metadata), anndata (.h5ad), and annotation readers (pyranges for
+# GTF, pyarrow for parquet) on top of the base inference deps.
+inference-anndata = [
+    "alphagenome-pytorch[inference]",
+    "pandas",
+    "anndata",
+    "pyranges",
+    "pyarrow",
+]
 finetuning = [
     "pybigwig",
     "pandas",

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -1485,6 +1485,16 @@ def main(args: argparse.Namespace | None = None) -> None:
         ann_path = args.gene_expr_annotation or args.gtf
         print_rank0(f"Loading annotation for gene-expression eval: {ann_path}", rank)
         gene_expr_annotation = GeneAnnotation(ann_path)
+        # The metric aggregates over exons, but --gtf may legitimately be a
+        # gene-only annotation (the gene-LFC loss only needs gene rows). Without
+        # exons the metric finds no genes and reports NaN every epoch, silently,
+        # for the whole run — so fail here, as the AnnData export path does.
+        if not gene_expr_annotation.has_exon_annotations():
+            raise ValueError(
+                f"--gene-expr-eval needs an annotation with exon rows, but none were "
+                f"found in {ann_path}. Pass --gene-expr-annotation pointing at a "
+                f"GTF/parquet that includes exon features."
+            )
         gene_expr_track_strands = list(args.modality_strands["rna_seq"])
         val_dataset.return_coords = True
 

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -438,6 +438,32 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
 
+    # Gene-expression validation metric (paper Fig. 2d) for the rna_seq head.
+    gene_eval = parser.add_argument_group("Gene expression eval")
+    gene_eval.add_argument(
+        "--gene-expr-eval",
+        action="store_true",
+        help=(
+            "Report the paper's Fig. 2d gene-expression correlations for the "
+            "rna_seq head each validation epoch: log-transformed mean coverage "
+            "over annotated exons, strand-matched, keeping genes with >=50%% of "
+            "their exons in-window. Emits rna_seq_gene_log_expr_pearson_* keys. "
+            "Requires an annotation with exon rows (--gene-expr-annotation or "
+            "--gtf) and rna_seq strands (--track-strands / config)."
+        ),
+    )
+    gene_eval.add_argument(
+        "--gene-expr-annotation",
+        type=str,
+        default=None,
+        help=(
+            "Annotation for --gene-expr-eval: a parquet (fast, recommended) or "
+            "GTF/GFF (slow, needs pyranges) that INCLUDES exon rows. If unset, "
+            "falls back to --gtf. Unlike --gtf's gene-only table (gene LFC loss), "
+            "this needs exon features."
+        ),
+    )
+
     # Model arguments
     model = parser.add_argument_group("Model")
     model.add_argument("--pretrained-weights", type=str, required=False, help="Pretrained weights .pth")
@@ -708,8 +734,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "track_strands",
         "gene_loss_weight",
         "gene_cross_track_weight",
+        "gene_expr_annotation",
     ):
         _apply_config_scalar(attr, config_data)
+
+    if "--gene-expr-eval" not in cli_flags and "gene_expr_eval" in config_data:
+        args.gene_expr_eval = bool(config_data["gene_expr_eval"])
 
     # Boolean aliases / migration-friendly keys
     if "--no-amp" not in cli_flags:
@@ -869,6 +899,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             parser.error(
                 "--gene-loss-weight > 0 requires per-track strand info for "
                 "rna_seq. Pass --track-strands or set "
+                "modalities.rna_seq.strand in the config."
+            )
+
+    # Validate gene-expression-eval config consistency.
+    if getattr(args, "gene_expr_eval", False):
+        if not (args.gene_expr_annotation or args.gtf):
+            parser.error(
+                "--gene-expr-eval requires an annotation with exon rows: pass "
+                "--gene-expr-annotation (parquet/GTF) or --gtf."
+            )
+        if "rna_seq" not in args.modality_to_bigwigs:
+            parser.error(
+                "--gene-expr-eval requires rna_seq in --modality / config; "
+                f"got modalities: {sorted(args.modality_to_bigwigs)}"
+            )
+        if "rna_seq" not in args.modality_strands:
+            parser.error(
+                "--gene-expr-eval requires per-track strand info for rna_seq "
+                "(sense-strand matching). Pass --track-strands or set "
                 "modalities.rna_seq.strand in the config."
             )
 
@@ -1421,6 +1470,24 @@ def main(args: argparse.Namespace | None = None) -> None:
     # Create datasets
     train_dataset, val_dataset, modality_track_names, modality_resolutions = create_datasets(args, rank)
 
+    # Optional gene-expression validation metric (paper Fig. 2d) for rna_seq.
+    # Load a GeneAnnotation WITH exon rows (decoupled from --gene-loss-weight,
+    # which only needs a gene-only body table) and stream per-window coords to
+    # the val loop so it can build exon masks.
+    gene_expr_annotation = None
+    gene_expr_track_strands = None
+    # Per-window exon-mask cache, created once and reused every val epoch so the
+    # pandas-heavy gene lookup runs once per window for the whole run.
+    gene_expr_window_cache: dict = {}
+    if getattr(args, "gene_expr_eval", False):
+        from alphagenome_pytorch.variant_scoring.annotations import GeneAnnotation
+
+        ann_path = args.gene_expr_annotation or args.gtf
+        print_rank0(f"Loading annotation for gene-expression eval: {ann_path}", rank)
+        gene_expr_annotation = GeneAnnotation(ann_path)
+        gene_expr_track_strands = list(args.modality_strands["rna_seq"])
+        val_dataset.return_coords = True
+
     # Optional rich track metadata (overrides BigWig stems with parquet names
     # and embeds the catalog into checkpoints / exported delta weights).
     modality_track_names, track_metadata_rows = load_track_metadata_for_finetune(
@@ -1815,6 +1882,9 @@ def main(args: argparse.Namespace | None = None) -> None:
                 world_size=world_size,
                 encoder_only=encoder_only,
                 organism=organism_index,
+                gene_annotation=gene_expr_annotation,
+                gene_expr_track_strands=gene_expr_track_strands,
+                gene_expr_window_cache=gene_expr_window_cache,
             )
 
             # Synchronize CUDA to ensure all validation ops complete before next epoch

--- a/scripts/finetune.py
+++ b/scripts/finetune.py
@@ -438,13 +438,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
 
-    # Gene-expression validation metric (paper Fig. 2d) for the rna_seq head.
+    # Gene-expression validation metric for the rna_seq head.
     gene_eval = parser.add_argument_group("Gene expression eval")
     gene_eval.add_argument(
         "--gene-expr-eval",
         action="store_true",
         help=(
-            "Report the paper's Fig. 2d gene-expression correlations for the "
+            "Report gene-expression correlations for the "
             "rna_seq head each validation epoch: log-transformed mean coverage "
             "over annotated exons, strand-matched, keeping genes with >=50%% of "
             "their exons in-window. Emits rna_seq_gene_log_expr_pearson_* keys. "
@@ -1470,7 +1470,7 @@ def main(args: argparse.Namespace | None = None) -> None:
     # Create datasets
     train_dataset, val_dataset, modality_track_names, modality_resolutions = create_datasets(args, rank)
 
-    # Optional gene-expression validation metric (paper Fig. 2d) for rna_seq.
+    # Optional gene-expression validation metric for rna_seq.
     # Load a GeneAnnotation WITH exon rows (decoupled from --gene-loss-weight,
     # which only needs a gene-only body table) and stream per-window coords to
     # the val loop so it can build exon masks.

--- a/scripts/predict_full_chromosome.py
+++ b/scripts/predict_full_chromosome.py
@@ -141,8 +141,14 @@ def main():
         "--gene-strand",
         choices=["all", "match"],
         default="all",
-        help="Strand handling for the gene x track matrix: 'all' keeps every track "
-             "(dense, default); 'match' NaNs strand-incompatible cells (needs --track-strands).",
+        help="Strand handling for the gene x track matrix. 'all' (default) fills "
+             "every cell, so each gene is also scored by tracks reading the "
+             "opposite strand -- that signal is antisense, not the gene's own "
+             "expression. 'match' sets those cells to NaN, leaving each gene "
+             "scored only by tracks on its strand; unstranded ('.') tracks match "
+             "everything. NaN rather than 0 so the cells drop out of downstream "
+             "means and correlations instead of averaging in as zeros. "
+             "Needs --track-strands.",
     )
     gene_out.add_argument(
         "--track-strands",

--- a/scripts/predict_full_chromosome.py
+++ b/scripts/predict_full_chromosome.py
@@ -134,8 +134,11 @@ def main():
         "--aggregate-func",
         choices=["sum", "mean", "log-mean"],
         default="sum",
-        help="AnnData X value: raw sum / counts (default), length-normalized mean, "
-             "or log1p(mean) (log-mean exon expression).",
+        help="AnnData X value: raw sum / counts (default), mean coverage per base, "
+             "or log1p of it (log-mean exon expression). The per-base means account "
+             "for 128bp predictions being bin sums, so they are comparable across "
+             "--resolution; at 128bp they stay approximate, since a bin an exon only "
+             "partly covers is summed whole.",
     )
     gene_out.add_argument(
         "--gene-strand",

--- a/scripts/predict_full_chromosome.py
+++ b/scripts/predict_full_chromosome.py
@@ -41,6 +41,18 @@ Examples:
         --resolution 1 \\
         --batch-size 2
 
+    # Per-gene RNA-seq count matrix (AnnData) by summing exon signal
+    python scripts/predict_full_chromosome.py \\
+        --model model.pth \\
+        --fasta hg38.fa \\
+        --output predictions/ \\
+        --head rna_seq \\
+        --resolution 1 --crop-bp 16384 \\
+        --anndata rna_seq_gene_counts.h5ad \\
+        --annotation gencode.v46.parquet \\
+        --aggregate-over exons --aggregate-func sum \\
+        --chromosomes chr20,chr21
+
     # Finetuned model with delta checkpoint
     python scripts/predict_full_chromosome.py \\
         --model pretrained.pth \\
@@ -87,12 +99,57 @@ def main():
     parser.add_argument(
         "--output",
         required=True,
-        help="Output directory for BigWig files",
+        help="Directory for output files such as BigWig files",
     )
     parser.add_argument(
         "--head",
         required=True,
         help="Prediction head to use (e.g., 'atac', 'dnase', or a custom finetuned head name)",
+    )
+
+    # Gene-count / AnnData output (aggregate signal into a per-gene x per-track table)
+    gene_out = parser.add_argument_group("Gene-count AnnData output")
+    gene_out.add_argument(
+        "--anndata",
+        type=str,
+        default=None,
+        help="Write a per-gene x per-track AnnData with this filename in --output, by "
+             "summing whole-chromosome signal over each gene's exons (or body), instead "
+             "of BigWig. Requires --annotation.",
+    )
+    gene_out.add_argument(
+        "--annotation",
+        type=str,
+        default=None,
+        help="GTF/parquet gene annotation for --anndata. Needs exon rows when "
+             "--aggregate-over exons (the default).",
+    )
+    gene_out.add_argument(
+        "--aggregate-over",
+        choices=["exons", "gene-body"],
+        default="exons",
+        help="Aggregate signal over each gene's exons (default) or its full gene body.",
+    )
+    gene_out.add_argument(
+        "--aggregate-func",
+        choices=["sum", "mean", "log-mean"],
+        default="sum",
+        help="AnnData X value: raw sum / counts (default), length-normalized mean, "
+             "or log1p(mean) (log-mean exon expression).",
+    )
+    gene_out.add_argument(
+        "--gene-strand",
+        choices=["all", "match"],
+        default="all",
+        help="Strand handling for the gene x track matrix: 'all' keeps every track "
+             "(dense, default); 'match' NaNs strand-incompatible cells (needs --track-strands).",
+    )
+    gene_out.add_argument(
+        "--track-strands",
+        type=str,
+        default=None,
+        help="Per-track strand chars ('+','-','.') for --gene-strand match, one per output "
+             "track. Accepts compact ('+-+-') or separated ('+,-,+,-') form.",
     )
 
     # Track selection
@@ -227,6 +284,27 @@ def main():
         print(f"Error: Transfer config not found: {args.transfer_config}", file=sys.stderr)
         sys.exit(1)
 
+    # Validate gene-count AnnData options.
+    if args.anndata:
+        if not args.annotation:
+            parser.error("--anndata requires --annotation (a GTF/parquet with exon rows)")
+        if not Path(args.annotation).exists():
+            print(f"Error: Annotation not found: {args.annotation}", file=sys.stderr)
+            sys.exit(1)
+        if args.gene_strand == "match" and not args.track_strands:
+            parser.error("--gene-strand match requires --track-strands")
+        # Fail fast (before the model load) if the AnnData deps aren't installed.
+        import importlib.util
+        ann_suffix = Path(args.annotation).suffix.lower()
+        engine = "pyranges" if ann_suffix in (".gtf", ".gff", ".gff3") else "pyarrow"
+        missing = [m for m in ("pandas", "anndata", engine)
+                   if importlib.util.find_spec(m) is None]
+        if missing:
+            parser.error(
+                f"--anndata needs {', '.join(missing)} (not installed). Install with: "
+                "pip install 'alphagenome-pytorch[inference-anndata]'"
+            )
+
     # Parse track indices
     track_indices = None
     if args.tracks:
@@ -236,6 +314,14 @@ def main():
     track_names = None
     if args.track_names:
         track_names = [t.strip() for t in args.track_names.split(",")]
+
+    # Parse per-track strands for --gene-strand match (compact or separated form).
+    track_strands = None
+    if args.track_strands:
+        track_strands = [c for c in args.track_strands if c not in ", \t"]
+        invalid = sorted({c for c in track_strands if c not in "+-."})
+        if invalid:
+            parser.error(f"--track-strands has invalid characters {invalid}; use only + - .")
 
     # Parse chromosomes
     chromosomes = None
@@ -249,6 +335,7 @@ def main():
     from alphagenome_pytorch.extensions.inference import (
         TilingConfig,
         predict_full_chromosomes_to_bigwig,
+        predict_full_chromosomes_to_anndata,
     )
 
     # Configure dtype policy
@@ -294,6 +381,10 @@ def main():
                 track_names = ckpt_track_names.get(args.head)
             else:
                 track_names = ckpt_track_names
+            # Checkpoint names cover the full head; subset to the selected tracks
+            # (explicit --track-names already describes only the selected tracks).
+            if track_names is not None and track_indices is not None:
+                track_names = [track_names[i] for i in track_indices]
     else:
         # Standard pretrained model (existing behavior)
         print(f"Loading model from {model_path}...")
@@ -335,26 +426,49 @@ def main():
     print(f"  Resolution: {config.resolution} bp")
     print(f"  Batch size: {config.batch_size}")
 
-    # Run prediction
+    # Run prediction. --anndata produces the gene-count table; otherwise BigWig.
     print(f"\nPredicting head '{args.head}'...")
 
-    results = predict_full_chromosomes_to_bigwig(
-        model=model,
-        fasta_path=str(fasta_path),
-        output_dir=args.output,
-        head=args.head,
-        chromosomes=chromosomes,
-        config=config,
-        track_indices=track_indices,
-        track_names=track_names,
-        organism_index=args.organism,
-        device=args.device,
-        show_progress=not args.quiet,
-    )
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Summary
-    total_files = sum(len(paths) for paths in results.values())
-    print(f"\nDone! Wrote {total_files} BigWig file(s) to {args.output}")
+    if args.anndata:
+        # sum -> counts; mean -> length-normalized; log-mean -> log1p(mean).
+        predict_full_chromosomes_to_anndata(
+            model=model,
+            fasta_path=str(fasta_path),
+            annotation_path=args.annotation,
+            head=args.head,
+            output_path=str(output_dir / args.anndata),
+            chromosomes=chromosomes,
+            config=config,
+            track_indices=track_indices,
+            track_names=track_names,
+            track_strands=track_strands,
+            over="exons" if args.aggregate_over == "exons" else "gene_body",
+            reduce="sum" if args.aggregate_func == "sum" else "mean",
+            log=args.aggregate_func == "log-mean",
+            strand=None if args.gene_strand == "all" else args.gene_strand,
+            organism_index=args.organism,
+            device=args.device,
+            show_progress=not args.quiet,
+        )
+    else:
+        results = predict_full_chromosomes_to_bigwig(
+            model=model,
+            fasta_path=str(fasta_path),
+            output_dir=args.output,
+            head=args.head,
+            chromosomes=chromosomes,
+            config=config,
+            track_indices=track_indices,
+            track_names=track_names,
+            organism_index=args.organism,
+            device=args.device,
+            show_progress=not args.quiet,
+        )
+        total_files = sum(len(paths) for paths in results.values())
+        print(f"\nDone! Wrote {total_files} BigWig file(s) to {args.output}")
 
 
 if __name__ == "__main__":

--- a/src/alphagenome_pytorch/__init__.py
+++ b/src/alphagenome_pytorch/__init__.py
@@ -33,6 +33,7 @@ from .aggregation import (
     normalize_expression,
     gene_expression_correlations,
     GeneCounts,
+    GeneCountAccumulator,
 )
 
 __all__ = [
@@ -46,4 +47,5 @@ __all__ = [
     'normalize_expression',
     'gene_expression_correlations',
     'GeneCounts',
+    'GeneCountAccumulator',
 ]

--- a/src/alphagenome_pytorch/__init__.py
+++ b/src/alphagenome_pytorch/__init__.py
@@ -24,8 +24,26 @@ except ImportError:
     __version_tuple__ = (0, 0, 0, "dev0")
 
 from .model import AlphaGenome
+from .aggregation import (
+    aggregate_intervals,
+    aggregate_genes,
+    gene_expression,
+    gene_expression_values,
+    combine_gene_expression,
+    normalize_expression,
+    gene_expression_correlations,
+    GeneCounts,
+)
 
 __all__ = [
     '__version__',
     'AlphaGenome',
+    'aggregate_intervals',
+    'aggregate_genes',
+    'gene_expression',
+    'gene_expression_values',
+    'combine_gene_expression',
+    'normalize_expression',
+    'gene_expression_correlations',
+    'GeneCounts',
 ]

--- a/src/alphagenome_pytorch/aggregation.py
+++ b/src/alphagenome_pytorch/aggregation.py
@@ -26,6 +26,21 @@ Design notes
   the resulting ``[genes × tracks]`` matrix (see :func:`aggregate_genes`).
 * Users bring their own GTF/parquet; no bundled annotation. ``anndata`` is an
   optional, lazily-imported dependency.
+
+Units
+-----
+AlphaGenome's 128bp predictions are **bin sums**, not per-base values —
+``heads.predictions_scaling`` multiplies by ``resolution`` to reach experimental
+space, and the fine-tuning pipeline bins targets the same way. So a mean over a
+region must divide by *bases*, not by elements, or it comes out ``resolution``×
+too large. That is what ``bin_size`` is for.
+
+This buys **unit consistency**, not exact agreement between resolutions. Region
+means at 128bp remain an approximation: :meth:`GeneAnnotation.get_exon_bin_ranges`
+includes every bin an exon *touches*, and such a boundary bin is an already-summed
+total that mixes exonic and non-exonic bases. No choice of divisor can separate
+them after the fact. Only regions whose boundaries land on bin edges agree exactly
+with the 1bp result.
 """
 
 from __future__ import annotations
@@ -64,16 +79,25 @@ def aggregate_intervals(
     predictions: Tensor,
     mask: Tensor,
     reduce: str = "sum",
+    bin_size: int = 1,
 ) -> Tensor:
     """Aggregate per-position predictions over R interval masks.
 
     Args:
-        predictions: ``[B, S, C]`` (or ``[S, C]``) per-position values.
+        predictions: ``[B, S, C]`` (or ``[S, C]``) per-element values.
         mask: ``[S, R]`` interval masks (bool or float); column ``r`` selects the
-            positions belonging to region ``r``.
+            elements belonging to region ``r``.
         reduce: ``"sum"`` for raw summed signal, or ``"mean"`` for the
             length-normalized mean (divides by each region's masked length,
             clamped to ``>= 1`` so an empty mask yields 0 rather than NaN).
+        bin_size: Number of bases integrated into each element of
+            ``predictions``. Only ``"mean"`` uses it: the divisor becomes
+            ``masked_elements * bin_size``, i.e. bases rather than elements.
+            Leave at 1 for per-base inputs (1bp predictions). Pass the bin width
+            only when the inputs are **bin sums** — AlphaGenome's 128bp outputs
+            are, since ``predictions_scaling`` multiplies by ``resolution`` to
+            reach experimental space. Passing it for per-base inputs would
+            wrongly shrink the mean by that factor.
 
     Returns:
         ``[B, R, C]`` aggregated values (a leading batch axis is always present,
@@ -92,6 +116,8 @@ def aggregate_intervals(
             f"mask length {mask.shape[0]} != predictions sequence length "
             f"{predictions.shape[1]}"
         )
+    if bin_size <= 0:
+        raise ValueError(f"bin_size must be positive, got {bin_size}")
 
     mask_f = mask.to(predictions.dtype)
     out = torch.einsum("bsc,sr->brc", predictions, mask_f)  # [B, R, C]
@@ -99,7 +125,7 @@ def aggregate_intervals(
     if reduce == "sum":
         return out
     if reduce == "mean":
-        lengths = mask_f.sum(dim=0).clamp(min=1.0)  # [R]
+        lengths = (mask_f.sum(dim=0) * bin_size).clamp(min=1.0)  # [R], in bases
         return out / lengths[None, :, None]
     raise ValueError(f"reduce must be 'sum' or 'mean', got {reduce!r}")
 
@@ -495,7 +521,11 @@ def aggregate_genes(
     mask = _bp_mask_to_bins(body_mask_np.any(axis=1), resolution, seq_len)  # [S, G]
     mask_t = torch.from_numpy(mask).to(predictions.device)
 
-    counts = aggregate_intervals(predictions, mask_t, reduce=reduce)  # [B, G, C]
+    # bin_size=resolution: 128bp predictions are bin sums, so "mean" must divide
+    # by bases to stay per-base (see the module's Units note).
+    counts = aggregate_intervals(
+        predictions, mask_t, reduce=reduce, bin_size=resolution
+    )  # [B, G, C]
 
     track_frame = _track_metadata_frame(track_metadata, predictions.shape[-1])
     counts, track_frame = _apply_strand(counts, gene_strands, track_frame, strand)
@@ -569,6 +599,7 @@ class _ExonWindow:
     gene_frame: "pd.DataFrame"
     bin_ranges: list[list[tuple[int, int]]]
     seq_len: int
+    resolution: int
 
     def build_mask(self, device=None, dtype: torch.dtype = torch.float32) -> Tensor:
         """Reconstruct the ``[S, G]`` exon mask from the cached bin-ranges."""
@@ -660,6 +691,7 @@ def _build_exon_window(
         gene_frame=gene_frame,
         bin_ranges=kept_ranges,
         seq_len=seq_len,
+        resolution=resolution,
     )
 
 
@@ -711,7 +743,9 @@ def _aggregate_exon_window(
         predictions = predictions.unsqueeze(0)
     if window.gene_ids:
         mask = window.build_mask(predictions.device, predictions.dtype)  # [S, G]
-        counts = aggregate_intervals(predictions, mask, reduce=reduce)   # [B, G, C]
+        counts = aggregate_intervals(
+            predictions, mask, reduce=reduce, bin_size=window.resolution
+        )  # [B, G, C]
     else:
         counts = predictions.new_zeros((predictions.shape[0], 0, predictions.shape[-1]))
     return _apply_log(counts, log)
@@ -998,7 +1032,10 @@ class GeneCountAccumulator:
         counts = torch.zeros(1, len(ids), c, dtype=torch.float32)
         for gi, base in enumerate(ids):
             s = torch.from_numpy(self._sum[base]).float()
-            counts[0, gi] = s / max(self._len[base], 1.0) if self.reduce == "mean" else s
+            # `_len` counts bins; 128bp values are bin sums, so a per-base mean
+            # divides by bases (see the module's Units note).
+            n_bases = max(self._len[base] * self.resolution, 1.0)
+            counts[0, gi] = s / n_bases if self.reduce == "mean" else s
         if log:
             counts = torch.log1p(counts)
 

--- a/src/alphagenome_pytorch/aggregation.py
+++ b/src/alphagenome_pytorch/aggregation.py
@@ -757,7 +757,6 @@ def gene_expression_values(
     annotation: "GeneAnnotation",
     interval: tuple[str, int, int],
     *,
-    resolution: int = 1,
     min_exon_fraction: float = 0.5,
     log: str | None = "log1p",
     track_strands: "Sequence[str] | None" = None,
@@ -768,8 +767,9 @@ def gene_expression_values(
     Returns ``(values, gene_ids, gene_strands)`` where ``values`` is ``[G, C]``
     (log-space by default). If ``track_strands`` is given, strand-incompatible
     ``(gene, track)`` cells are set to NaN (sense-strand matching).
-    ``resolution`` is informational here; the interval width and the
-    prediction sequence length determine the true bin size.
+
+    Bin size is derived from the interval width and the prediction sequence
+    length, so predictions at any resolution work without being told which.
 
     Args:
         predictions: ``[S, C]`` or ``[1, S, C]`` predictions for one window.

--- a/src/alphagenome_pytorch/aggregation.py
+++ b/src/alphagenome_pytorch/aggregation.py
@@ -359,6 +359,17 @@ def _track_metadata_frame(
     return pd.DataFrame([t.to_dict() for t in track_metadata])
 
 
+def _validate_track_strands(strands: "Sequence[str]") -> None:
+    """Reject strand labels outside ``{'+', '-', '.'}``.
+
+    Unknown labels (``'plus'``, ``'?'``, …) would otherwise be silently treated as
+    strand-incompatible by the matching logic, producing all-NaN gene rows.
+    """
+    invalid = sorted({str(s) for s in strands if str(s) not in ("+", "-", ".")})
+    if invalid:
+        raise ValueError(f"track strands must be '+', '-', or '.'; got invalid {invalid}")
+
+
 def _track_strands(track_frame: "pd.DataFrame") -> list[str]:
     if "strand" not in track_frame.columns:
         raise ValueError(
@@ -366,7 +377,9 @@ def _track_strands(track_frame: "pd.DataFrame") -> list[str]:
             "(none found). Pass track_metadata with per-track strand, or use "
             "strand=None."
         )
-    return [str(s) for s in track_frame["strand"].tolist()]
+    strands = [str(s) for s in track_frame["strand"].tolist()]
+    _validate_track_strands(strands)
+    return strands
 
 
 def _apply_strand(
@@ -795,6 +808,7 @@ def _strand_match_values(
         )
     gs = list(gene_strands)
     ts = [str(t) for t in track_strands]
+    _validate_track_strands(ts)
     compat = torch.ones(len(gs), len(ts), dtype=torch.bool)
     for gi, g in enumerate(gs):
         for ci, t in enumerate(ts):

--- a/src/alphagenome_pytorch/aggregation.py
+++ b/src/alphagenome_pytorch/aggregation.py
@@ -8,14 +8,14 @@ Two user-facing helpers build on the primitive:
 
 * :func:`aggregate_genes` — loss-style **gene-body** counts (exons + introns),
   mirroring the training gene-LFC aggregation. Linear space.
-* :func:`gene_expression` — the AlphaGenome paper's Fig. 2d quantity:
+* :func:`gene_expression` — gene-expression:
   **log-transformed mean coverage over a gene's annotated exons**, strand-matched,
   keeping genes with ≥50% of their exons inside the interval.
 
 Both return a :class:`GeneCounts` object with torch-native data plus DataFrame /
 AnnData converters. The correlation helpers (:func:`normalize_expression`,
-:func:`gene_expression_correlations`) implement the three Fig. 2d flavors and are
-reused by the fine-tuning validation metric.
+:func:`gene_expression_correlations`) implement the three gene-expression
+correlation flavors and are reused by the fine-tuning validation metric.
 
 Design notes
 ------------
@@ -49,6 +49,7 @@ __all__ = [
     "normalize_expression",
     "gene_expression_correlations",
     "GeneCounts",
+    "GeneCountAccumulator",
     "aggregate_genes",
     "gene_expression",
     "gene_expression_values",
@@ -104,7 +105,7 @@ def aggregate_intervals(
 
 
 # --------------------------------------------------------------------------- #
-# Correlation helpers (Fig. 2d)
+# Correlation helpers (gene-expression)
 # --------------------------------------------------------------------------- #
 def _nan_pearson(pred: Tensor, obs: Tensor, dim: int, eps: float = 1e-8) -> Tensor:
     """Pearson correlation over ``dim``, ignoring entries where either is NaN.
@@ -140,10 +141,10 @@ def _nan_pearson(pred: Tensor, obs: Tensor, dim: int, eps: float = 1e-8) -> Tens
 def normalize_expression(matrix: Tensor) -> Tensor:
     """Quantile-normalize across genes per track, then gene-mean-center.
 
-    Implements the AlphaGenome Fig. 2d normalization for the *specificity*
-    panels: for each track (column) the gene values are quantile-normalized
-    across genes to a common reference (the mean of the per-column sorted
-    values); then each gene's (row) mean across tracks is subtracted.
+    Implements the AlphaGenome *specificity* normalization: for each track
+    (column) the gene values are quantile-normalized across genes to a common
+    reference (the mean of the per-column sorted values); then each gene's (row)
+    mean across tracks is subtracted.
 
     Args:
         matrix: ``[G, C]`` gene × track expression (no NaN). Genes are rows.
@@ -176,7 +177,7 @@ def gene_expression_correlations(
     *,
     eps: float = 1e-8,
 ) -> dict[str, float]:
-    """The three AlphaGenome Fig. 2d gene-expression correlations.
+    """The three AlphaGenome gene-expression correlations.
 
     Args:
         pred: ``[G, C]`` predicted (log-space) gene × track expression.
@@ -186,11 +187,10 @@ def gene_expression_correlations(
 
     Returns:
         Dict with mean correlations:
-          * ``across_genes`` — raw, per-track across genes (Fig. 2d left)
+          * ``across_genes`` — raw, per-track across genes
           * ``across_genes_norm`` — quantile-normalized + gene-mean-centered,
-            per-track across genes (middle)
+            per-track across genes
           * ``across_tracks_norm`` — same normalized data, per-gene across tracks
-            (right)
     """
     if pred.shape != obs.shape:
         raise ValueError(f"pred {tuple(pred.shape)} and obs {tuple(obs.shape)} must match")
@@ -329,8 +329,8 @@ class GeneCounts:
             import anndata
         except ImportError:
             raise ImportError(
-                "anndata is required for AnnData output. "
-                "Install with: pip install anndata"
+                "anndata is required for AnnData output. Install with: "
+                "pip install anndata  (or pip install 'alphagenome-pytorch[inference-anndata]')"
             )
         x, obs, var = self.to_tables()
         obs = obs.copy()
@@ -420,7 +420,7 @@ def _merge_strand_pairs(counts: Tensor, track_frame: "pd.DataFrame"):
             order.append(key)
         groups[key].append(ci)
 
-    merged = torch.zeros(b, g, len(order), dtype=counts.dtype)
+    merged = counts.new_zeros(b, g, len(order))  # preserve device + dtype
     new_rows = []
     for out_i, key in enumerate(order):
         idxs = groups[key]
@@ -491,7 +491,7 @@ def aggregate_genes(
 
 
 # --------------------------------------------------------------------------- #
-# gene_expression — exon-based, log-space (paper Fig. 2d)
+# gene_expression — exon-based, log-space
 # --------------------------------------------------------------------------- #
 def gene_expression(
     predictions: Tensor,
@@ -504,7 +504,7 @@ def gene_expression(
     min_exon_fraction: float = 0.5,
     reduce: str = "mean",
 ) -> GeneCounts:
-    """AlphaGenome Fig. 2d gene expression: log mean coverage over annotated exons.
+    """AlphaGenome gene expression: log mean coverage over annotated exons.
 
     Args:
         predictions: ``[B, S, C]`` (or ``[S, C]``) RNA-seq tensor in experimental
@@ -516,9 +516,10 @@ def gene_expression(
         log: ``"log1p"`` (default), ``"log"``, or ``None`` for linear.
         strand: default ``"match"`` (sense-strand expression). Same modes as
             :func:`aggregate_genes`.
-        min_exon_fraction: keep a gene only if at least this fraction of its total
-            exonic bases falls inside the interval (paper: ≥50%).
-        reduce: ``"mean"`` (paper) or ``"sum"``.
+        min_exon_fraction: keep a gene only if at least this fraction of its
+            annotated exons fall fully within the interval — a count of whole
+            exons, not a base-pair fraction.
+        reduce: ``"mean"`` (default) or ``"sum"``.
     """
     per_gene = _exon_expression_matrix(
         predictions, annotation, interval,
@@ -612,9 +613,13 @@ def _build_exon_window(
         exons = annotation._get_exons_for_gene(base)
         if not exons:
             continue
-        total_bp = sum(e - s for s, e in exons)
-        in_bp = sum(max(0, min(e, end) - max(s, start)) for s, e in exons)
-        if total_bp <= 0 or (in_bp / total_bp) < min_exon_fraction:
+        # Keep a gene when at least ``min_exon_fraction`` of its annotated exons
+        # fall fully within the interval — a count of whole contained exons, not a
+        # base-pair fraction. "Exons" here are the gene's *merged* exonic blocks
+        # (overlapping/adjacent records collapsed across transcripts by
+        # ``_get_exons_for_gene``), not raw GTF exon rows.
+        n_within = sum(1 for s, e in exons if s >= start and e <= end)
+        if (n_within / len(exons)) < min_exon_fraction:
             continue
         ranges = annotation.get_exon_bin_ranges(gid, iv, resolution, seq_len)
         if not ranges:
@@ -749,8 +754,8 @@ def gene_expression_values(
 
     Returns ``(values, gene_ids, gene_strands)`` where ``values`` is ``[G, C]``
     (log-space by default). If ``track_strands`` is given, strand-incompatible
-    ``(gene, track)`` cells are set to NaN (sense-strand matching, as in the
-    paper). ``resolution`` is informational here; the interval width and the
+    ``(gene, track)`` cells are set to NaN (sense-strand matching).
+    ``resolution`` is informational here; the interval width and the
     prediction sequence length determine the true bin size.
 
     Args:
@@ -804,11 +809,11 @@ def combine_gene_expression(
     *,
     eps: float = 1e-8,
 ) -> dict[str, float]:
-    """Combine per-window ``(gene_ids, pred[G,C], obs[G,C])`` into Fig. 2d metrics.
+    """Combine per-window ``(gene_ids, pred[G,C], obs[G,C])`` into gene-expression correlations.
 
-    Genes are deduplicated by id across windows (first occurrence wins, matching
-    the paper's "avoid duplicate genes across test intervals"). Returns the three
-    correlation flavors plus ``n_genes``.
+    Genes are deduplicated by id across windows (first occurrence wins), avoiding
+    duplicate genes across overlapping windows. Returns the three correlation
+    flavors plus ``n_genes``.
     """
     seen: dict[str, int] = {}
     pred_rows: list[Tensor] = []
@@ -834,6 +839,171 @@ def combine_gene_expression(
     result = gene_expression_correlations(pred_m, obs_m, eps=eps)
     result["n_genes"] = len(pred_rows)
     return result
+
+
+# --------------------------------------------------------------------------- #
+# Whole-chromosome streaming accumulator (tiled inference -> gene counts)
+# --------------------------------------------------------------------------- #
+class GeneCountAccumulator:
+    """Accumulate per-gene counts from tiled whole-chromosome predictions.
+
+    Feed each tile's predictions with their genomic coordinates via
+    :meth:`add_tile`; the signal over each gene's exons (or gene body) is summed
+    (or averaged) into a running ``[gene, track]`` matrix. A gene whose exons span
+    several tiles is summed across all of them. Call :meth:`to_gene_counts` for a
+    :class:`GeneCounts` (``.to_anndata()`` for an AnnData).
+
+    Args:
+        annotation: a :class:`GeneAnnotation`; exon rows required for
+            ``over="exons"``.
+        resolution: bp per prediction bin (1 or 128).
+        over: ``"exons"`` (default) or ``"gene_body"``.
+        reduce: ``"sum"`` (default, count-like) or ``"mean"`` (length-normalized).
+    """
+
+    def __init__(
+        self,
+        annotation: "GeneAnnotation",
+        *,
+        resolution: int,
+        over: str = "exons",
+        reduce: str = "sum",
+    ) -> None:
+        if over not in ("exons", "gene_body"):
+            raise ValueError(f"over must be 'exons' or 'gene_body', got {over!r}")
+        if reduce not in ("sum", "mean"):
+            raise ValueError(f"reduce must be 'sum' or 'mean', got {reduce!r}")
+        self.annotation = annotation
+        self.resolution = int(resolution)
+        self.over = over
+        self.reduce = reduce
+        self.n_tracks: int | None = None
+        self._sum: dict[str, Any] = {}     # base gene id -> np.ndarray [n_tracks] running sum
+        self._len: dict[str, float] = {}   # base gene id -> total masked bins (for mean)
+        self._meta: dict[str, dict] = {}   # base gene id -> gene metadata row
+        self._order: list[str] = []        # first-seen gene order
+
+    @property
+    def n_genes(self) -> int:
+        return len(self._order)
+
+    def add_tile(self, preds, chrom: str, start: int, end: int) -> None:
+        """Accumulate one tile's kept-region predictions.
+
+        Args:
+            preds: ``[n_bins, n_tracks]`` predictions covering genomic
+                ``[start, end)`` at ``self.resolution`` (``n_bins == (end-start)
+                // resolution``). Tensor or ndarray.
+            chrom, start, end: genomic span of ``preds`` (0-based half-open,
+                resolution-aligned).
+        """
+        import numpy as np
+        from .variant_scoring.types import Interval
+
+        arr = preds.detach().cpu().numpy() if isinstance(preds, Tensor) else np.asarray(preds)
+        if arr.ndim != 2:
+            raise ValueError(f"preds must be [n_bins, n_tracks], got {arr.shape}")
+        n_bins, c = arr.shape
+        if self.n_tracks is None:
+            self.n_tracks = c
+        elif c != self.n_tracks:
+            raise ValueError(f"tile has {c} tracks but accumulator holds {self.n_tracks}")
+
+        iv = Interval(chrom, start, end)
+        for gid in self.annotation.get_genes_in_interval(iv):
+            if self.over == "exons":
+                ranges = self.annotation.get_exon_bin_ranges(gid, iv, self.resolution, n_bins)
+            else:
+                ranges = self._body_bin_ranges(gid, start, end, n_bins)
+            if not ranges:
+                continue
+            # Merge overlapping/adjacent bin ranges so a bin shared by two exons
+            # (e.g. exons split by a short intron under coarse resolution) is
+            # counted once, not once per exon.
+            signal = np.zeros(c, dtype=np.float64)
+            length = 0
+            for b0, b1 in self.annotation._merge_intervals(ranges):
+                signal += arr[b0:b1].sum(axis=0)
+                length += b1 - b0
+            if length == 0:
+                continue
+            base = gid.split(".")[0]
+            if base not in self._sum:
+                self._order.append(base)
+                self._sum[base] = np.zeros(c, dtype=np.float64)
+                self._len[base] = 0.0
+                self._meta[base] = self._gene_meta_row(gid, base)
+            self._sum[base] += signal
+            self._len[base] += length
+
+    def _body_bin_ranges(self, gid: str, start: int, end: int, n_bins: int):
+        """Single ``[bin_start, bin_end)`` range for a gene body within the tile."""
+        info = self.annotation.get_gene_info(gid)
+        if not info or info.get("start") is None or info.get("end") is None:
+            return []
+        res, width = self.resolution, end - start
+        rel_start = max(0, int(info["start"]) - start)
+        rel_end = min(width, int(info["end"]) - start)
+        if rel_start >= width or rel_end <= 0:
+            return []
+        b0 = max(0, min(rel_start // res, n_bins))
+        b1 = max(0, min((rel_end + res - 1) // res, n_bins))
+        return [(b0, b1)] if b0 < b1 else []
+
+    def _gene_meta_row(self, gid: str, base: str) -> dict:
+        info = self.annotation.get_gene_info(gid) or {}
+        return {
+            "gene_id": info.get("gene_id", base),
+            "gene_name": info.get("gene_name"),
+            "gene_type": info.get("gene_type"),
+            "strand": info.get("strand", "."),
+            "Start": info.get("start"),
+            "End": info.get("end"),
+        }
+
+    def to_gene_counts(
+        self,
+        *,
+        track_metadata: "Sequence[TrackMetadata] | pd.DataFrame | None" = None,
+        log: bool = False,
+        strand: str | None = None,
+    ) -> GeneCounts:
+        """Finalize accumulated signal into a single-interval :class:`GeneCounts`.
+
+        Args:
+            track_metadata: per-track metadata (``TrackMetadata`` sequence or a
+                ready ``[C]``-row DataFrame) for the ``obs`` table and strand logic.
+            log: if True, apply ``log1p`` after the reduce.
+            strand: ``None``/``"match"``/``"merge"`` post-processing on the
+                ``[gene × track]`` matrix (see :func:`aggregate_genes`).
+        """
+        import pandas as pd
+
+        ids = self._order
+        c = self.n_tracks or 0
+        counts = torch.zeros(1, len(ids), c, dtype=torch.float32)
+        for gi, base in enumerate(ids):
+            s = torch.from_numpy(self._sum[base]).float()
+            counts[0, gi] = s / max(self._len[base], 1.0) if self.reduce == "mean" else s
+        if log:
+            counts = torch.log1p(counts)
+
+        if isinstance(track_metadata, pd.DataFrame):
+            track_frame = track_metadata.reset_index(drop=True)
+        else:
+            track_frame = _track_metadata_frame(track_metadata, c)
+        gene_frame = (
+            pd.DataFrame([self._meta[b] for b in ids]) if ids
+            else pd.DataFrame(columns=_GENE_FRAME_COLUMNS)
+        )
+        gene_strands = [self._meta[b]["strand"] for b in ids]
+        counts, track_frame = _apply_strand(counts, gene_strands, track_frame, strand)
+        return GeneCounts(
+            counts=counts,
+            gene_metadata=gene_frame,
+            track_metadata=track_frame,
+            space="log" if log else "linear",
+        )
 
 
 # --------------------------------------------------------------------------- #

--- a/src/alphagenome_pytorch/aggregation.py
+++ b/src/alphagenome_pytorch/aggregation.py
@@ -1003,6 +1003,15 @@ class GeneCountAccumulator:
             counts = torch.log1p(counts)
 
         if isinstance(track_metadata, pd.DataFrame):
+            # Same length check the TrackMetadata path gets via
+            # _track_metadata_frame: a frame that doesn't describe the accumulated
+            # tracks yields a GeneCounts whose counts and obs disagree, which only
+            # surfaces later as a dimension error from inside anndata.
+            if len(track_metadata) != c:
+                raise ValueError(
+                    f"track_metadata has {len(track_metadata)} rows but predictions "
+                    f"have {c} tracks."
+                )
             track_frame = track_metadata.reset_index(drop=True)
         else:
             track_frame = _track_metadata_frame(track_metadata, c)

--- a/src/alphagenome_pytorch/aggregation.py
+++ b/src/alphagenome_pytorch/aggregation.py
@@ -1,0 +1,882 @@
+"""Interval / gene aggregation for AlphaGenome-PyTorch predictions.
+
+This module turns per-position predictions (``[B, S, C]``) into per-region
+matrices — most usefully **per-gene × per-track** counts and expression values —
+using a single positional primitive that all consumers share.
+
+Two user-facing helpers build on the primitive:
+
+* :func:`aggregate_genes` — loss-style **gene-body** counts (exons + introns),
+  mirroring the training gene-LFC aggregation. Linear space.
+* :func:`gene_expression` — the AlphaGenome paper's Fig. 2d quantity:
+  **log-transformed mean coverage over a gene's annotated exons**, strand-matched,
+  keeping genes with ≥50% of their exons inside the interval.
+
+Both return a :class:`GeneCounts` object with torch-native data plus DataFrame /
+AnnData converters. The correlation helpers (:func:`normalize_expression`,
+:func:`gene_expression_correlations`) implement the three Fig. 2d flavors and are
+reused by the fine-tuning validation metric.
+
+Design notes
+------------
+* The core (``aggregate_intervals`` + the correlation helpers) is **pure tensor**
+  code — no pandas / anndata — so the training validation loop can import it
+  without pulling optional deps.
+* Aggregation is **always purely positional**. ``strand`` is post-processing on
+  the resulting ``[genes × tracks]`` matrix (see :func:`aggregate_genes`).
+* Users bring their own GTF/parquet; no bundled annotation. ``anndata`` is an
+  optional, lazily-imported dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Sequence
+
+import torch
+from torch import Tensor
+
+from .metrics import pearson_r
+
+if TYPE_CHECKING:  # avoid importing heavy / optional modules at import time
+    import pandas as pd
+    from .named_outputs import TrackMetadata
+    from .variant_scoring.annotations import GeneAnnotation
+
+
+__all__ = [
+    "aggregate_intervals",
+    "normalize_expression",
+    "gene_expression_correlations",
+    "GeneCounts",
+    "aggregate_genes",
+    "gene_expression",
+    "gene_expression_values",
+    "combine_gene_expression",
+]
+
+
+# --------------------------------------------------------------------------- #
+# Core primitive
+# --------------------------------------------------------------------------- #
+def aggregate_intervals(
+    predictions: Tensor,
+    mask: Tensor,
+    reduce: str = "sum",
+) -> Tensor:
+    """Aggregate per-position predictions over R interval masks.
+
+    Args:
+        predictions: ``[B, S, C]`` (or ``[S, C]``) per-position values.
+        mask: ``[S, R]`` interval masks (bool or float); column ``r`` selects the
+            positions belonging to region ``r``.
+        reduce: ``"sum"`` for raw summed signal, or ``"mean"`` for the
+            length-normalized mean (divides by each region's masked length,
+            clamped to ``>= 1`` so an empty mask yields 0 rather than NaN).
+
+    Returns:
+        ``[B, R, C]`` aggregated values (a leading batch axis is always present,
+        even when ``predictions`` was 2-D).
+    """
+    if predictions.dim() == 2:
+        predictions = predictions.unsqueeze(0)
+    if predictions.dim() != 3:
+        raise ValueError(
+            f"predictions must be [B, S, C] or [S, C], got shape {tuple(predictions.shape)}"
+        )
+    if mask.dim() != 2:
+        raise ValueError(f"mask must be [S, R], got shape {tuple(mask.shape)}")
+    if mask.shape[0] != predictions.shape[1]:
+        raise ValueError(
+            f"mask length {mask.shape[0]} != predictions sequence length "
+            f"{predictions.shape[1]}"
+        )
+
+    mask_f = mask.to(predictions.dtype)
+    out = torch.einsum("bsc,sr->brc", predictions, mask_f)  # [B, R, C]
+
+    if reduce == "sum":
+        return out
+    if reduce == "mean":
+        lengths = mask_f.sum(dim=0).clamp(min=1.0)  # [R]
+        return out / lengths[None, :, None]
+    raise ValueError(f"reduce must be 'sum' or 'mean', got {reduce!r}")
+
+
+# --------------------------------------------------------------------------- #
+# Correlation helpers (Fig. 2d)
+# --------------------------------------------------------------------------- #
+def _nan_pearson(pred: Tensor, obs: Tensor, dim: int, eps: float = 1e-8) -> Tensor:
+    """Pearson correlation over ``dim``, ignoring entries where either is NaN.
+
+    Positions that are NaN in ``pred`` or ``obs`` are dropped pairwise (their
+    contribution is zeroed and excluded from the counts / means). Columns with
+    fewer than two valid points return NaN.
+    """
+    pred = pred.float()
+    obs = obs.float()
+    valid = ~(torch.isnan(pred) | torch.isnan(obs))
+    w = valid.float()
+
+    n = w.sum(dim=dim, keepdim=True)  # valid count along dim
+    pred0 = torch.where(valid, pred, torch.zeros_like(pred))
+    obs0 = torch.where(valid, obs, torch.zeros_like(obs))
+
+    mean_p = (pred0.sum(dim=dim, keepdim=True)) / n.clamp(min=1)
+    mean_o = (obs0.sum(dim=dim, keepdim=True)) / n.clamp(min=1)
+
+    pc = torch.where(valid, pred - mean_p, torch.zeros_like(pred))
+    oc = torch.where(valid, obs - mean_o, torch.zeros_like(obs))
+
+    num = (pc * oc).sum(dim=dim)
+    den = pc.pow(2).sum(dim=dim).sqrt() * oc.pow(2).sum(dim=dim).sqrt()
+    r = num / (den + eps)
+
+    # Undefined where fewer than 2 valid points.
+    enough = (n.squeeze(dim) >= 2)
+    return torch.where(enough, r, torch.full_like(r, float("nan")))
+
+
+def normalize_expression(matrix: Tensor) -> Tensor:
+    """Quantile-normalize across genes per track, then gene-mean-center.
+
+    Implements the AlphaGenome Fig. 2d normalization for the *specificity*
+    panels: for each track (column) the gene values are quantile-normalized
+    across genes to a common reference (the mean of the per-column sorted
+    values); then each gene's (row) mean across tracks is subtracted.
+
+    Args:
+        matrix: ``[G, C]`` gene × track expression (no NaN). Genes are rows.
+
+    Returns:
+        ``[G, C]`` normalized matrix.
+    """
+    if matrix.dim() != 2:
+        raise ValueError(f"matrix must be [G, C], got {tuple(matrix.shape)}")
+    x = matrix.float()
+    g, c = x.shape
+    if g < 2 or c < 1:
+        return x - x.mean(dim=1, keepdim=True) if g >= 1 and c >= 1 else x
+
+    # Quantile normalization per column (track), across genes (rows).
+    order = x.argsort(dim=0)                    # [G, C] indices sorting each column
+    ranks = order.argsort(dim=0)               # [G, C] rank of each entry in its column
+    sorted_x, _ = x.sort(dim=0)                # [G, C] sorted values per column
+    reference = sorted_x.mean(dim=1)           # [G] mean of the sorted values across tracks
+    qn = reference[ranks]                      # map each entry to its rank's reference value
+
+    # Gene-mean centering (subtract each gene's mean across tracks).
+    qn = qn - qn.mean(dim=1, keepdim=True)
+    return qn
+
+
+def gene_expression_correlations(
+    pred: Tensor,
+    obs: Tensor,
+    *,
+    eps: float = 1e-8,
+) -> dict[str, float]:
+    """The three AlphaGenome Fig. 2d gene-expression correlations.
+
+    Args:
+        pred: ``[G, C]`` predicted (log-space) gene × track expression.
+        obs: ``[G, C]`` observed (log-space) gene × track expression. NaN cells
+            (e.g. strand-incompatible) are handled pairwise.
+        eps: numerical epsilon.
+
+    Returns:
+        Dict with mean correlations:
+          * ``across_genes`` — raw, per-track across genes (Fig. 2d left)
+          * ``across_genes_norm`` — quantile-normalized + gene-mean-centered,
+            per-track across genes (middle)
+          * ``across_tracks_norm`` — same normalized data, per-gene across tracks
+            (right)
+    """
+    if pred.shape != obs.shape:
+        raise ValueError(f"pred {tuple(pred.shape)} and obs {tuple(obs.shape)} must match")
+
+    # Raw / across genes: correlate over genes (dim=0), one r per track, mean.
+    raw = _nan_pearson(pred, obs, dim=0, eps=eps)  # [C]
+
+    result = {"across_genes": float(_nanmean(raw))}
+
+    # Normalized variants need a dense matrix; drop genes/tracks that are all-NaN.
+    pred_d, obs_d = _dense_common(pred, obs)
+    if pred_d is not None and pred_d.shape[0] >= 2 and pred_d.shape[1] >= 2:
+        pred_n = normalize_expression(pred_d)
+        obs_n = normalize_expression(obs_d)
+        ag_norm = _nan_pearson(pred_n, obs_n, dim=0, eps=eps)   # [C]
+        at_norm = _nan_pearson(pred_n, obs_n, dim=1, eps=eps)   # [G]
+        result["across_genes_norm"] = float(_nanmean(ag_norm))
+        result["across_tracks_norm"] = float(_nanmean(at_norm))
+    else:
+        result["across_genes_norm"] = float("nan")
+        result["across_tracks_norm"] = float("nan")
+    return result
+
+
+def _nanmean(x: Tensor) -> Tensor:
+    valid = ~torch.isnan(x)
+    if valid.sum() == 0:
+        return torch.tensor(float("nan"))
+    return x[valid].mean()
+
+
+def _dense_common(pred: Tensor, obs: Tensor):
+    """Drop rows/cols that are entirely NaN in either matrix (for QN)."""
+    finite = ~(torch.isnan(pred) | torch.isnan(obs))
+    keep_g = finite.any(dim=1)
+    keep_c = finite.any(dim=0)
+    if keep_g.sum() < 2 or keep_c.sum() < 2:
+        return None, None
+    pred_d = pred[keep_g][:, keep_c]
+    obs_d = obs[keep_g][:, keep_c]
+    # Remaining NaNs (sparse strand mismatches) → 0 after centering is imperfect;
+    # replace with column means so QN ranks are well-defined.
+    pred_d = _fill_nan_colmean(pred_d)
+    obs_d = _fill_nan_colmean(obs_d)
+    return pred_d, obs_d
+
+
+def _fill_nan_colmean(x: Tensor) -> Tensor:
+    nan = torch.isnan(x)
+    if not nan.any():
+        return x
+    x = x.clone()
+    # column means over non-NaN entries
+    valid = (~nan).float()
+    means = (torch.where(nan, torch.zeros_like(x), x)).sum(0) / valid.sum(0).clamp(min=1)
+    x[nan] = means.repeat(x.shape[0], 1)[nan]
+    return x
+
+
+# --------------------------------------------------------------------------- #
+# Result object
+# --------------------------------------------------------------------------- #
+@dataclass
+class GeneCounts:
+    """Per-gene × per-track aggregated result with export converters.
+
+    Attributes:
+        counts: ``[B, G, C]`` aggregated values (``space`` labels the scale).
+        gene_metadata: ``G``-row DataFrame (→ AnnData ``var``): gene_id,
+            gene_name, gene_type, strand, Start, End.
+        track_metadata: ``C``-row DataFrame (→ AnnData ``obs``): track_index,
+            track_name, strand, and any extras.
+        space: ``"linear"`` or ``"log"``.
+    """
+
+    counts: Tensor
+    gene_metadata: "pd.DataFrame"
+    track_metadata: "pd.DataFrame"
+    space: str = "linear"
+
+    @property
+    def value_column(self) -> str:
+        return "log_expression" if self.space == "log" else "count"
+
+    def to_dataframe(self, long: bool = True) -> "pd.DataFrame":
+        """Tidy long table: one row per (interval, gene, track) with metadata."""
+        import pandas as pd
+
+        b, g, c = self.counts.shape
+        vals = self.counts.detach().float().cpu().numpy()
+        gene_meta = self.gene_metadata.reset_index(drop=True)
+        track_meta = self.track_metadata.reset_index(drop=True)
+
+        rows = []
+        for bi in range(b):
+            for gi in range(g):
+                grow = gene_meta.iloc[gi].to_dict()
+                for ci in range(c):
+                    trow = track_meta.iloc[ci].to_dict()
+                    rec = {"batch": bi}
+                    rec.update({f"gene_{k}": v for k, v in grow.items()})
+                    rec.update({f"track_{k}": v for k, v in trow.items()})
+                    rec[self.value_column] = vals[bi, gi, ci]
+                    rows.append(rec)
+        df = pd.DataFrame(rows)
+        if not long:
+            raise ValueError("Only long=True is supported; use to_tables() for a matrix.")
+        return df
+
+    def to_tables(self):
+        """Return ``(X, obs, var)`` with ``X`` of shape ``[tracks, genes]``.
+
+        Requires a single interval (``B == 1``); raises otherwise so the AnnData
+        layout is unambiguous.
+        """
+        b = self.counts.shape[0]
+        if b != 1:
+            raise ValueError(
+                f"to_tables()/to_anndata() require a single interval (B==1), got B={b}. "
+                "Index a single window, e.g. gc.counts[i], or loop over intervals."
+            )
+        x = self.counts[0].detach().float().cpu().numpy().T  # [tracks, genes]
+        obs = self.track_metadata.reset_index(drop=True).copy()
+        var = self.gene_metadata.reset_index(drop=True).copy()
+        return x, obs, var
+
+    def to_anndata(self):
+        """Build an ``anndata.AnnData`` (obs=tracks, var=genes, X=[tracks, genes]).
+
+        ``obs_names`` are track names (falling back to track index) and
+        ``var_names`` are gene ids — the scanpy convention. Setting them
+        explicitly also avoids anndata's ``ImplicitModificationWarning`` about
+        coercing an integer index to strings.
+        """
+        try:
+            import anndata
+        except ImportError:
+            raise ImportError(
+                "anndata is required for AnnData output. "
+                "Install with: pip install anndata"
+            )
+        x, obs, var = self.to_tables()
+        obs = obs.copy()
+        var = var.copy()
+        obs.index = _string_index(obs, "track_name", "track_index")
+        var.index = _string_index(var, "gene_id", None)
+        return anndata.AnnData(X=x, obs=obs, var=var)
+
+
+# --------------------------------------------------------------------------- #
+# Shared metadata helpers
+# --------------------------------------------------------------------------- #
+def _track_metadata_frame(
+    track_metadata: "Sequence[TrackMetadata] | None",
+    num_tracks: int,
+) -> "pd.DataFrame":
+    import pandas as pd
+
+    if track_metadata is None:
+        return pd.DataFrame({"track_index": list(range(num_tracks))})
+    if len(track_metadata) != num_tracks:
+        raise ValueError(
+            f"track_metadata has {len(track_metadata)} entries but predictions have "
+            f"{num_tracks} tracks."
+        )
+    return pd.DataFrame([t.to_dict() for t in track_metadata])
+
+
+def _track_strands(track_frame: "pd.DataFrame") -> list[str]:
+    if "strand" not in track_frame.columns:
+        raise ValueError(
+            "strand-aware handling requires a 'strand' field on track_metadata "
+            "(none found). Pass track_metadata with per-track strand, or use "
+            "strand=None."
+        )
+    return [str(s) for s in track_frame["strand"].tolist()]
+
+
+def _apply_strand(
+    counts: Tensor,                 # [B, G, C]
+    gene_strands: Sequence[str],
+    track_frame: "pd.DataFrame",
+    strand: str | None,
+):
+    """Apply strand post-processing; returns (counts, track_frame)."""
+    if strand in (None, "ignore", "all"):
+        return counts, track_frame
+
+    if strand == "match":
+        track_strands = _track_strands(track_frame)
+        gs = list(gene_strands)
+        compat = torch.ones(len(gs), len(track_strands), dtype=torch.bool)
+        for gi, g in enumerate(gs):
+            for ci, t in enumerate(track_strands):
+                compat[gi, ci] = (t == ".") or (g == ".") or (t == g)
+        counts = counts.clone()
+        counts[:, ~compat] = float("nan")
+        return counts, track_frame
+
+    if strand == "merge":
+        return _merge_strand_pairs(counts, track_frame)
+
+    raise ValueError(
+        f"strand must be None/'ignore'/'all'/'match'/'merge', got {strand!r}"
+    )
+
+
+def _merge_strand_pairs(counts: Tensor, track_frame: "pd.DataFrame"):
+    """Sum +/- track pairs sharing all metadata except strand → ~C/2 columns."""
+    import pandas as pd
+
+    if "strand" not in track_frame.columns:
+        raise ValueError("strand='merge' requires a 'strand' field on track_metadata.")
+    group_cols = [c for c in track_frame.columns if c not in ("strand", "track_index", "track_name")]
+    if not group_cols:
+        raise ValueError(
+            "strand='merge' needs metadata fields besides strand to pair tracks "
+            "(e.g. biosample/ontology/assay)."
+        )
+    b, g, _ = counts.shape
+    groups: dict[tuple, list[int]] = {}
+    order: list[tuple] = []
+    for ci, row in track_frame.iterrows():
+        key = tuple(row[col] for col in group_cols)
+        if key not in groups:
+            groups[key] = []
+            order.append(key)
+        groups[key].append(ci)
+
+    merged = torch.zeros(b, g, len(order), dtype=counts.dtype)
+    new_rows = []
+    for out_i, key in enumerate(order):
+        idxs = groups[key]
+        merged[:, :, out_i] = counts[:, :, idxs].sum(dim=-1)
+        base = track_frame.iloc[idxs[0]].to_dict()
+        base["strand"] = "."
+        base.pop("track_index", None)
+        new_rows.append(base)
+    new_frame = pd.DataFrame(new_rows)
+    new_frame.insert(0, "track_index", list(range(len(order))))
+    return merged, new_frame
+
+
+# --------------------------------------------------------------------------- #
+# aggregate_genes — gene-body counts
+# --------------------------------------------------------------------------- #
+def aggregate_genes(
+    predictions: Tensor,
+    gene_table: "pd.DataFrame",
+    interval: tuple[str, int, int],
+    *,
+    track_metadata: "Sequence[TrackMetadata] | None" = None,
+    reduce: str = "mean",
+    strand: str | None = None,
+) -> GeneCounts:
+    """Aggregate predictions over gene **bodies** (exons + introns).
+
+    Loss-style per-gene counts, using the same gene-body masks as the training
+    gene-LFC loss (via :class:`GeneMaskExtractor`). Linear space.
+
+    Args:
+        predictions: ``[B, S, C]`` (or ``[S, C]``) RNA-seq tensor. ``S`` must span
+            the interval at the tensor's resolution.
+        gene_table: gene-body table from
+            ``extensions.finetuning.gene_annotation.cached_load_gene_table``.
+        interval: ``(chrom, start, end)`` the window covers (0-based half-open).
+        track_metadata: per-track metadata for labels + strand.
+        reduce: ``"mean"`` (length-normalized, default) or ``"sum"``.
+        strand: post-processing of the ``[genes × tracks]`` matrix —
+            ``None``/``"ignore"``/``"all"`` (no strand logic), ``"match"``
+            (NaN incompatible cells), or ``"merge"`` (sum +/- track pairs).
+    """
+    from .extensions.finetuning.gene_annotation import GeneMaskExtractor
+
+    if predictions.dim() == 2:
+        predictions = predictions.unsqueeze(0)
+    chrom, start, end = interval
+    seq_len = predictions.shape[1]
+    resolution = (end - start) // seq_len
+    if resolution < 1 or resolution * seq_len != (end - start):
+        raise ValueError(
+            f"interval width {end - start} is not divisible by sequence length {seq_len}."
+        )
+
+    extractor = GeneMaskExtractor(gene_table)
+    body_mask_np, gene_meta = extractor.extract(chrom, start, end)  # [W, 2, G] at 1bp
+    gene_strands = [str(s) for s in gene_meta["Strand"].tolist()] if len(gene_meta) else []
+
+    mask = _bp_mask_to_bins(body_mask_np.any(axis=1), resolution, seq_len)  # [S, G]
+    mask_t = torch.from_numpy(mask).to(predictions.device)
+
+    counts = aggregate_intervals(predictions, mask_t, reduce=reduce)  # [B, G, C]
+
+    track_frame = _track_metadata_frame(track_metadata, predictions.shape[-1])
+    counts, track_frame = _apply_strand(counts, gene_strands, track_frame, strand)
+    gene_frame = _gene_metadata_frame(gene_meta)
+    return GeneCounts(counts=counts, gene_metadata=gene_frame, track_metadata=track_frame, space="linear")
+
+
+# --------------------------------------------------------------------------- #
+# gene_expression — exon-based, log-space (paper Fig. 2d)
+# --------------------------------------------------------------------------- #
+def gene_expression(
+    predictions: Tensor,
+    annotation: "GeneAnnotation",
+    interval: tuple[str, int, int],
+    *,
+    track_metadata: "Sequence[TrackMetadata] | None" = None,
+    log: str | None = "log1p",
+    strand: str | None = "match",
+    min_exon_fraction: float = 0.5,
+    reduce: str = "mean",
+) -> GeneCounts:
+    """AlphaGenome Fig. 2d gene expression: log mean coverage over annotated exons.
+
+    Args:
+        predictions: ``[B, S, C]`` (or ``[S, C]``) RNA-seq tensor in experimental
+            (linear) space.
+        annotation: a :class:`GeneAnnotation` built from a GTF/parquet that
+            includes exon rows.
+        interval: ``(chrom, start, end)`` (0-based half-open).
+        track_metadata: per-track metadata (for labels + strand matching).
+        log: ``"log1p"`` (default), ``"log"``, or ``None`` for linear.
+        strand: default ``"match"`` (sense-strand expression). Same modes as
+            :func:`aggregate_genes`.
+        min_exon_fraction: keep a gene only if at least this fraction of its total
+            exonic bases falls inside the interval (paper: ≥50%).
+        reduce: ``"mean"`` (paper) or ``"sum"``.
+    """
+    per_gene = _exon_expression_matrix(
+        predictions, annotation, interval,
+        min_exon_fraction=min_exon_fraction, reduce=reduce, log=log,
+    )
+    counts = per_gene.counts           # [B, G, C]
+    gene_strands = per_gene.gene_strands
+    track_frame = _track_metadata_frame(track_metadata, counts.shape[-1])
+    counts, track_frame = _apply_strand(counts, gene_strands, track_frame, strand)
+    space = "log" if log else "linear"
+    return GeneCounts(
+        counts=counts,
+        gene_metadata=per_gene.gene_frame,
+        track_metadata=track_frame,
+        space=space,
+    )
+
+
+_GENE_FRAME_COLUMNS = ["gene_id", "gene_name", "gene_type", "strand", "Start", "End"]
+
+
+@dataclass
+class _ExonWindow:
+    """Cached per-window exon selection — the expensive annotation lookup.
+
+    Holds only compact data: the kept genes' ids/strands/metadata and their exon
+    ``[bin_start, bin_end)`` ranges. The dense ``[S, G]`` mask is rebuilt on
+    demand (cheap tensor writes), so a cache of these stays small and device- /
+    dtype-agnostic and can be reused across the pred/obs pair and across epochs.
+    """
+
+    gene_ids: list[str]
+    gene_strands: list[str]
+    gene_frame: "pd.DataFrame"
+    bin_ranges: list[list[tuple[int, int]]]
+    seq_len: int
+
+    def build_mask(self, device=None, dtype: torch.dtype = torch.float32) -> Tensor:
+        """Reconstruct the ``[S, G]`` exon mask from the cached bin-ranges."""
+        mask = torch.zeros(self.seq_len, len(self.gene_ids), dtype=dtype, device=device)
+        for g, ranges in enumerate(self.bin_ranges):
+            for b0, b1 in ranges:
+                mask[b0:b1, g] = 1
+        return mask
+
+
+@dataclass
+class _ExonExpr:
+    counts: Tensor
+    gene_frame: "pd.DataFrame"
+    gene_strands: list[str]
+    gene_ids: list[str]
+
+
+def _window_resolution(interval: tuple[str, int, int], seq_len: int) -> int:
+    _, start, end = interval
+    resolution = (end - start) // seq_len
+    if resolution < 1 or resolution * seq_len != (end - start):
+        raise ValueError(
+            f"interval width {end - start} is not divisible by sequence length {seq_len}."
+        )
+    return resolution
+
+
+def _build_exon_window(
+    annotation: "GeneAnnotation",
+    interval: tuple[str, int, int],
+    seq_len: int,
+    *,
+    min_exon_fraction: float,
+) -> _ExonWindow:
+    """Select genes in ``interval`` (≥``min_exon_fraction`` exon rule) + exon ranges.
+
+    This is the only pandas-heavy step in the metric; :func:`_get_exon_window`
+    memoizes it so it runs once per unique window across the whole run.
+    """
+    import pandas as pd
+    from .variant_scoring.types import Interval
+
+    resolution = _window_resolution(interval, seq_len)
+    chrom, start, end = interval
+    iv = Interval(chrom, start, end)
+
+    kept_ids: list[str] = []
+    kept_strands: list[str] = []
+    kept_rows: list[dict] = []
+    kept_ranges: list[list[tuple[int, int]]] = []
+
+    for gid in annotation.get_genes_in_interval(iv):
+        base = gid.split(".")[0]
+        exons = annotation._get_exons_for_gene(base)
+        if not exons:
+            continue
+        total_bp = sum(e - s for s, e in exons)
+        in_bp = sum(max(0, min(e, end) - max(s, start)) for s, e in exons)
+        if total_bp <= 0 or (in_bp / total_bp) < min_exon_fraction:
+            continue
+        ranges = annotation.get_exon_bin_ranges(gid, iv, resolution, seq_len)
+        if not ranges:
+            continue
+        info = annotation.get_gene_info(gid) or {}
+        kept_ids.append(base)
+        kept_strands.append(str(info.get("strand", ".")))
+        kept_rows.append({
+            "gene_id": info.get("gene_id", base),
+            "gene_name": info.get("gene_name"),
+            "gene_type": info.get("gene_type"),
+            "strand": info.get("strand", "."),
+            "Start": info.get("start"),
+            "End": info.get("end"),
+        })
+        kept_ranges.append(ranges)
+
+    gene_frame = (
+        pd.DataFrame(kept_rows) if kept_rows
+        else pd.DataFrame(columns=_GENE_FRAME_COLUMNS)
+    )
+    return _ExonWindow(
+        gene_ids=kept_ids,
+        gene_strands=kept_strands,
+        gene_frame=gene_frame,
+        bin_ranges=kept_ranges,
+        seq_len=seq_len,
+    )
+
+
+def _get_exon_window(
+    annotation: "GeneAnnotation",
+    interval: tuple[str, int, int],
+    seq_len: int,
+    *,
+    min_exon_fraction: float,
+    cache: dict | None = None,
+) -> _ExonWindow:
+    """:func:`_build_exon_window` with optional memoization by window key.
+
+    ``cache`` is a plain dict owned by the caller (e.g. the fine-tuning val loop
+    creates one and reuses it every epoch). Keying on
+    ``(chrom, start, end, seq_len, min_exon_fraction)`` makes the pandas lookup
+    run once per unique window across the whole run, and lets the pred/obs pair
+    share it within a window.
+    """
+    if cache is None:
+        return _build_exon_window(annotation, interval, seq_len, min_exon_fraction=min_exon_fraction)
+    key = (str(interval[0]), int(interval[1]), int(interval[2]), int(seq_len), float(min_exon_fraction))
+    window = cache.get(key)
+    if window is None:
+        window = _build_exon_window(annotation, interval, seq_len, min_exon_fraction=min_exon_fraction)
+        cache[key] = window
+    return window
+
+
+def _apply_log(counts: Tensor, log: str | None) -> Tensor:
+    if log == "log1p":
+        return torch.log1p(counts)
+    if log == "log":
+        return torch.log(counts + 1e-6)
+    if log is None:
+        return counts
+    raise ValueError(f"log must be 'log1p', 'log', or None, got {log!r}")
+
+
+def _aggregate_exon_window(
+    predictions: Tensor,
+    window: _ExonWindow,
+    *,
+    reduce: str,
+    log: str | None,
+) -> Tensor:
+    """Aggregate ``predictions`` over a prebuilt exon window → ``[B, G, C]``."""
+    if predictions.dim() == 2:
+        predictions = predictions.unsqueeze(0)
+    if window.gene_ids:
+        mask = window.build_mask(predictions.device, predictions.dtype)  # [S, G]
+        counts = aggregate_intervals(predictions, mask, reduce=reduce)   # [B, G, C]
+    else:
+        counts = predictions.new_zeros((predictions.shape[0], 0, predictions.shape[-1]))
+    return _apply_log(counts, log)
+
+
+def _exon_expression_matrix(
+    predictions: Tensor,
+    annotation: "GeneAnnotation",
+    interval: tuple[str, int, int],
+    *,
+    min_exon_fraction: float,
+    reduce: str,
+    log: str | None,
+    window: _ExonWindow | None = None,
+) -> _ExonExpr:
+    """Per-gene exon-mean (optionally log) matrix + gene metadata.
+
+    Shared by :func:`gene_expression` (serving) and the fine-tuning validation
+    metric. Applies the ≥``min_exon_fraction`` exon-containment rule; strand
+    matching is left to the caller so both consumers stay in control. Pass a
+    prebuilt ``window`` to skip the annotation lookup.
+    """
+    if predictions.dim() == 2:
+        predictions = predictions.unsqueeze(0)
+    if window is None:
+        window = _build_exon_window(
+            annotation, interval, predictions.shape[1], min_exon_fraction=min_exon_fraction
+        )
+    counts = _aggregate_exon_window(predictions, window, reduce=reduce, log=log)
+    return _ExonExpr(
+        counts=counts,
+        gene_frame=window.gene_frame,
+        gene_strands=window.gene_strands,
+        gene_ids=window.gene_ids,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Validation-metric helpers (single-window values + cross-window combine)
+# --------------------------------------------------------------------------- #
+def gene_expression_values(
+    predictions: Tensor,
+    annotation: "GeneAnnotation",
+    interval: tuple[str, int, int],
+    *,
+    resolution: int = 1,
+    min_exon_fraction: float = 0.5,
+    log: str | None = "log1p",
+    track_strands: "Sequence[str] | None" = None,
+    window_cache: dict | None = None,
+):
+    """Per-gene exon expression for a **single** window (for the val metric).
+
+    Returns ``(values, gene_ids, gene_strands)`` where ``values`` is ``[G, C]``
+    (log-space by default). If ``track_strands`` is given, strand-incompatible
+    ``(gene, track)`` cells are set to NaN (sense-strand matching, as in the
+    paper). ``resolution`` is informational here; the interval width and the
+    prediction sequence length determine the true bin size.
+
+    Args:
+        predictions: ``[S, C]`` or ``[1, S, C]`` predictions for one window.
+        annotation: a :class:`GeneAnnotation` with exon rows.
+        interval: ``(chrom, start, end)`` of this window.
+        track_strands: per-track strand chars for strand matching (optional).
+        window_cache: optional dict memoizing the per-window annotation lookup
+            (the only pandas-heavy step). Pass the same dict for the pred and obs
+            calls of a window, and reuse it across epochs, to build each window's
+            exon selection exactly once. See :func:`_get_exon_window`.
+    """
+    if predictions.dim() == 2:
+        predictions = predictions.unsqueeze(0)
+    if predictions.shape[0] != 1:
+        raise ValueError("gene_expression_values expects a single window (B==1).")
+    window = _get_exon_window(
+        annotation, interval, predictions.shape[1],
+        min_exon_fraction=min_exon_fraction, cache=window_cache,
+    )
+    counts = _aggregate_exon_window(predictions, window, reduce="mean", log=log)
+    values = counts[0]  # [G, C]
+    if track_strands is not None and values.numel() > 0:
+        values = _strand_match_values(values, window.gene_strands, track_strands)
+    return values, window.gene_ids, window.gene_strands
+
+
+def _strand_match_values(
+    values: Tensor,                 # [G, C]
+    gene_strands: Sequence[str],
+    track_strands: Sequence[str],
+) -> Tensor:
+    if values.shape[1] != len(track_strands):
+        raise ValueError(
+            f"track_strands has {len(track_strands)} entries but values have "
+            f"{values.shape[1]} tracks."
+        )
+    gs = list(gene_strands)
+    ts = [str(t) for t in track_strands]
+    compat = torch.ones(len(gs), len(ts), dtype=torch.bool)
+    for gi, g in enumerate(gs):
+        for ci, t in enumerate(ts):
+            compat[gi, ci] = (t == ".") or (g == ".") or (t == g)
+    out = values.clone()
+    out[~compat] = float("nan")
+    return out
+
+
+def combine_gene_expression(
+    windows: "Sequence[tuple[Sequence[str], Tensor, Tensor]]",
+    *,
+    eps: float = 1e-8,
+) -> dict[str, float]:
+    """Combine per-window ``(gene_ids, pred[G,C], obs[G,C])`` into Fig. 2d metrics.
+
+    Genes are deduplicated by id across windows (first occurrence wins, matching
+    the paper's "avoid duplicate genes across test intervals"). Returns the three
+    correlation flavors plus ``n_genes``.
+    """
+    seen: dict[str, int] = {}
+    pred_rows: list[Tensor] = []
+    obs_rows: list[Tensor] = []
+    for gene_ids, pred, obs in windows:
+        if pred.numel() == 0:
+            continue
+        for gi, gid in enumerate(gene_ids):
+            if gid in seen:
+                continue
+            seen[gid] = len(pred_rows)
+            pred_rows.append(pred[gi].float().cpu())
+            obs_rows.append(obs[gi].float().cpu())
+    if len(pred_rows) < 2:
+        return {
+            "across_genes": float("nan"),
+            "across_genes_norm": float("nan"),
+            "across_tracks_norm": float("nan"),
+            "n_genes": len(pred_rows),
+        }
+    pred_m = torch.stack(pred_rows, dim=0)  # [G_total, C]
+    obs_m = torch.stack(obs_rows, dim=0)
+    result = gene_expression_correlations(pred_m, obs_m, eps=eps)
+    result["n_genes"] = len(pred_rows)
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# small utilities
+# --------------------------------------------------------------------------- #
+def _string_index(frame: "pd.DataFrame", primary: str, fallback: str | None):
+    """A unique string index for AnnData obs/var names (primary, else fallback)."""
+    if primary in frame.columns:
+        idx = frame[primary].astype(str)
+        if idx.is_unique:
+            return idx.values
+    if fallback is not None and fallback in frame.columns:
+        return frame[fallback].astype(str).values
+    return frame.index.astype(str)
+
+
+def _bp_mask_to_bins(bp_mask, resolution: int, seq_len: int):
+    """Downsample a base-pair ``[W, G]`` bool mask to ``[S, G]`` bins (max-pool)."""
+    import numpy as np
+
+    if resolution == 1:
+        return np.ascontiguousarray(bp_mask.astype(bool))
+    w, g = bp_mask.shape
+    usable = seq_len * resolution
+    if w < usable:
+        pad = np.zeros((usable - w, g), dtype=bool)
+        bp_mask = np.concatenate([bp_mask, pad], axis=0)
+    bp_mask = bp_mask[:usable]
+    return bp_mask.reshape(seq_len, resolution, g).any(axis=1)
+
+
+def _gene_metadata_frame(gene_meta: "pd.DataFrame") -> "pd.DataFrame":
+    """Normalize a GeneMaskExtractor metadata slice to the GeneCounts var schema."""
+    import pandas as pd
+
+    if gene_meta is None or len(gene_meta) == 0:
+        return pd.DataFrame(columns=["gene_id", "gene_name", "gene_type", "strand", "Start", "End"])
+    out = pd.DataFrame({
+        "gene_id": gene_meta.get("gene_id"),
+        "gene_name": gene_meta.get("gene_name"),
+        "gene_type": gene_meta.get("gene_type"),
+        "strand": gene_meta.get("Strand"),
+        "Start": gene_meta.get("Start"),
+        "End": gene_meta.get("End"),
+    })
+    return out.reset_index(drop=True)

--- a/src/alphagenome_pytorch/extensions/finetuning/datasets.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/datasets.py
@@ -40,7 +40,7 @@ import json
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import numpy as np
 import torch
@@ -963,9 +963,13 @@ class MultimodalDataset(Dataset):
         >>> # modality_targets = {"atac": {1: tensor, 128: tensor}, "rna_seq": {...}}
     """
 
-    def __init__(self, datasets: dict[str, GenomicDataset]):
+    def __init__(self, datasets: dict[str, GenomicDataset], return_coords: bool = False):
         self.datasets = datasets
         self.modalities = list(datasets.keys())
+        # When True, __getitem__ appends the window's (chrom, start, end) coords
+        # as a trailing tuple element. Used by the gene-expression validation
+        # metric, which needs per-window coordinates to build exon masks.
+        self.return_coords = return_coords
 
         # Verify all datasets have the same length
         lengths = {name: len(ds) for name, ds in datasets.items()}
@@ -1014,23 +1018,40 @@ class MultimodalDataset(Dataset):
                 targets_dict = result[1]
             modality_targets[modality] = targets_dict
 
+        # Optional trailing extras, in a fixed order the collate can sniff by
+        # type: gene_mask (Tensor) then coords (tuple). Both are optional.
+        extras: list = []
         if gene_mask is not None:
-            return sequence, modality_targets, gene_mask
+            extras.append(gene_mask)
+        if self.return_coords:
+            extras.append(self._primary_dataset._positions_list[idx])
+
+        if extras:
+            return (sequence, modality_targets, *extras)
         return sequence, modality_targets
 
 
 def collate_multimodal(
-    batch: list[tuple[torch.Tensor, dict[str, dict[int, torch.Tensor]]]],
-) -> tuple[torch.Tensor, dict[str, dict[int, torch.Tensor]]]:
+    batch: list[tuple],
+) -> tuple:
     """Collate function for MultimodalDataset.
 
     Args:
-        batch: List of (sequence, modality_targets) tuples.
+        batch: List of tuples, each ``(sequence, modality_targets)`` optionally
+            followed by extras — a ``gene_mask`` tensor (training gene-LFC loss)
+            and/or a ``(chrom, start, end)`` coords tuple (gene-expression
+            validation metric). Extras are identified by type, not position.
 
     Returns:
-        Tuple of (sequences, modality_targets) where:
-            - sequences: Stacked sequences (batch, seq_len, 4)
-            - modality_targets: Dict of modality -> {resolution -> (batch, out_len, n_tracks)}
+        ``(sequences, modality_targets)`` when there are no extras, otherwise
+        ``(sequences, modality_targets, extras)`` where ``extras`` is a dict
+        with optional keys:
+            - ``"gene_mask"``: stacked ``(batch, seq_len, 2, g_max)`` bool masks
+            - ``"coords"``: list of per-sample ``(chrom, start, end)`` tuples
+
+        Historically this collate dropped everything past ``item[1]``, silently
+        discarding the gene_mask so the gene-LFC training loss never fired;
+        preserving extras here is what makes that loss (and the val metric) work.
     """
     sequences = torch.stack([item[0] for item in batch])
 
@@ -1045,6 +1066,19 @@ def collate_multimodal(
                 item[1][modality][res] for item in batch
             ])
 
+    # Collate optional trailing extras. Each item carries the same schema, so we
+    # sniff types from the first item: a Tensor is the gene_mask, anything else
+    # (a coords tuple) is coordinates.
+    extras: dict[str, Any] = {}
+    for pos in range(2, len(batch[0])):
+        sample = batch[0][pos]
+        if isinstance(sample, torch.Tensor):
+            extras["gene_mask"] = torch.stack([item[pos] for item in batch])
+        else:
+            extras["coords"] = [tuple(item[pos]) for item in batch]
+
+    if extras:
+        return sequences, modality_targets, extras
     return sequences, modality_targets
 
 

--- a/src/alphagenome_pytorch/extensions/finetuning/training.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/training.py
@@ -709,7 +709,7 @@ def _gene_expr_metrics(
     modality: str,
     world_size: int = 1,
 ) -> dict[str, float]:
-    """Reduce accumulated per-window ``(gene_ids, pred, obs)`` to Fig. 2d metrics.
+    """Reduce accumulated per-window ``(gene_ids, pred, obs)`` to gene-expression correlations.
 
     Gathers windows across ranks (DDP), deduplicates genes, and returns the three
     correlation flavors plus the gene count under ``{modality}_gene_log_expr_*``
@@ -1700,7 +1700,7 @@ def validate_multihead(
         encoder_only: If True, run only the CNN encoder and pass raw encoder output
             (B, S//128, 1536) to all heads as resolution 128.
         gene_annotation: Optional ``GeneAnnotation`` (with exon rows) enabling the
-            paper's Fig. 2d gene-expression validation metric for
+            gene-expression validation metric for
             ``gene_expr_modality``. When set (and ``compute_pearson``), per-window
             log-mean exon coverage is aggregated for predictions and observed
             targets, deduplicated across windows, and three Pearson correlations
@@ -1712,7 +1712,7 @@ def validate_multihead(
         gene_expr_modality: Modality the gene-expression metric applies to
             (default ``"rna_seq"``).
         gene_expr_resolution: Resolution at which to compute the metric
-            (default ``1`` bp, matching the paper).
+            (default ``1`` bp).
         gene_expr_window_cache: Optional dict reused across epochs to memoize the
             per-window exon-mask lookup (the only pandas-heavy step). Create once
             in the training driver and pass it every epoch so each validation
@@ -1842,7 +1842,7 @@ def validate_multihead(
                         accumulated_pred_counts[modality][res].append(pred_unscaled.sum(dim=1).float().cpu())
                         accumulated_true_counts[modality][res].append(targets.sum(dim=1).float().cpu())
 
-                        # Exon-based gene-expression metric (paper Fig. 2d).
+                        # Exon-based gene-expression metric.
                         if (
                             gene_expr_enabled
                             and modality == gene_expr_modality
@@ -1909,7 +1909,7 @@ def validate_multihead(
                     else:
                         metrics[f"{modality}_{res}bp_count_pearson_r"] = float("nan")
 
-    # Exon-based gene-expression metric (paper Fig. 2d): gather per-window
+    # Exon-based gene-expression metric: gather per-window
     # (gene_ids, pred, obs) across ranks, dedup genes, and emit three Pearsons.
     if gene_expr_enabled:
         metrics.update(_gene_expr_metrics(

--- a/src/alphagenome_pytorch/extensions/finetuning/training.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/training.py
@@ -651,6 +651,89 @@ def _cuda_sync(device: torch.device) -> None:
         torch.cuda.synchronize()
 
 
+def _unpack_batch(batch_data) -> tuple:
+    """Unpack a ``collate_multimodal`` batch into ``(sequences, targets, extras)``.
+
+    ``collate_multimodal`` yields a 2-tuple ``(sequences, modality_targets)`` or a
+    3-tuple with a trailing ``extras`` dict (``{"gene_mask", "coords"}``). This
+    normalizes both to a 3-tuple with ``extras`` defaulting to an empty dict.
+    """
+    if len(batch_data) == 3:
+        sequences, modality_targets, extras = batch_data
+    else:
+        sequences, modality_targets = batch_data
+        extras = {}
+    return sequences, modality_targets, extras
+
+
+def _accumulate_gene_expr_windows(
+    windows: list,
+    *,
+    pred_unscaled: Tensor,
+    targets: Tensor,
+    coords: list,
+    annotation: Any,
+    track_strands: list[str] | None,
+    window_cache: dict | None = None,
+) -> None:
+    """Append per-window ``(gene_ids, pred[G,C], obs[G,C])`` for the val metric.
+
+    For each window in the batch, build exon masks (≥50%-exon rule, strand-matched
+    to ``track_strands``) and aggregate log-mean exon coverage for the predicted
+    and observed RNA-seq signal. Windows with no qualifying gene are skipped.
+    ``window_cache`` (a plain dict reused across batches and epochs) memoizes the
+    per-window annotation lookup so it runs once per unique window, and lets the
+    pred and obs calls of a window share it.
+    """
+    from alphagenome_pytorch.aggregation import gene_expression_values
+
+    batch_size = pred_unscaled.shape[0]
+    for b in range(batch_size):
+        interval = tuple(coords[b])
+        pred_vals, gene_ids, _ = gene_expression_values(
+            pred_unscaled[b], annotation, interval,
+            log="log1p", track_strands=track_strands, window_cache=window_cache,
+        )
+        if pred_vals.numel() == 0:
+            continue
+        obs_vals, _, _ = gene_expression_values(
+            targets[b], annotation, interval,
+            log="log1p", track_strands=track_strands, window_cache=window_cache,
+        )
+        windows.append((gene_ids, pred_vals.float().cpu(), obs_vals.float().cpu()))
+
+
+def _gene_expr_metrics(
+    gene_expr_windows: list,
+    *,
+    modality: str,
+    world_size: int = 1,
+) -> dict[str, float]:
+    """Reduce accumulated per-window ``(gene_ids, pred, obs)`` to Fig. 2d metrics.
+
+    Gathers windows across ranks (DDP), deduplicates genes, and returns the three
+    correlation flavors plus the gene count under ``{modality}_gene_log_expr_*``
+    keys. Pure given ``gene_expr_windows`` (the ``world_size == 1`` path needs no
+    distributed context), so it is unit-testable without a model.
+    """
+    from alphagenome_pytorch.aggregation import combine_gene_expression
+
+    all_windows = gene_expr_windows
+    if world_size > 1:
+        gathered: list = [None] * world_size
+        dist.all_gather_object(gathered, gene_expr_windows)
+        all_windows = [w for part in gathered if part for w in part]
+
+    ge = combine_gene_expression(all_windows)
+    prefix = f"{modality}_gene_log_expr_pearson"
+    return {
+        f"{prefix}_across_genes": ge["across_genes"],
+        f"{prefix}_across_genes_norm": ge["across_genes_norm"],
+        f"{prefix}_across_tracks_norm": ge["across_tracks_norm"],
+        f"{modality}_gene_log_expr_n_genes": ge["n_genes"],
+    }
+
+
 def _compute_multinomial_resolution(
     seq_len: int,
     num_segments: int = NUM_SEGMENTS,
@@ -1313,13 +1396,11 @@ def train_epoch_multihead(
     gene_loss_weights = gene_loss_weights or {}
 
     for batch_idx, batch_data in enumerate(pbar):
-        # Dataset returns 3-tuple when gene_mask is configured, else 2-tuple.
-        if len(batch_data) == 3:
-            sequences, modality_targets, gene_mask = batch_data
+        # collate_multimodal yields an optional extras dict (gene_mask/coords).
+        sequences, modality_targets, extras = _unpack_batch(batch_data)
+        gene_mask = extras.get("gene_mask")
+        if gene_mask is not None:
             gene_mask = gene_mask.to(device)
-        else:
-            sequences, modality_targets = batch_data
-            gene_mask = None
 
         is_profiling = do_profile and batch_idx < profile_batches
 
@@ -1593,6 +1674,11 @@ def validate_multihead(
     world_size: int = 1,
     encoder_only: bool = False,
     organism: int = 0,
+    gene_annotation: Any = None,
+    gene_expr_track_strands: list[str] | None = None,
+    gene_expr_modality: str = "rna_seq",
+    gene_expr_resolution: int = 1,
+    gene_expr_window_cache: dict | None = None,
 ) -> tuple[float, dict[str, Any]]:
     """Validate model with multiple modality heads.
 
@@ -1613,6 +1699,24 @@ def validate_multihead(
         world_size: Total number of processes.
         encoder_only: If True, run only the CNN encoder and pass raw encoder output
             (B, S//128, 1536) to all heads as resolution 128.
+        gene_annotation: Optional ``GeneAnnotation`` (with exon rows) enabling the
+            paper's Fig. 2d gene-expression validation metric for
+            ``gene_expr_modality``. When set (and ``compute_pearson``), per-window
+            log-mean exon coverage is aggregated for predictions and observed
+            targets, deduplicated across windows, and three Pearson correlations
+            are emitted: ``{modality}_gene_log_expr_pearson_{across_genes,
+            across_genes_norm, across_tracks_norm}``.
+        gene_expr_track_strands: Per-track strand chars (``'+'/'-'/'.'``) for
+            ``gene_expr_modality``, used for sense-strand matching. Required for a
+            correct metric when tracks are stranded.
+        gene_expr_modality: Modality the gene-expression metric applies to
+            (default ``"rna_seq"``).
+        gene_expr_resolution: Resolution at which to compute the metric
+            (default ``1`` bp, matching the paper).
+        gene_expr_window_cache: Optional dict reused across epochs to memoize the
+            per-window exon-mask lookup (the only pandas-heavy step). Create once
+            in the training driver and pass it every epoch so each validation
+            window's gene selection is built exactly once for the whole run.
 
     Returns:
         Tuple of (avg_total_loss, metrics_dict).
@@ -1637,13 +1741,23 @@ def validate_multihead(
     accumulated_pred_counts: dict[str, dict[int, list[Tensor]]] = {m: defaultdict(list) for m in heads}
     accumulated_true_counts: dict[str, dict[int, list[Tensor]]] = {m: defaultdict(list) for m in heads}
 
+    # For the exon-based gene-expression metric: per-window (gene_ids, pred, obs).
+    gene_expr_enabled = (
+        gene_annotation is not None
+        and compute_pearson
+        and gene_expr_modality in heads
+    )
+    gene_expr_windows: list[tuple[list[str], Tensor, Tensor]] = []
+
     if is_main_process(rank):
         pbar = tqdm(val_loader, desc="Validation")
     else:
         pbar = val_loader
 
     with torch.no_grad():
-        for sequences, modality_targets in pbar:
+        for batch_data in pbar:
+            sequences, modality_targets, extras = _unpack_batch(batch_data)
+            coords = extras.get("coords")
             sequences = sequences.to(device)
             organism_idx = torch.full((sequences.shape[0],), organism, dtype=torch.long, device=device)
 
@@ -1728,6 +1842,23 @@ def validate_multihead(
                         accumulated_pred_counts[modality][res].append(pred_unscaled.sum(dim=1).float().cpu())
                         accumulated_true_counts[modality][res].append(targets.sum(dim=1).float().cpu())
 
+                        # Exon-based gene-expression metric (paper Fig. 2d).
+                        if (
+                            gene_expr_enabled
+                            and modality == gene_expr_modality
+                            and res == gene_expr_resolution
+                            and coords is not None
+                        ):
+                            _accumulate_gene_expr_windows(
+                                gene_expr_windows,
+                                pred_unscaled=pred_unscaled,
+                                targets=targets,
+                                coords=coords,
+                                annotation=gene_annotation,
+                                track_strands=gene_expr_track_strands,
+                                window_cache=gene_expr_window_cache,
+                            )
+
                 weighted_modality_loss = modality_loss * modality_weight
                 loss = loss + weighted_modality_loss
                 modality_loss_accum[modality] += modality_loss.item()
@@ -1777,6 +1908,13 @@ def validate_multihead(
                         metrics[f"{modality}_{res}bp_count_pearson_r"] = count_r.mean().item()
                     else:
                         metrics[f"{modality}_{res}bp_count_pearson_r"] = float("nan")
+
+    # Exon-based gene-expression metric (paper Fig. 2d): gather per-window
+    # (gene_ids, pred, obs) across ranks, dedup genes, and emit three Pearsons.
+    if gene_expr_enabled:
+        metrics.update(_gene_expr_metrics(
+            gene_expr_windows, modality=gene_expr_modality, world_size=world_size,
+        ))
 
     return avg_loss, metrics
 
@@ -1888,13 +2026,11 @@ def train_epoch_sequence_parallel(
     gene_loss_weights = gene_loss_weights or {}
 
     for batch_idx, batch_data in enumerate(pbar):
-        # Dataset returns 3-tuple when gene_mask is configured, else 2-tuple.
-        if len(batch_data) == 3:
-            sequences, modality_targets, gene_mask = batch_data
+        # collate_multimodal yields an optional extras dict (gene_mask/coords).
+        sequences, modality_targets, extras = _unpack_batch(batch_data)
+        gene_mask = extras.get("gene_mask")
+        if gene_mask is not None:
             gene_mask = gene_mask.to(device)
-        else:
-            sequences, modality_targets = batch_data
-            gene_mask = None
         sequences = sequences.to(device)
         organism_idx = torch.full((sequences.shape[0],), organism, dtype=torch.long, device=device)
 

--- a/src/alphagenome_pytorch/extensions/finetuning/training.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/training.py
@@ -1677,7 +1677,7 @@ def validate_multihead(
     gene_annotation: Any = None,
     gene_expr_track_strands: list[str] | None = None,
     gene_expr_modality: str = "rna_seq",
-    gene_expr_resolution: int = 1,
+    gene_expr_resolution: int | None = None,
     gene_expr_window_cache: dict | None = None,
 ) -> tuple[float, dict[str, Any]]:
     """Validate model with multiple modality heads.
@@ -1711,8 +1711,12 @@ def validate_multihead(
             correct metric when tracks are stranded.
         gene_expr_modality: Modality the gene-expression metric applies to
             (default ``"rna_seq"``).
-        gene_expr_resolution: Resolution at which to compute the metric
-            (default ``1`` bp).
+        gene_expr_resolution: Resolution of the head output the metric reads.
+            Defaults to 128 under ``encoder_only`` (those heads emit 128bp only)
+            and 1 otherwise. The metric itself is resolution-agnostic — it
+            derives bin size from the interval width — so this only selects
+            *which* head output to consume. It must be a resolution the head
+            actually emits, or no windows accumulate and the metric is NaN.
         gene_expr_window_cache: Optional dict reused across epochs to memoize the
             per-window exon-mask lookup (the only pandas-heavy step). Create once
             in the training driver and pass it every epoch so each validation
@@ -1747,6 +1751,22 @@ def validate_multihead(
         and compute_pearson
         and gene_expr_modality in heads
     )
+    # Encoder-only heads emit 128bp only, so the 1bp default would match no
+    # output and the metric would silently report NaN every epoch.
+    if gene_expr_resolution is None:
+        gene_expr_resolution = 128 if encoder_only else 1
+    if gene_expr_enabled:
+        # The metric only reads the head output at `gene_expr_resolution`. If the
+        # modality never emits it, no window ever accumulates and every epoch
+        # reports n_genes=0 with NaN correlations and no error. Fail instead.
+        available = sorted(resolution_weights.get(gene_expr_modality, {}))
+        if gene_expr_resolution not in available:
+            raise ValueError(
+                f"gene-expression metric requested at {gene_expr_resolution}bp, but "
+                f"'{gene_expr_modality}' emits {available or 'no resolutions'}"
+                + (" (encoder_only forces 128bp)" if encoder_only else "")
+                + ". Pass gene_expr_resolution matching an emitted resolution."
+            )
     gene_expr_windows: list[tuple[list[str], Tensor, Tensor]] = []
 
     if is_main_process(rank):

--- a/src/alphagenome_pytorch/extensions/inference/__init__.py
+++ b/src/alphagenome_pytorch/extensions/inference/__init__.py
@@ -32,6 +32,7 @@ from .full_chromosome import (
     GenomeSequenceProvider,
     predict_full_chromosome,
     predict_full_chromosomes_to_bigwig,
+    predict_full_chromosomes_to_anndata,
     write_bigwig,
     HEAD_CONFIGS,
 )
@@ -57,6 +58,7 @@ __all__ = [
     'GenomeSequenceProvider',
     'predict_full_chromosome',
     'predict_full_chromosomes_to_bigwig',
+    'predict_full_chromosomes_to_anndata',
     'write_bigwig',
     'HEAD_CONFIGS',
     # Region / locus / sequence prediction

--- a/src/alphagenome_pytorch/extensions/inference/full_chromosome.py
+++ b/src/alphagenome_pytorch/extensions/inference/full_chromosome.py
@@ -232,6 +232,99 @@ def _generate_tiles(
     return tiles
 
 
+def _resolve_head_config(model, head: str, resolution: int) -> dict:
+    """Resolve a head's ``{num_tracks, resolutions}`` and validate ``resolution``.
+
+    Introspects the model's live heads first (finetuned/custom heads), falling
+    back to the hardcoded ``HEAD_CONFIGS`` for stock pretrained heads.
+    """
+    _inner = getattr(model, '_orig_mod', model)  # unwrap torch.compile
+    heads = getattr(_inner, 'heads', None)
+    head_module = heads[head] if heads is not None and head in heads else None
+
+    if head_module is not None:
+        head_config = {
+            'num_tracks': head_module.num_tracks,
+            'resolutions': list(head_module.resolutions),
+        }
+    elif head in HEAD_CONFIGS:
+        head_config = HEAD_CONFIGS[head]
+    else:
+        available = list(heads.keys()) if heads is not None else list(HEAD_CONFIGS.keys())
+        raise ValueError(f"Unknown head: {head}. Available: {available}")
+
+    if resolution not in head_config['resolutions']:
+        raise ValueError(
+            f"Head '{head}' does not support resolution {resolution}. "
+            f"Supported: {head_config['resolutions']}"
+        )
+    return head_config
+
+
+def _iter_tile_predictions(
+    model,
+    genome: "GenomeSequenceProvider",
+    chrom: str,
+    head: str,
+    config: TilingConfig,
+    track_indices: list[int],
+    output_length: int,
+    *,
+    organism_index: int = 0,
+    device: str | torch.device = "cuda",
+    show_progress: bool = True,
+):
+    """Yield ``(out_start_res, kept_preds)`` for each tile's kept central region.
+
+    ``kept_preds`` is a ``[n_bins, n_tracks]`` float32 ndarray for output-resolution
+    positions ``[out_start_res, out_start_res + n_bins)``, clamped to the chromosome
+    and with the ``config.crop_bp`` edges removed. Shared by the BigWig and
+    gene-count output paths.
+    """
+    tiles = _generate_tiles(genome.chrom_sizes[chrom], config)
+    if not tiles:
+        return
+    model.eval()
+    device = torch.device(device)
+
+    n_batches = (len(tiles) + config.batch_size - 1) // config.batch_size
+    iterator = range(0, len(tiles), config.batch_size)
+    if show_progress:
+        iterator = tqdm(iterator, total=n_batches, desc=f"Predicting {chrom}")
+
+    for batch_start in iterator:
+        batch_tiles = tiles[batch_start:batch_start + config.batch_size]
+
+        sequences = [genome.fetch(chrom, ws, we) for ws, we, _, _ in batch_tiles]
+        batch_seq = torch.tensor(np.stack(sequences), device=device)
+        batch_org = torch.tensor(
+            [organism_index] * len(batch_tiles), device=device, dtype=torch.long
+        )
+
+        with torch.no_grad():
+            preds = model.predict(
+                batch_seq, batch_org,
+                resolutions=(config.resolution,), heads=(head,),
+            )
+
+        # (batch, seq_len_at_res, n_tracks)
+        head_preds = preds[head][config.resolution][:, :, track_indices].cpu().numpy()
+        del preds, batch_seq, batch_org
+
+        for i, (window_start, window_end, keep_start, keep_end) in enumerate(batch_tiles):
+            keep_start_res = keep_start // config.resolution
+            keep_end_res = keep_end // config.resolution
+            genome_pos = (window_start + keep_start) // config.resolution
+
+            out_start = max(0, genome_pos)
+            out_end = min(output_length, genome_pos + (keep_end_res - keep_start_res))
+            pred_start = keep_start_res + (out_start - genome_pos)
+            pred_end = pred_start + (out_end - out_start)
+
+            if out_start < out_end:
+                yield out_start, head_preds[i, pred_start:pred_end]
+
+
 def predict_full_chromosome(
     model,
     genome: GenomeSequenceProvider | str | Path,
@@ -262,31 +355,7 @@ def predict_full_chromosome(
     """
     config = config or TilingConfig()
 
-    # Validate head — introspect the model first, fall back to hardcoded
-    # HEAD_CONFIGS for pretrained heads.
-    _inner = getattr(model, '_orig_mod', model)  # unwrap torch.compile
-    heads = getattr(_inner, 'heads', None)
-    head_module = heads[head] if heads is not None and head in heads else None
-
-    if head_module is not None:
-        head_config = {
-            'num_tracks': head_module.num_tracks,
-            'resolutions': list(head_module.resolutions),
-        }
-    elif head in HEAD_CONFIGS:
-        head_config = HEAD_CONFIGS[head]
-    else:
-        available = list(heads.keys()) if heads is not None else list(HEAD_CONFIGS.keys())
-        raise ValueError(
-            f"Unknown head: {head}. "
-            f"Available: {available}"
-        )
-
-    if config.resolution not in head_config['resolutions']:
-        raise ValueError(
-            f"Head '{head}' does not support resolution {config.resolution}. "
-            f"Supported: {head_config['resolutions']}"
-        )
+    head_config = _resolve_head_config(model, head, config.resolution)
 
     # Setup genome provider
     if isinstance(genome, (str, Path)):
@@ -307,78 +376,22 @@ def predict_full_chromosome(
     # Initialize output array
     predictions = np.zeros((output_length, n_output_tracks), dtype=np.float32)
 
-    # Generate tiles
     tiles = _generate_tiles(chrom_length, config)
-
     if len(tiles) == 0:
         return predictions
 
-    # Process in batches
-    model.eval()
-    device = torch.device(device)
-
-    n_batches = (len(tiles) + config.batch_size - 1) // config.batch_size
-
     if show_progress:
-        output_mb = predictions.nbytes / 1e6
+        n_batches = (len(tiles) + config.batch_size - 1) // config.batch_size
         print(f"  Tiles: {len(tiles)}, Batches: {n_batches}")
-        print(f"  Output array: {output_mb:.1f} MB ({output_length:,} x {n_output_tracks} float32)")
+        print(f"  Output array: {predictions.nbytes / 1e6:.1f} MB "
+              f"({output_length:,} x {n_output_tracks} float32)")
 
-    iterator = range(0, len(tiles), config.batch_size)
-    if show_progress:
-        iterator = tqdm(iterator, total=n_batches, desc=f"Predicting {chrom}")
-
-    for batch_start in iterator:
-        batch_tiles = tiles[batch_start:batch_start + config.batch_size]
-
-        # Extract sequences
-        sequences = []
-        for window_start, window_end, _, _ in batch_tiles:
-            seq = genome.fetch(chrom, window_start, window_end)
-            sequences.append(seq)
-
-        # Stack and predict
-        batch_seq = torch.tensor(np.stack(sequences), device=device)
-        batch_org = torch.tensor(
-            [organism_index] * len(batch_tiles),
-            device=device,
-            dtype=torch.long,
-        )
-
-        with torch.no_grad():
-            preds = model.predict(
-                batch_seq,
-                batch_org,
-                resolutions=(config.resolution,),
-                heads=(head,),
-            )
-
-        # Extract predictions for the requested head
-        # Output shape: (batch, seq_len_at_res, n_tracks)
-        head_preds = preds[head][config.resolution]
-        head_preds = head_preds[:, :, track_indices].cpu().numpy()
-
-        del preds, batch_seq, batch_org
-
-        # Place kept regions into output
-        for i, (window_start, window_end, keep_start, keep_end) in enumerate(batch_tiles):
-            # Convert to output resolution
-            keep_start_res = keep_start // config.resolution
-            keep_end_res = keep_end // config.resolution
-
-            # Genomic position of kept region start (at output resolution)
-            genome_pos = (window_start + keep_start) // config.resolution
-
-            # Handle edges
-            out_start = max(0, genome_pos)
-            out_end = min(output_length, genome_pos + (keep_end_res - keep_start_res))
-
-            # Corresponding indices in the prediction
-            pred_start = keep_start_res + (out_start - genome_pos)
-            pred_end = pred_start + (out_end - out_start)
-
-            if out_start < out_end:
-                predictions[out_start:out_end] = head_preds[i, pred_start:pred_end]
+    # Stitch each tile's kept region into the full-chromosome array.
+    for out_start, kept in _iter_tile_predictions(
+        model, genome, chrom, head, config, track_indices, output_length,
+        organism_index=organism_index, device=device, show_progress=show_progress,
+    ):
+        predictions[out_start:out_start + kept.shape[0]] = kept
 
     return predictions
 
@@ -537,3 +550,124 @@ def predict_full_chromosomes_to_bigwig(
         print(f"  Wrote {len(written)} file(s): {[p.name for p in written]}")
 
     return results
+
+
+def _build_track_frame(track_indices, track_names=None, track_strands=None):
+    """A ``[C]``-row track-metadata DataFrame for the AnnData ``obs`` table."""
+    import pandas as pd
+
+    n = len(track_indices)
+    data: dict = {"track_index": list(track_indices)}
+    if track_names is not None:
+        if len(track_names) != n:
+            raise ValueError(f"track_names has {len(track_names)} entries but "
+                             f"{n} tracks are being aggregated.")
+        data["track_name"] = list(track_names)
+    if track_strands is not None:
+        if len(track_strands) != n:
+            raise ValueError(f"track_strands has {len(track_strands)} entries but "
+                             f"{n} tracks are being aggregated.")
+        data["strand"] = [str(s) for s in track_strands]
+    return pd.DataFrame(data)
+
+
+def predict_full_chromosomes_to_anndata(
+    model,
+    fasta_path: str | Path,
+    annotation_path: str | Path,
+    head: str,
+    *,
+    output_path: str | Path | None = None,
+    chromosomes: list[str] | None = None,
+    config: TilingConfig | None = None,
+    track_indices: list[int] | None = None,
+    track_names: list[str] | None = None,
+    track_strands: list[str] | None = None,
+    over: str = "exons",
+    reduce: str = "sum",
+    log: bool = False,
+    strand: str | None = None,
+    organism_index: int = 0,
+    device: str | torch.device = "cuda",
+    show_progress: bool = True,
+):
+    """Aggregate whole-chromosome predictions into a per-gene × per-track table.
+
+    Tiles each chromosome, streams every tile's predictions through a
+    :class:`~alphagenome_pytorch.aggregation.GeneCountAccumulator`, and returns a
+    single :class:`~alphagenome_pytorch.aggregation.GeneCounts` (``.to_anndata()``
+    for an AnnData).
+
+    Args:
+        model: loaded AlphaGenome model.
+        fasta_path: reference genome FASTA (or a prebuilt provider).
+        annotation_path: GTF/parquet gene annotation (or a prebuilt
+            ``GeneAnnotation``); needs exon rows when ``over="exons"``.
+        head: prediction head (e.g. ``"rna_seq"``).
+        output_path: optional ``.h5ad`` to write (via ``GeneCounts.to_anndata``).
+        chromosomes: default ``chr1..22, chrX``.
+        config: :class:`TilingConfig` (use ``crop_bp`` to trim edge artifacts).
+        track_indices / track_names / track_strands: track subset + labels; strands
+            are required for ``strand="match"``.
+        over: ``"exons"`` (default) or ``"gene_body"``.
+        reduce: ``"sum"`` (default, count-like) or ``"mean"``.
+        log: if True, apply ``log1p`` after the reduce.
+        strand: ``None``/``"match"``/``"merge"`` post-processing.
+
+    Returns:
+        A :class:`GeneCounts` with ``B == 1`` (whole run collapsed to one table).
+    """
+    from ...aggregation import GeneCountAccumulator
+    from ...variant_scoring.annotations import GeneAnnotation
+
+    config = config or TilingConfig()
+    if chromosomes is None:
+        chromosomes = [f"chr{i}" for i in range(1, 23)] + ["chrX"]
+
+    # `fasta_path` / `annotation_path` accept prebuilt objects too (handy for tests
+    # and for reusing an already-loaded genome / annotation).
+    if isinstance(fasta_path, GenomeSequenceProvider):
+        genome = fasta_path
+    else:
+        genome = GenomeSequenceProvider(fasta_path, chromosomes=set(chromosomes), cache=True)
+    chromosomes = [c for c in chromosomes if c in genome.chrom_sizes]
+    if not chromosomes:
+        raise ValueError("No valid chromosomes found in genome")
+
+    head_config = _resolve_head_config(model, head, config.resolution)
+    if track_indices is None:
+        track_indices = list(range(head_config['num_tracks']))
+
+    # Build (and length-validate) the track-metadata frame up front, so a
+    # track_names / track_strands mismatch fails now instead of after inference.
+    track_frame = _build_track_frame(track_indices, track_names, track_strands)
+
+    annotation = (
+        annotation_path if isinstance(annotation_path, GeneAnnotation)
+        else GeneAnnotation(annotation_path)
+    )
+    accumulator = GeneCountAccumulator(
+        annotation, resolution=config.resolution, over=over, reduce=reduce,
+    )
+
+    print(f"Aggregating {head} over {over} for {len(chromosomes)} chromosomes: {chromosomes}")
+    for chrom in chromosomes:
+        print(f"\nProcessing {chrom}...")
+        output_length = genome.chrom_sizes[chrom] // config.resolution
+        for out_start, kept in _iter_tile_predictions(
+            model, genome, chrom, head, config, track_indices, output_length,
+            organism_index=organism_index, device=device, show_progress=show_progress,
+        ):
+            start_bp = out_start * config.resolution
+            end_bp = start_bp + kept.shape[0] * config.resolution
+            accumulator.add_tile(kept, chrom, start_bp, end_bp)
+        print(f"  Genes so far: {accumulator.n_genes}")
+
+    gene_counts = accumulator.to_gene_counts(track_metadata=track_frame, log=log, strand=strand)
+
+    if output_path is not None:
+        adata = gene_counts.to_anndata()
+        adata.write_h5ad(str(output_path))
+        print(f"\nWrote AnnData ({adata.shape[0]} tracks x {adata.shape[1]} genes) to {output_path}")
+
+    return gene_counts

--- a/src/alphagenome_pytorch/extensions/inference/full_chromosome.py
+++ b/src/alphagenome_pytorch/extensions/inference/full_chromosome.py
@@ -567,6 +567,8 @@ def _build_track_frame(track_indices, track_names=None, track_strands=None):
         if len(track_strands) != n:
             raise ValueError(f"track_strands has {len(track_strands)} entries but "
                              f"{n} tracks are being aggregated.")
+        from ...aggregation import _validate_track_strands
+        _validate_track_strands(track_strands)
         data["strand"] = [str(s) for s in track_strands]
     return pd.DataFrame(data)
 
@@ -646,6 +648,12 @@ def predict_full_chromosomes_to_anndata(
         annotation_path if isinstance(annotation_path, GeneAnnotation)
         else GeneAnnotation(annotation_path)
     )
+    if over == "exons" and not annotation.has_exon_annotations():
+        raise ValueError(
+            "over='exons' needs an annotation with exon rows, but none were found "
+            f"in {annotation_path!r}. Provide a GTF/parquet that includes exon "
+            "features, or use over='gene_body'."
+        )
     accumulator = GeneCountAccumulator(
         annotation, resolution=config.resolution, over=over, reduce=reduce,
     )

--- a/src/alphagenome_pytorch/variant_scoring/annotations.py
+++ b/src/alphagenome_pytorch/variant_scoring/annotations.py
@@ -61,7 +61,14 @@ class GeneAnnotation:
         self.annotation_path = Path(annotation_path)
         self._df: pd.DataFrame | None = None
         self._gene_index: dict[str, GeneInfo] = {}
+        # Exon coordinates by (versionless) gene id. Built once, lazily, in a
+        # single groupby pass — see `_get_exons_for_gene`.
         self._exon_cache: dict[str, list[tuple[int, int]]] = {}
+        self._exon_index_built: bool = False
+        # Per-chromosome start-sorted gene index for fast interval overlap
+        # queries; built lazily in `get_genes_in_interval`.
+        self._interval_index: dict[str, dict[str, Any]] | None = None
+        self._max_gene_span: int = 0
 
         # Detect file format
         suffix = self.annotation_path.suffix.lower()
@@ -140,43 +147,46 @@ class GeneAnnotation:
                 strand=row.get('Strand', '.'),
             )
 
-    def _get_exons_for_gene(self, gene_id: str) -> list[tuple[int, int]]:
-        """Get exon coordinates for a gene.
+    @staticmethod
+    def _merge_intervals(intervals: list[tuple[int, int]]) -> list[tuple[int, int]]:
+        """Sort and merge overlapping/adjacent (start, end) intervals."""
+        if not intervals:
+            return []
+        intervals = sorted(intervals)
+        merged = [intervals[0]]
+        for start, end in intervals[1:]:
+            if start <= merged[-1][1]:
+                merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+            else:
+                merged.append((start, end))
+        return merged
 
-        Args:
-            gene_id: Gene ID (without version)
+    def _build_exon_index(self) -> None:
+        """Index merged exon coordinates by versionless gene id in one pass.
 
-        Returns:
-            List of (start, end) tuples for exons (0-based coordinates)
+        Replaces per-gene full-frame filtering: a single ``groupby`` over the
+        exon rows populates ``_exon_cache`` for every gene at once, so
+        ``_get_exons_for_gene`` is O(1) even on a cold cache. Built lazily the
+        first time exons are requested, so gene-only consumers never pay for it.
         """
-        if gene_id in self._exon_cache:
-            return self._exon_cache[gene_id]
-
-        # Filter for exons of this gene
-        # Match both versioned and unversioned gene IDs
         exons_df = self.df[self.df['Feature'] == 'exon']
-        exons_df = exons_df[exons_df['gene_id'].str.split('.').str[0] == gene_id]
+        if not exons_df.empty:
+            # Group exon (start, end) pairs by versionless gene id, then merge.
+            base_ids = exons_df['gene_id'].str.split('.').str[0].to_numpy()
+            starts = exons_df['Start'].astype(int).to_numpy()
+            ends = exons_df['End'].astype(int).to_numpy()
+            by_gene: dict[str, list[tuple[int, int]]] = {}
+            for gid, s, e in zip(base_ids, starts, ends):
+                by_gene.setdefault(gid, []).append((int(s), int(e)))
+            for gid, ivals in by_gene.items():
+                self._exon_cache[gid] = self._merge_intervals(ivals)
+        self._exon_index_built = True
 
-        exons = []
-        for _, row in exons_df.iterrows():
-            # Coordinates are 0-based
-            start = int(row['Start'])
-            end = int(row['End'])
-            exons.append((start, end))
-
-        # Merge overlapping exons
-        if exons:
-            exons.sort()
-            merged = [exons[0]]
-            for start, end in exons[1:]:
-                if start <= merged[-1][1]:
-                    merged[-1] = (merged[-1][0], max(merged[-1][1], end))
-                else:
-                    merged.append((start, end))
-            exons = merged
-
-        self._exon_cache[gene_id] = exons
-        return exons
+    def _get_exons_for_gene(self, gene_id: str) -> list[tuple[int, int]]:
+        """Get merged exon coordinates for a gene (0-based (start, end) tuples)."""
+        if not self._exon_index_built:
+            self._build_exon_index()
+        return self._exon_cache.get(gene_id, [])
 
     def get_gene_info(self, gene_id: str) -> dict[str, Any] | None:
         """Get information for a gene.
@@ -221,32 +231,73 @@ class GeneAnnotation:
         Returns:
             List of gene IDs (without version)
         """
-        # Ensure index is built by accessing df
-        _ = self.df
+        import bisect
 
-        genes = []
-        chrom = interval.chromosome
+        if self._interval_index is None:
+            self._build_interval_index()
 
-        for gene_id, info in self._gene_index.items():
-            # Check chromosome match (handle chr prefix)
-            if info.chromosome != chrom:
-                if info.chromosome == 'chr' + chrom or chrom == 'chr' + info.chromosome:
-                    pass  # Match with chr prefix difference
-                else:
-                    continue
-
-            # Check overlap
-            if info.end <= interval.start or info.start >= interval.end:
+        genes: list[tuple[int, str]] = []  # (insertion_rank, gene_id)
+        for key in self._matching_chrom_keys(interval.chromosome):
+            entry = self._interval_index.get(key)
+            if entry is None:
                 continue
+            starts = entry['starts']
+            ends = entry['ends']
+            ids = entry['ids']
+            ranks = entry['ranks']
+            # An overlapping gene has start < interval.end and start >=
+            # interval.start - max_gene_span (any gene starting earlier than that
+            # cannot reach into the interval). Bisect both bounds on the
+            # start-sorted array, then filter end > interval.start.
+            lo = bisect.bisect_left(starts, interval.start - self._max_gene_span)
+            hi = bisect.bisect_left(starts, interval.end)
+            for i in range(lo, hi):
+                if ends[i] <= interval.start:
+                    continue  # start < interval.end already guaranteed
+                if gene_types is not None:
+                    if self._gene_index[ids[i]].gene_type not in gene_types:
+                        continue
+                genes.append((ranks[i], ids[i]))
 
-            # Check gene type if specified
-            if gene_types is not None:
-                if info.gene_type not in gene_types:
-                    continue
+        # Preserve the original _gene_index insertion order of the results.
+        genes.sort()
+        return [gid for _, gid in genes]
 
-            genes.append(gene_id)
+    def _matching_chrom_keys(self, chrom: str) -> list[str]:
+        """Index keys matching a query chromosome, tolerating 'chr' prefix diffs.
 
-        return genes
+        Mirrors the original overlap check: a gene on chromosome ``K`` matches a
+        query ``Q`` when ``K == Q``, ``K == 'chr'+Q``, or ``Q == 'chr'+K``.
+        """
+        keys = {chrom, 'chr' + chrom}
+        if chrom.startswith('chr'):
+            keys.add(chrom[3:])
+        return list(keys)
+
+    def _build_interval_index(self) -> None:
+        """Per-chromosome, start-sorted gene arrays for O(log G + k) overlap."""
+        _ = self.df  # ensure gene index is built
+        by_chrom: dict[str, list[tuple[int, int, str, int]]] = {}
+        max_span = 0
+        for rank, (gene_id, info) in enumerate(self._gene_index.items()):
+            by_chrom.setdefault(info.chromosome, []).append(
+                (info.start, info.end, gene_id, rank)
+            )
+            span = info.end - info.start
+            if span > max_span:
+                max_span = span
+
+        index: dict[str, dict[str, Any]] = {}
+        for chrom, entries in by_chrom.items():
+            entries.sort(key=lambda e: e[0])  # by start
+            index[chrom] = {
+                'starts': [e[0] for e in entries],
+                'ends': [e[1] for e in entries],
+                'ids': [e[2] for e in entries],
+                'ranks': [e[3] for e in entries],
+            }
+        self._interval_index = index
+        self._max_gene_span = max_span
 
     def get_genes_overlapping_variant(
         self,
@@ -313,31 +364,40 @@ class GeneAnnotation:
         Returns:
             Boolean mask tensor of shape (seq_length,) where True = exonic
         """
-        gene_id_base = gene_id.split('.')[0]
-        exons = self._get_exons_for_gene(gene_id_base)
-
         mask = torch.zeros(seq_length, dtype=torch.bool, device=device)
+        for bin_start, bin_end in self.get_exon_bin_ranges(
+            gene_id, interval, resolution, seq_length
+        ):
+            mask[bin_start:bin_end] = True
+        return mask
 
+    def get_exon_bin_ranges(
+        self,
+        gene_id: str,
+        interval: 'Interval',
+        resolution: int,
+        seq_length: int,
+    ) -> list[tuple[int, int]]:
+        """Exonic ``[bin_start, bin_end)`` ranges for a gene within an interval.
+
+        The compact form underlying :meth:`get_exon_mask` — a few int pairs per
+        gene instead of a dense ``[seq_length]`` tensor. Cheap to cache and to
+        rebuild a mask from (see ``aggregation._ExonWindow``).
+        """
+        exons = self._get_exons_for_gene(gene_id.split('.')[0])
+        ranges: list[tuple[int, int]] = []
         for exon_start, exon_end in exons:
-            # Convert to interval-relative coordinates
+            # Interval-relative coordinates
             rel_start = max(0, exon_start - interval.start)
             rel_end = min(interval.width, exon_end - interval.start)
-
             if rel_start >= interval.width or rel_end <= 0:
                 continue
-
-            # Convert to bin coordinates
-            bin_start = rel_start // resolution
-            bin_end = (rel_end + resolution - 1) // resolution  # Ceiling division
-
-            # Clamp to sequence length
-            bin_start = max(0, min(bin_start, seq_length))
-            bin_end = max(0, min(bin_end, seq_length))
-
+            # Bin coordinates (ceiling division on the end), clamped.
+            bin_start = max(0, min(rel_start // resolution, seq_length))
+            bin_end = max(0, min((rel_end + resolution - 1) // resolution, seq_length))
             if bin_start < bin_end:
-                mask[bin_start:bin_end] = True
-
-        return mask
+                ranges.append((bin_start, bin_end))
+        return ranges
 
     def get_gene_mask(
         self,

--- a/src/alphagenome_pytorch/variant_scoring/annotations.py
+++ b/src/alphagenome_pytorch/variant_scoring/annotations.py
@@ -169,6 +169,9 @@ class GeneAnnotation:
         ``_get_exons_for_gene`` is O(1) even on a cold cache. Built lazily the
         first time exons are requested, so gene-only consumers never pay for it.
         """
+        if 'Feature' not in self.df.columns:
+            self._exon_index_built = True
+            return
         exons_df = self.df[self.df['Feature'] == 'exon']
         if not exons_df.empty:
             # Group exon (start, end) pairs by versionless gene id, then merge.
@@ -187,6 +190,12 @@ class GeneAnnotation:
         if not self._exon_index_built:
             self._build_exon_index()
         return self._exon_cache.get(gene_id, [])
+
+    def has_exon_annotations(self) -> bool:
+        """True if the annotation contains any exon rows (needed for exon masks)."""
+        if not self._exon_index_built:
+            self._build_exon_index()
+        return bool(self._exon_cache)
 
     def get_gene_info(self, gene_id: str) -> dict[str, Any] | None:
         """Get information for a gene.

--- a/src/alphagenome_pytorch/variant_scoring/annotations.py
+++ b/src/alphagenome_pytorch/variant_scoring/annotations.py
@@ -3,7 +3,7 @@
 This module provides classes for loading and querying gene annotations
 from GTF/GFF or Parquet files for use with gene-centric variant scorers.
 
-For best performance, convert GTF files to Parquet format using:
+Convert GTF files to Parquet with:
     python scripts/convert_gtf_to_parquet.py --input annotation.gtf --output annotation.parquet
 """
 
@@ -32,35 +32,78 @@ class GeneInfo:
     strand: str
 
 
-class GeneAnnotation:
-    """Load and query gene/exon annotations from GTF or Parquet files.
+_REQUIRED_COLUMNS = ('Feature', 'Chromosome', 'Start', 'End', 'gene_id')
 
-    Supports both GTF/GFF files (using pyranges) and pre-converted Parquet files.
-    Parquet files load ~50-100x faster than GTF files.
+
+def _validate_annotation_frame(df: pd.DataFrame, source: str) -> None:
+    """Reject frames GeneAnnotation cannot index, at the point of supply.
+
+    Gene lookups are driven entirely by ``Feature == 'gene'`` rows, so a frame
+    without them answers every query with an empty result instead of raising.
+    Filtering a GTF on a transcript-level attribute (``tag``, ``transcript_type``)
+    drops those rows — fail loudly instead.
+    """
+    missing = [c for c in _REQUIRED_COLUMNS if c not in df.columns]
+    if missing:
+        raise ValueError(
+            f"Annotation from {source} is missing required column(s): {missing}. "
+            f"Expected at least {list(_REQUIRED_COLUMNS)}."
+        )
+    if not (df['Feature'] == 'gene').any():
+        raise ValueError(
+            f"Annotation from {source} contains no `Feature == 'gene'` rows, so "
+            "every gene lookup would return empty. Filtering a GTF on a "
+            "transcript-level attribute (e.g. tag == 'MANE_Select') drops them — "
+            "keep the gene rows alongside the filtered transcript/exon rows."
+        )
+
+
+class GeneAnnotation:
+    """Load and query gene/exon annotations from a GTF, Parquet file, or DataFrame.
+
+    Accepts GTF/GFF files (via pyranges), Parquet files, or an in-memory
+    DataFrame in the same layout — one row per GTF feature, with at least
+    ``Feature``, ``Chromosome``, ``Start``, ``End``, and ``gene_id`` columns,
+    and coordinates 0-based half-open.
+
+    Passing a DataFrame is the supported way to restrict the annotation: filter
+    it with pandas first. Keep the ``Feature == 'gene'`` rows — gene lookups are
+    built from those, and a frame without them is rejected at construction.
 
     To convert GTF to Parquet:
         python scripts/convert_gtf_to_parquet.py --input annotation.gtf --output annotation.parquet
 
     Example:
-        >>> # Fast loading from Parquet (recommended)
         >>> annotation = GeneAnnotation('/path/to/gencode.parquet')
         >>> genes = annotation.get_genes_in_interval(interval)
         >>>
-        >>> # Traditional GTF loading (slower)
         >>> annotation = GeneAnnotation('/path/to/gencode.gtf')
+        >>>
+        >>> # Pre-filtered DataFrame (e.g. protein-coding only). `gene_type` is
+        >>> # present on gene and exon rows alike, so one predicate covers both.
+        >>> import pandas as pd
+        >>> gtf = pd.read_parquet('/path/to/gencode.parquet')
+        >>> annotation = GeneAnnotation(gtf[gtf.gene_type == 'protein_coding'])
     """
 
-    def __init__(self, annotation_path: str | Path):
-        """Initialize with path to annotation file.
+    def __init__(self, annotation: str | Path | pd.DataFrame):
+        """Initialize from an annotation path or a DataFrame.
 
         Args:
-            annotation_path: Path to annotation file. Supports:
-                - Parquet files (.parquet) - fast loading, recommended
-                - GTF/GFF files (.gtf, .gff, .gff3) - slow, requires pyranges
+            annotation: One of:
+                - Parquet file path (.parquet)
+                - GTF/GFF file path (.gtf, .gff, .gff3), requires pyranges
+                - A pandas DataFrame in GTF layout (see the class docstring).
+                  Held by reference and not copied, so do not mutate it
+                  afterwards; the indices built from it would go stale.
+
+        Raises:
+            ValueError: If a DataFrame is missing required columns or has no
+                ``Feature == 'gene'`` rows.
         """
-        self.annotation_path = Path(annotation_path)
         self._df: pd.DataFrame | None = None
         self._gene_index: dict[str, GeneInfo] = {}
+        self._gene_index_built: bool = False
         # Exon coordinates by (versionless) gene id. Built once, lazily, in a
         # single groupby pass — see `_get_exons_for_gene`.
         self._exon_cache: dict[str, list[tuple[int, int]]] = {}
@@ -69,6 +112,17 @@ class GeneAnnotation:
         # queries; built lazily in `get_genes_in_interval`.
         self._interval_index: dict[str, dict[str, Any]] | None = None
         self._max_gene_span: int = 0
+
+        if isinstance(annotation, pd.DataFrame):
+            # Validate eagerly: there is no IO to defer, and raising here points
+            # at the caller's filter rather than at some later gene lookup.
+            _validate_annotation_frame(annotation, 'DataFrame')
+            self.annotation_path = None
+            self._file_format = 'dataframe'
+            self._df = annotation
+            return
+
+        self.annotation_path = Path(annotation)
 
         # Detect file format
         suffix = self.annotation_path.suffix.lower()
@@ -82,10 +136,11 @@ class GeneAnnotation:
                 del _pr
             except ImportError:
                 raise ImportError(
-                    "pyranges is required for GTF files. "
+                    "pyranges is required to read GTF/GFF files. "
                     "Install with: pip install pyranges\n"
-                    "Or convert to Parquet for faster loading: "
-                    "python scripts/convert_gtf_to_parquet.py"
+                    "Or pass a .parquet file or a DataFrame, neither of which "
+                    "needs it. (scripts/convert_gtf_to_parquet.py converts a GTF "
+                    "once, but itself runs on pyranges.)"
                 )
         else:
             raise ValueError(
@@ -95,18 +150,23 @@ class GeneAnnotation:
 
     # Keep gtf_path as alias for backward compatibility
     @property
-    def gtf_path(self) -> Path:
-        """Alias for annotation_path (backward compatibility)."""
+    def gtf_path(self) -> Path | None:
+        """Alias for annotation_path (backward compatibility).
+
+        ``None`` when built from a DataFrame.
+        """
         return self.annotation_path
 
     @property
     def df(self) -> pd.DataFrame:
-        """Lazy-loaded annotation DataFrame."""
+        """Annotation DataFrame; loaded and indexed on first access."""
         if self._df is None:
             if self._file_format == 'parquet':
                 self._load_from_parquet()
             else:
                 self._load_from_gtf()
+            _validate_annotation_frame(self._df, str(self.annotation_path))
+        if not self._gene_index_built:
             self._build_gene_index()
         return self._df
 
@@ -130,6 +190,7 @@ class GeneAnnotation:
         """Build index of gene information."""
         # Filter for gene features
         genes_df = self._df[self._df['Feature'] == 'gene']
+        self._gene_index_built = True
 
         for _, row in genes_df.iterrows():
             gene_id = row.get('gene_id', '')
@@ -458,8 +519,13 @@ class PolyAAnnotation:
     """PolyA site annotations from GENCODE polyAs GTF or linked parquet.
 
     This class loads and queries polyadenylation site annotations from
-    GENCODE polyAs files. For best results, use a linked parquet created
-    by scripts/preprocess_polya.py which contains proper Ensembl gene IDs.
+    GENCODE polyAs files.
+
+    A *linked* parquet (from scripts/preprocess_polya.py) carries Ensembl gene
+    IDs, which changes what this class can do rather than just how fast it is:
+    PAS are matched to a gene by ID, mirroring the JAX reference. Without them,
+    :meth:`get_pas_for_gene` falls back to spatial overlap and
+    :meth:`get_total_pas_count_for_gene` returns 0.
 
     Features read: polyA_site, polyA_signal, pseudo_polyA
 
@@ -473,9 +539,10 @@ class PolyAAnnotation:
 
         Args:
             polya_path: Path to annotation file. Supports:
-                - Linked parquet files (recommended, created by preprocess_polya.py)
+                - Linked parquet from preprocess_polya.py (carries Ensembl gene
+                  IDs; see the class docstring for what they enable)
                 - Raw parquet files (.parquet)
-                - GTF files (.gtf) - slower, requires pyranges
+                - GTF files (.gtf), requires pyranges
         """
         self.polya_path = Path(polya_path)
         self._df: pd.DataFrame | None = None
@@ -493,9 +560,11 @@ class PolyAAnnotation:
                 del _pr
             except ImportError:
                 raise ImportError(
-                    "pyranges is required for GTF files. "
+                    "pyranges is required to read GTF/GFF files. "
                     "Install with: pip install pyranges\n"
-                    "Or convert to Parquet for faster loading."
+                    "Or pass a .parquet file, which does not need it. "
+                    "(scripts/preprocess_polya.py converts a GTF once, but "
+                    "itself runs on pyranges.)"
                 )
         else:
             raise ValueError(

--- a/src/alphagenome_pytorch/variant_scoring/scorers/gene_mask.py
+++ b/src/alphagenome_pytorch/variant_scoring/scorers/gene_mask.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
+from ...aggregation import aggregate_intervals
 from ..aggregations import align_alternate
 from ..types import Interval, OutputType, Variant, VariantScore
 from .base import BaseVariantScorer
@@ -215,15 +216,12 @@ class GeneMaskLFCScorer(BaseVariantScorer):
                 # No coverage in this interval for this gene
                 continue
 
-            # Apply mask and sum
-            mask = gene_mask.unsqueeze(0).unsqueeze(-1)  # (1, S, 1)
-            ref_masked = (ref_preds * mask).sum(dim=1)  # (B, T)
-            alt_masked = (alt_preds_aligned * mask).sum(dim=1)  # (B, T)
-            
-            # Normalize by mask sum to get mean (matches JAX)
-            gene_mask_sum = gene_mask.sum()
-            ref_mean = ref_masked / gene_mask_sum
-            alt_mean = alt_masked / gene_mask_sum
+            # Mean over masked positions via the shared aggregation primitive
+            # (identical to (pred*mask).sum(1)/mask.sum(); the earlier zero-sum
+            # `continue` guarantees a non-empty mask, so the mean is well-defined).
+            gene_mask_col = gene_mask.unsqueeze(-1).to(ref_preds.dtype)  # (S, 1)
+            ref_mean = aggregate_intervals(ref_preds, gene_mask_col, reduce="mean").squeeze(1)  # (B, T)
+            alt_mean = aggregate_intervals(alt_preds_aligned, gene_mask_col, reduce="mean").squeeze(1)
 
             # Log fold change: ln(alt) - ln(ref) using natural log
             lfc = torch.log(alt_mean + eps) - torch.log(ref_mean + eps)
@@ -422,10 +420,11 @@ class GeneMaskActiveScorer(BaseVariantScorer):
                 # No coverage in this interval for this gene
                 continue
 
-            # Apply mask and compute mean (matching JAX implementation)
-            mask = gene_mask.unsqueeze(0).unsqueeze(-1)  # (1, S, 1)
-            ref_mean = (ref_preds * mask).sum(dim=1) / gene_mask_sum  # (B, T)
-            alt_mean = (alt_preds_aligned * mask).sum(dim=1) / gene_mask_sum  # (B, T)
+            # Mean over masked positions via the shared aggregation primitive
+            # (identical to (pred*mask).sum(1)/mask.sum(); non-empty mask guaranteed above).
+            gene_mask_col = gene_mask.unsqueeze(-1).to(ref_preds.dtype)  # (S, 1)
+            ref_mean = aggregate_intervals(ref_preds, gene_mask_col, reduce="mean").squeeze(1)  # (B, T)
+            alt_mean = aggregate_intervals(alt_preds_aligned, gene_mask_col, reduce="mean").squeeze(1)
 
             # Active score: max(mean(ref), mean(alt))
             active_scores = torch.maximum(ref_mean, alt_mean)

--- a/tests/integration/api_utils.py
+++ b/tests/integration/api_utils.py
@@ -150,6 +150,7 @@ def save_api_scores(
     api_scores: list['anndata.AnnData'],
     cache_dir: Path | str | None = None,
     variant_str: str | None = None,
+    cache_path: Path | str | None = None,
 ) -> Path:
     """Save API scores to cache.
 
@@ -157,11 +158,19 @@ def save_api_scores(
         api_scores: List of AnnData objects from API
         cache_dir: Directory to save cache. If None, uses default.
         variant_str: Variant string for metadata
+        cache_path: Exact file to write. Takes precedence over ``cache_dir``.
+            Callers that read from a specific file must write back to that same
+            file — deriving a directory from it is not enough, since the
+            ``cache_dir`` form would rename it to ``variant_scores.pkl`` and the
+            next read would miss.
 
     Returns:
         Path to saved pickle file
     """
-    if cache_dir is None:
+    if cache_path is not None:
+        cache_path = Path(cache_path)
+        cache_dir = cache_path.parent
+    elif cache_dir is None:
         cache_path = get_cache_path()
         cache_dir = cache_path.parent
     else:
@@ -229,9 +238,10 @@ def get_or_fetch_api_scores(
 
         api_scores = fetch_api_scores(api_key=api_key)
 
-        # Save to cache for future use
+        # Save to cache for future use — back to the file we read from, or the
+        # caller misses and refetches from the API on every single call.
         variant_str = f"{DEFAULT_VARIANT_CHROMOSOME}:{DEFAULT_VARIANT_POSITION}:{DEFAULT_VARIANT_REFERENCE_BASES}>{DEFAULT_VARIANT_ALTERNATE_BASES}"
-        save_path = save_api_scores(api_scores, variant_str=variant_str)
+        save_path = save_api_scores(api_scores, variant_str=variant_str, cache_path=cache_path)
         if verbose:
             print(f"Fetched {len(api_scores)} scorer results from API")
             print(f"Saved to cache: {save_path}")
@@ -386,9 +396,24 @@ def save_api_predictions(
     predictions: dict,
     cache_dir: Path | str | None = None,
     variant_str: str | None = None,
+    cache_path: Path | str | None = None,
 ) -> Path:
-    """Save windowed API predictions to cache (mirrors save_api_scores)."""
-    if cache_dir is None:
+    """Save windowed API predictions to cache (mirrors save_api_scores).
+
+    Args:
+        predictions: Windowed predictions keyed by output type.
+        cache_dir: Directory to write into; the filename is chosen for you.
+        variant_str: Variant string for the metadata sidecar.
+        cache_path: Exact file to write. Takes precedence over ``cache_dir``.
+            Callers that read from a specific file must write back to that same
+            file — deriving a directory from it is not enough, since the
+            ``cache_dir`` form would rename it to ``variant_predictions.pkl``
+            and the next read would miss.
+    """
+    if cache_path is not None:
+        cache_path = Path(cache_path)
+        cache_dir = cache_path.parent
+    elif cache_dir is None:
         cache_path = get_predictions_cache_path()
         cache_dir = cache_path.parent
     else:
@@ -439,7 +464,11 @@ def get_or_fetch_api_predictions(
             f"{DEFAULT_VARIANT_CHROMOSOME}:{DEFAULT_VARIANT_POSITION}:"
             f"{DEFAULT_VARIANT_REFERENCE_BASES}>{DEFAULT_VARIANT_ALTERNATE_BASES}"
         )
-        save_path = save_api_predictions(predictions, variant_str=variant_str)
+        # Write back to the file we read from, or the caller misses and refetches
+        # from the API on every single call.
+        save_path = save_api_predictions(
+            predictions, variant_str=variant_str, cache_path=cache_path
+        )
         if verbose:
             print(f"Fetched predictions for {len(predictions)} output types from API")
             print(f"Saved to cache: {save_path}")

--- a/tests/integration/api_utils.py
+++ b/tests/integration/api_utils.py
@@ -13,6 +13,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 if TYPE_CHECKING:
     import anndata
 
@@ -244,5 +246,210 @@ def get_or_fetch_api_scores(
     except Exception as e:
         raise RuntimeError(
             f"Cannot load cache and API call failed: {e}\n"
+            "Check your API key and network connection."
+        ) from e
+
+
+# =============================================================================
+# Raw prediction parity (localizing diagnostic: do PREDICTIONS diverge from the
+# API, upstream of scoring?). Full predictions are huge, so we cache a center
+# window around the variant per output type.
+# =============================================================================
+
+# Output types compared for prediction parity (the CenterMask track outputs).
+PREDICTION_OUTPUT_TYPES = (
+    "ATAC",
+    "DNASE",
+    "CAGE",
+    "PROCAP",
+    "CHIP_TF",
+    "CHIP_HISTONE",
+)
+
+# Width (bp) of the center window kept per output type. Large enough to cover
+# the variant's neighborhood; small enough to cache. Windowed per resolution.
+DEFAULT_PREDICTION_WINDOW_BP = 8192
+
+
+def get_predictions_cache_path(cache_dir: Path | str | None = None) -> Path:
+    """Path to the cached API predictions pickle (mirrors get_cache_path)."""
+    if cache_dir:
+        return Path(cache_dir) / "variant_predictions.pkl"
+    possible_paths = [
+        Path("data/api_cache/variant_predictions.pkl"),
+        Path(__file__).parent.parent.parent
+        / "data"
+        / "api_cache"
+        / "variant_predictions.pkl",
+    ]
+    for p in possible_paths:
+        if p.exists():
+            return p.absolute()
+    return possible_paths[0].absolute()
+
+
+def window_trackdata(ref_td, alt_td, variant, window_bp: int) -> dict:
+    """Slice a center window (around the variant) out of ref/alt TrackData.
+
+    Returns a plain, picklable dict with per-track names/strands, the windowed
+    ref (and alt) values ``(window_bins, num_tracks)``, the resolution, and the
+    slice bounds so a local model's prediction can be windowed identically.
+    """
+    resolution = int(ref_td.resolution)
+    ref_values = np.asarray(ref_td.values)
+    n_bins = ref_values.shape[0]
+
+    # 0-based variant position relative to the interval, in bins. Fall back to
+    # the interval centre (resize() centres the interval on the variant).
+    interval = getattr(ref_td, "interval", None)
+    if interval is not None:
+        center_bin = (variant.start - interval.start) // resolution
+    else:
+        center_bin = n_bins // 2
+
+    half = max(1, (window_bp // resolution) // 2)
+    start = int(max(0, center_bin - half))
+    end = int(min(n_bins, center_bin + half))
+
+    alt_values = np.asarray(alt_td.values) if alt_td is not None else None
+    return {
+        "resolution": resolution,
+        "interval_start": int(interval.start) if interval is not None else None,
+        "start_bin": start,
+        "end_bin": end,
+        "names": [str(n) for n in ref_td.metadata["name"].tolist()],
+        "strands": [str(s) for s in ref_td.metadata["strand"].tolist()],
+        "ref": ref_values[start:end].astype(np.float32),
+        "alt": (
+            alt_values[start:end].astype(np.float32)
+            if alt_values is not None
+            else None
+        ),
+    }
+
+
+def fetch_api_predictions(
+    variant_chromosome: str = DEFAULT_VARIANT_CHROMOSOME,
+    variant_position: int = DEFAULT_VARIANT_POSITION,
+    variant_reference_bases: str = DEFAULT_VARIANT_REFERENCE_BASES,
+    variant_alternate_bases: str = DEFAULT_VARIANT_ALTERNATE_BASES,
+    sequence_length: str = DEFAULT_SEQUENCE_LENGTH,
+    window_bp: int = DEFAULT_PREDICTION_WINDOW_BP,
+    api_key: str | None = None,
+) -> dict:
+    """Fetch raw ref/alt predictions from the API, windowed around the variant.
+
+    Returns ``{output_type_name: window_trackdata(...) dict}`` for the
+    ``PREDICTION_OUTPUT_TYPES`` (uses the same variant/interval as the scores
+    cache).
+    """
+    from alphagenome.data import genome
+    from alphagenome.models import dna_client, dna_output
+
+    if api_key is None:
+        api_key = get_api_key()
+    if not api_key:
+        raise ValueError("No API key available")
+
+    client = dna_client.create(api_key=api_key)
+
+    variant = genome.Variant(
+        chromosome=variant_chromosome,
+        position=variant_position,
+        reference_bases=variant_reference_bases,
+        alternate_bases=variant_alternate_bases,
+    )
+    sequence_length_value = dna_client.SUPPORTED_SEQUENCE_LENGTHS[
+        f"SEQUENCE_LENGTH_{sequence_length}"
+    ]
+    interval = variant.reference_interval.resize(sequence_length_value)
+
+    requested = [getattr(dna_output.OutputType, n) for n in PREDICTION_OUTPUT_TYPES]
+    variant_output = client.predict_variant(
+        interval=interval,
+        variant=variant,
+        requested_outputs=requested,
+        ontology_terms=None,
+    )
+
+    result: dict = {}
+    for output_type in requested:
+        ref_td = variant_output.reference.get(output_type)
+        alt_td = variant_output.alternate.get(output_type)
+        if ref_td is None:
+            continue
+        result[output_type.name] = window_trackdata(ref_td, alt_td, variant, window_bp)
+    return result
+
+
+def save_api_predictions(
+    predictions: dict,
+    cache_dir: Path | str | None = None,
+    variant_str: str | None = None,
+) -> Path:
+    """Save windowed API predictions to cache (mirrors save_api_scores)."""
+    if cache_dir is None:
+        cache_path = get_predictions_cache_path()
+        cache_dir = cache_path.parent
+    else:
+        cache_dir = Path(cache_dir)
+        cache_path = cache_dir / "variant_predictions.pkl"
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    with open(cache_path, "wb") as f:
+        pickle.dump(predictions, f)
+
+    metadata = {
+        "timestamp": datetime.now().isoformat(),
+        "variant": variant_str or "unknown",
+        "output_types": list(predictions.keys()),
+        "window_bp": DEFAULT_PREDICTION_WINDOW_BP,
+    }
+    with open(cache_dir / "api_predictions_metadata.json", "w") as f:
+        json.dump(metadata, f, indent=2)
+    return cache_path
+
+
+def get_or_fetch_api_predictions(
+    cache_path: Path | str | None = None,
+    force_refresh: bool = False,
+    verbose: bool = True,
+) -> dict:
+    """Get windowed API predictions from cache, or fetch and cache them.
+
+    Mirrors get_or_fetch_api_scores but for raw predictions.
+    """
+    if not force_refresh:
+        path = Path(cache_path) if cache_path else get_predictions_cache_path()
+        if path.exists():
+            with open(path, "rb") as f:
+                cached = pickle.load(f)
+            if verbose:
+                print(f"Loaded predictions for {len(cached)} output types from cache")
+            return cached
+
+    if verbose:
+        print("Prediction cache not found, fetching from API...")
+    try:
+        api_key = get_api_key()
+        if not api_key:
+            raise ValueError("No API key available")
+        predictions = fetch_api_predictions(api_key=api_key)
+        variant_str = (
+            f"{DEFAULT_VARIANT_CHROMOSOME}:{DEFAULT_VARIANT_POSITION}:"
+            f"{DEFAULT_VARIANT_REFERENCE_BASES}>{DEFAULT_VARIANT_ALTERNATE_BASES}"
+        )
+        save_path = save_api_predictions(predictions, variant_str=variant_str)
+        if verbose:
+            print(f"Fetched predictions for {len(predictions)} output types from API")
+            print(f"Saved to cache: {save_path}")
+        return predictions
+    except ImportError as e:
+        raise RuntimeError(
+            f"Cannot load cache and alphagenome package not installed: {e}"
+        ) from e
+    except Exception as e:
+        raise RuntimeError(
+            f"Cannot load prediction cache and API call failed: {e}\n"
             "Check your API key and network connection."
         ) from e

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -1,0 +1,328 @@
+"""Unit tests for the gene / interval aggregation module.
+
+Covers the shared primitive, the Fig. 2d correlation helpers, and the two
+serving helpers (`aggregate_genes` gene-body, `gene_expression` exon-based),
+plus the `GeneCounts` converters. Uses dependency-free toy fixtures (no pyranges,
+no bigwigs).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from alphagenome_pytorch.aggregation import (
+    GeneCounts,
+    aggregate_genes,
+    aggregate_intervals,
+    combine_gene_expression,
+    gene_expression,
+    gene_expression_correlations,
+    gene_expression_values,
+    normalize_expression,
+)
+from alphagenome_pytorch.named_outputs import TrackMetadata
+from alphagenome_pytorch.variant_scoring.annotations import GeneAnnotation
+
+
+# --------------------------------------------------------------------------- #
+# fixtures
+# --------------------------------------------------------------------------- #
+INTERVAL = ("chr1", 100, 120)  # width 20; use 1bp resolution (seq_len == 20)
+
+
+def _position_preds(n_tracks=3, seq_len=20):
+    """[1, S, C] where channel c = position index * (c + 1)."""
+    pos = torch.arange(seq_len, dtype=torch.float32)
+    return torch.stack([pos * (c + 1) for c in range(n_tracks)], dim=-1).unsqueeze(0)
+
+
+def _gene_table():
+    # geneA + on [102,108); geneB - on [110,116). Both fully inside [100,120).
+    return pd.DataFrame({
+        "Chromosome": ["chr1", "chr1"],
+        "Start": [102, 110],
+        "End": [108, 116],
+        "Strand": ["+", "-"],
+        "gene_id": ["ENSGA", "ENSGB"],
+        "gene_name": ["A", "B"],
+        "gene_type": ["protein_coding", "protein_coding"],
+    })
+
+
+def _make_annotation():
+    """GeneAnnotation from an in-memory GTF-like frame (no file / pyranges)."""
+    rows = [
+        # geneA + : exons [102,104) and [106,108) (intron 104-106)
+        dict(Feature="gene", Chromosome="chr1", Start=102, End=108, Strand="+",
+             gene_id="ENSGA", gene_name="A", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=102, End=104, Strand="+",
+             gene_id="ENSGA", gene_name="A", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=106, End=108, Strand="+",
+             gene_id="ENSGA", gene_name="A", gene_type="protein_coding"),
+        # geneB - : exon [110,116)
+        dict(Feature="gene", Chromosome="chr1", Start=110, End=116, Strand="-",
+             gene_id="ENSGB", gene_name="B", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=110, End=116, Strand="-",
+             gene_id="ENSGB", gene_name="B", gene_type="protein_coding"),
+        # geneC : mostly outside interval — total exon 20bp, only 2bp inside -> dropped by >=50% rule
+        dict(Feature="gene", Chromosome="chr1", Start=118, End=200, Strand="+",
+             gene_id="ENSGC", gene_name="C", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=118, End=128, Strand="+",
+             gene_id="ENSGC", gene_name="C", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=190, End=200, Strand="+",
+             gene_id="ENSGC", gene_name="C", gene_type="protein_coding"),
+    ]
+    df = pd.DataFrame(rows)
+    ann = GeneAnnotation("/tmp/does_not_exist.parquet")  # suffix only; file never read
+    ann._df = df
+    ann._build_gene_index()
+    return ann
+
+
+def _tracks():
+    return [
+        TrackMetadata(0, "rna_seq", 0, "t0", {"strand": "+", "biosample": "liver"}),
+        TrackMetadata(1, "rna_seq", 0, "t1", {"strand": "-", "biosample": "liver"}),
+        TrackMetadata(2, "rna_seq", 0, "t2", {"strand": ".", "biosample": "brain"}),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# primitive
+# --------------------------------------------------------------------------- #
+def test_aggregate_intervals_sum_mean():
+    pred = torch.arange(12, dtype=torch.float32).reshape(1, 6, 2)
+    mask = torch.zeros(6, 2)
+    mask[0:3, 0] = 1.0
+    mask[3:6, 1] = 1.0
+    s = aggregate_intervals(pred, mask, "sum")
+    m = aggregate_intervals(pred, mask, "mean")
+    assert s.shape == (1, 2, 2)
+    assert s[0, 0, 0] == 6 and m[0, 0, 0] == 2
+    assert s[0, 1, 1] == 27 and m[0, 1, 1] == 9
+
+
+def test_aggregate_intervals_empty_mask_and_2d():
+    pred = torch.ones(1, 6, 1)
+    empty = torch.zeros(6, 1)
+    assert aggregate_intervals(pred, empty, "mean").abs().sum() == 0  # clamp, no NaN
+    # 2D input gets a batch axis
+    assert aggregate_intervals(pred[0], torch.ones(6, 1), "sum").shape == (1, 1, 1)
+
+
+def test_aggregate_intervals_validation():
+    with pytest.raises(ValueError):
+        aggregate_intervals(torch.ones(1, 6, 1), torch.ones(5, 1))  # length mismatch
+    with pytest.raises(ValueError):
+        aggregate_intervals(torch.ones(1, 6, 1), torch.ones(6, 1), reduce="bogus")
+
+
+# --------------------------------------------------------------------------- #
+# correlation helpers
+# --------------------------------------------------------------------------- #
+def test_normalize_expression_gene_centered():
+    torch.manual_seed(0)
+    m = torch.randn(20, 4)
+    n = normalize_expression(m)
+    assert n.shape == (20, 4)
+    assert n.mean(dim=1).abs().max() < 1e-5  # each gene's row mean is ~0
+
+
+def test_gene_expression_correlations_three_flavors():
+    torch.manual_seed(1)
+    truth = torch.randn(30, 5)
+    pred = truth + 0.05 * torch.randn(30, 5)
+    d = gene_expression_correlations(pred, truth)
+    assert set(d) == {"across_genes", "across_genes_norm", "across_tracks_norm"}
+    assert d["across_genes"] > 0.9
+    assert d["across_genes_norm"] > 0.8
+
+
+def test_gene_expression_correlations_handles_nan():
+    torch.manual_seed(2)
+    truth = torch.randn(15, 3)
+    pred = truth.clone()
+    pred[0, 1] = float("nan")  # strand-incompatible cell
+    d = gene_expression_correlations(pred, truth)
+    assert not math.isnan(d["across_genes"])
+
+
+# --------------------------------------------------------------------------- #
+# aggregate_genes (gene-body)
+# --------------------------------------------------------------------------- #
+def test_aggregate_genes_body_mean():
+    pred = _position_preds()
+    gc = aggregate_genes(pred, _gene_table(), INTERVAL, track_metadata=_tracks())
+    assert gc.space == "linear"
+    assert gc.counts.shape == (1, 2, 3)  # 2 genes, 3 tracks
+    # geneA body rel positions 2..7 -> channel0 mean = mean(2..7) = 4.5
+    assert gc.counts[0, 0, 0].item() == pytest.approx(4.5)
+    # channel1 doubles the position values -> 9.0
+    assert gc.counts[0, 0, 1].item() == pytest.approx(9.0)
+    # geneB body rel positions 10..15 -> channel0 mean = mean(10..15) = 12.5
+    assert gc.counts[0, 1, 0].item() == pytest.approx(12.5)
+
+
+def test_aggregate_genes_strand_modes():
+    pred = _position_preds()
+    tracks = _tracks()
+    # default: no strand logic, full 3 columns, no NaN
+    gc = aggregate_genes(pred, _gene_table(), INTERVAL, track_metadata=tracks)
+    assert gc.counts.shape[-1] == 3 and not torch.isnan(gc.counts).any()
+
+    # match: geneA(+) NaN on t1(-); geneB(-) NaN on t0(+); t2(.) always kept
+    gm = aggregate_genes(pred, _gene_table(), INTERVAL, track_metadata=tracks, strand="match")
+    assert torch.isnan(gm.counts[0, 0, 1])   # geneA x t1(-)
+    assert not torch.isnan(gm.counts[0, 0, 0])  # geneA x t0(+)
+    assert not torch.isnan(gm.counts[0, 0, 2])  # geneA x t2(.)
+    assert torch.isnan(gm.counts[0, 1, 0])   # geneB x t0(+)
+
+    # merge: liver +/- pair collapses; brain '.' stays -> 2 columns
+    gmerge = aggregate_genes(pred, _gene_table(), INTERVAL, track_metadata=tracks, strand="merge")
+    assert gmerge.counts.shape[-1] == 2
+
+
+# --------------------------------------------------------------------------- #
+# gene_expression (exon-based, log)
+# --------------------------------------------------------------------------- #
+def test_gene_expression_exon_log_and_50pct_rule():
+    pred = _position_preds()
+    ann = _make_annotation()
+    ge = gene_expression(pred, ann, INTERVAL, track_metadata=_tracks())
+    assert ge.space == "log"
+    # geneC dropped by the >=50%-exon rule -> only geneA, geneB remain
+    assert ge.counts.shape[1] == 2
+    assert set(ge.gene_metadata["gene_id"]) == {"ENSGA", "ENSGB"}
+    # geneA exon positions rel 2,3 (102-104) and 6,7 (106-108) -> channel0 mean = (2+3+6+7)/4 = 4.5
+    row = ge.gene_metadata.index[ge.gene_metadata["gene_id"] == "ENSGA"][0]
+    assert ge.counts[0, row, 0].item() == pytest.approx(math.log1p(4.5), abs=1e-5)
+
+
+def test_gene_expression_linear_and_strand_default_match():
+    pred = _position_preds()
+    ann = _make_annotation()
+    ge = gene_expression(pred, ann, INTERVAL, track_metadata=_tracks(), log=None)
+    assert ge.space == "linear"
+    # default strand="match": geneA(+) is NaN on the '-' track
+    a_row = ge.gene_metadata.index[ge.gene_metadata["gene_id"] == "ENSGA"][0]
+    minus_track = 1
+    assert torch.isnan(ge.counts[0, a_row, minus_track])
+
+
+def test_gene_expression_excludes_introns():
+    # constant-1 preds: exon mean == 1 exactly; the intron positions (104-106)
+    # must not change the mean (they're excluded from the mask).
+    pred = torch.ones(1, 20, 1)
+    ann = _make_annotation()
+    ge = gene_expression(pred, ann, INTERVAL, track_metadata=None, log=None, strand=None)
+    assert torch.allclose(ge.counts, torch.ones_like(ge.counts))
+
+
+# --------------------------------------------------------------------------- #
+# GeneCounts converters
+# --------------------------------------------------------------------------- #
+def test_gene_counts_to_tables_and_long():
+    pred = _position_preds()
+    gc = aggregate_genes(pred, _gene_table(), INTERVAL, track_metadata=_tracks())
+    x, obs, var = gc.to_tables()
+    assert x.shape == (3, 2)  # [tracks, genes]
+    assert len(obs) == 3 and len(var) == 2
+    df = gc.to_dataframe(long=True)
+    assert len(df) == 2 * 3  # gene x track rows
+    assert "count" in df.columns
+
+
+def test_gene_counts_to_tables_requires_single_interval():
+    pred = _position_preds().repeat(2, 1, 1)  # B=2
+    gc = aggregate_genes(pred, _gene_table(), INTERVAL, track_metadata=_tracks())
+    with pytest.raises(ValueError):
+        gc.to_tables()
+
+
+def test_gene_counts_to_anndata_optional():
+    import warnings
+
+    pred = _position_preds()
+    gc = aggregate_genes(pred, _gene_table(), INTERVAL, track_metadata=_tracks())
+    anndata = pytest.importorskip("anndata")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", anndata.ImplicitModificationWarning)
+        adata = gc.to_anndata()  # must not warn about coercing the index to str
+    assert adata.X.shape == (3, 2)
+    assert adata.obs.shape[0] == 3 and adata.var.shape[0] == 2
+    # idiomatic names: var_names = gene ids, obs_names = track names.
+    assert list(adata.var_names) == ["ENSGA", "ENSGB"]
+    assert list(adata.obs_names) == ["t0", "t1", "t2"]
+
+
+# --------------------------------------------------------------------------- #
+# validation-metric helpers (single-window values + cross-window combine)
+# --------------------------------------------------------------------------- #
+def test_gene_expression_values_shape_ids_and_strand():
+    pred = _position_preds()
+    ann = _make_annotation()
+    values, gene_ids, gene_strands = gene_expression_values(
+        pred, ann, INTERVAL, track_strands=["+", "-", "."]
+    )
+    # geneC dropped by the >=50%-exon rule -> geneA, geneB kept, in index order.
+    assert gene_ids == ["ENSGA", "ENSGB"]
+    assert gene_strands == ["+", "-"]
+    assert values.shape == (2, 3)  # [G, C], log space
+    # geneA(+): '+' track kept, '-' track NaN, '.' track kept.
+    assert values[0, 0].item() == pytest.approx(math.log1p(4.5), abs=1e-5)
+    assert torch.isnan(values[0, 1])           # geneA x '-' track
+    assert not torch.isnan(values[0, 2])       # geneA x '.' track
+    # geneB(-): '+' track NaN, '-' track kept.
+    assert torch.isnan(values[1, 0])           # geneB x '+' track
+    assert not torch.isnan(values[1, 1])
+
+
+def test_gene_expression_values_no_strand_matching():
+    pred = _position_preds()
+    ann = _make_annotation()
+    values, _, _ = gene_expression_values(pred, ann, INTERVAL, track_strands=None)
+    assert not torch.isnan(values).any()       # no strand logic -> no NaN
+    # linear-space check via log=None
+    lin, _, _ = gene_expression_values(pred, ann, INTERVAL, log=None, track_strands=None)
+    assert lin[0, 0].item() == pytest.approx(4.5, abs=1e-5)
+
+
+def test_combine_gene_expression_dedup_and_corr():
+    torch.manual_seed(3)
+    truth = torch.randn(5, 4)
+    pred = truth + 0.02 * torch.randn(5, 4)
+    # window 1: genes g0..g2 ; window 2: genes g2..g4 (g2 overlaps -> deduped)
+    w1 = (["g0", "g1", "g2"], pred[:3], truth[:3])
+    w2 = (["g2", "g3", "g4"], pred[2:], truth[2:])
+    out = combine_gene_expression([w1, w2])
+    assert out["n_genes"] == 5                 # g2 counted once
+    assert out["across_genes"] > 0.9
+    assert set(out) == {"across_genes", "across_genes_norm", "across_tracks_norm", "n_genes"}
+
+
+def test_combine_gene_expression_too_few_genes():
+    out = combine_gene_expression([(["g0"], torch.zeros(1, 3), torch.zeros(1, 3))])
+    assert out["n_genes"] == 1
+    assert math.isnan(out["across_genes"])
+
+
+def test_gene_expression_values_window_cache_reuse():
+    pred = _position_preds()
+    ann = _make_annotation()
+    cache: dict = {}
+    v1, ids1, s1 = gene_expression_values(pred, ann, INTERVAL, window_cache=cache)
+    # Same window a second time (e.g. the obs pass, or a later epoch): one entry.
+    v2, ids2, s2 = gene_expression_values(pred, ann, INTERVAL, window_cache=cache)
+    assert len(cache) == 1
+    assert ids1 == ids2 and s1 == s2
+    # Cached result is identical to the uncached path (NaNs compare equal here).
+    v_nocache, _, _ = gene_expression_values(pred, ann, INTERVAL)
+    assert torch.equal(torch.nan_to_num(v1, nan=-1.0), torch.nan_to_num(v_nocache, nan=-1.0))
+    # A different window adds a distinct cache entry.
+    gene_expression_values(pred, ann, ("chr1", 100_000, 100_020), window_cache=cache)
+    assert len(cache) == 2

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -79,9 +79,7 @@ def _make_annotation():
              gene_id="ENSGC", gene_name="C", gene_type="protein_coding"),
     ]
     df = pd.DataFrame(rows)
-    ann = GeneAnnotation("/tmp/does_not_exist.parquet")  # suffix only; file never read
-    ann._df = df
-    ann._build_gene_index()
+    ann = GeneAnnotation(df)
     return ann
 
 
@@ -230,9 +228,7 @@ def test_gene_expression_50pct_rule_counts_contained_exons_not_basepairs():
         dict(Feature="exon", Chromosome="chr1", Start=125, End=127, Strand="+",
              gene_id="ENSDROP", gene_name="D", gene_type="protein_coding"),   # outside
     ]
-    ann = GeneAnnotation("/tmp/does_not_exist.parquet")
-    ann._df = pd.DataFrame(rows)
-    ann._build_gene_index()
+    ann = GeneAnnotation(pd.DataFrame(rows))
 
     _, gene_ids, _ = gene_expression_values(
         torch.ones(1, 20, 1), ann, interval, track_strands=None
@@ -386,9 +382,7 @@ def _two_tile_annotation():
         dict(Feature="exon", Chromosome="chr1", Start=16, End=18, Strand="-",
              gene_id="ENSH", gene_name="H", gene_type="protein_coding"),
     ]
-    ann = GeneAnnotation("/tmp/does_not_exist.parquet")
-    ann._df = pd.DataFrame(rows)
-    ann._build_gene_index()
+    ann = GeneAnnotation(pd.DataFrame(rows))
     return ann
 
 
@@ -449,9 +443,7 @@ def test_accumulator_merges_bins_shared_by_exons_at_128bp():
         dict(Feature="exon", Chromosome="chr1", Start=140, End=150, Strand="+",
              gene_id="ENSG", gene_name="G", gene_type="protein_coding"),   # -> bin 1
     ]
-    ann = GeneAnnotation("/tmp/does_not_exist.parquet")
-    ann._df = pd.DataFrame(rows)
-    ann._build_gene_index()
+    ann = GeneAnnotation(pd.DataFrame(rows))
     preds = torch.tensor([[5.0], [7.0]])  # [2 bins, 1 track]: bin0=5, bin1=7
 
     acc = GeneCountAccumulator(ann, resolution=128, over="exons", reduce="sum")

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -489,3 +489,30 @@ def test_gene_expression_match_rejects_invalid_track_metadata_strand():
     ]
     with pytest.raises(ValueError, match="track strands must be"):
         gene_expression(pred, ann, INTERVAL, track_metadata=bad_tracks, strand="match")
+
+
+def test_to_gene_counts_rejects_mismatched_dataframe_track_metadata():
+    """A DataFrame must describe the accumulated tracks, like a TrackMetadata list does.
+
+    Without the check the mismatch survives into GeneCounts and only surfaces
+    later as a dimension error from inside anndata, about X vs obs rather than
+    about the metadata the caller passed.
+    """
+    import pandas as pd
+
+    ann = GeneAnnotation(pd.DataFrame([
+        dict(Feature="gene", Chromosome="chr1", Start=0, End=10, Strand="+",
+             gene_id="ENSG1", gene_name="G1", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=0, End=10, Strand="+",
+             gene_id="ENSG1", gene_name="G1", gene_type="protein_coding"),
+    ]))
+    acc = GeneCountAccumulator(ann, resolution=1, over="exons", reduce="sum")
+    acc.add_tile(torch.ones(10, 2), "chr1", 0, 10)  # 2 tracks
+
+    bad = pd.DataFrame({"track_index": [0, 1, 2], "track_name": ["a", "b", "c"]})
+    with pytest.raises(ValueError, match="3 rows but predictions have 2 tracks"):
+        acc.to_gene_counts(track_metadata=bad)
+
+    ok = pd.DataFrame({"track_index": [0, 1], "track_name": ["a", "b"]})
+    gc = acc.to_gene_counts(track_metadata=ok)
+    assert gc.counts.shape[-1] == len(gc.track_metadata) == 2

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -475,3 +475,25 @@ def test_accumulator_strand_and_track_metadata():
     g = gc.gene_metadata.index[gc.gene_metadata["gene_id"] == "ENSG"][0]  # '+' gene
     assert not torch.isnan(gc.counts[0, g, 0])       # '+' track kept
     assert torch.isnan(gc.counts[0, g, 1])           # '-' track NaN'd
+
+
+# --------------------------------------------------------------------------- #
+# strand-label validation (API must agree with the CLI)
+# --------------------------------------------------------------------------- #
+def test_gene_expression_values_rejects_invalid_strand_labels():
+    ann = _make_annotation()
+    pred = _position_preds()  # 3 tracks
+    with pytest.raises(ValueError, match="track strands must be"):
+        gene_expression_values(pred, ann, INTERVAL, track_strands=["plus", "-", "."])
+
+
+def test_gene_expression_match_rejects_invalid_track_metadata_strand():
+    ann = _make_annotation()
+    pred = _position_preds()
+    bad_tracks = [
+        TrackMetadata(0, "rna_seq", 0, "t0", {"strand": "+"}),
+        TrackMetadata(1, "rna_seq", 0, "t1", {"strand": "?"}),   # invalid
+        TrackMetadata(2, "rna_seq", 0, "t2", {"strand": "."}),
+    ]
+    with pytest.raises(ValueError, match="track strands must be"):
+        gene_expression(pred, ann, INTERVAL, track_metadata=bad_tracks, strand="match")

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -453,8 +453,9 @@ def test_accumulator_merges_bins_shared_by_exons_at_128bp():
 
     acc_mean = GeneCountAccumulator(ann, resolution=128, over="exons", reduce="mean")
     acc_mean.add_tile(preds, "chr1", 0, 256)
-    # mean over 2 distinct bins = 6.0 (not 17/3 from counting bin0 twice).
-    assert acc_mean.to_gene_counts().counts[0, 0, 0].item() == pytest.approx(6.0)
+    # Per-base mean over 2 distinct bins: 12 / (2 bins * 128 bases). Counting bin0
+    # twice would instead give 17 / (3 * 128), so this still pins the dedup.
+    assert acc_mean.to_gene_counts().counts[0, 0, 0].item() == pytest.approx(12.0 / (2 * 128))
 
 
 def test_accumulator_strand_and_track_metadata():
@@ -516,3 +517,139 @@ def test_to_gene_counts_rejects_mismatched_dataframe_track_metadata():
     ok = pd.DataFrame({"track_index": [0, 1], "track_name": ["a", "b"]})
     gc = acc.to_gene_counts(track_metadata=ok)
     assert gc.counts.shape[-1] == len(gc.track_metadata) == 2
+
+
+# --------------------------------------------------------------------------- #
+# Unit consistency between 1bp and 128bp (bin-sum inputs)
+# --------------------------------------------------------------------------- #
+def _per_base_signal(n_bases: int, seed: int = 0):
+    """Nonconstant per-base coverage. Constant signal hides divisor errors."""
+    g = torch.Generator().manual_seed(seed)
+    return torch.rand(n_bases, 1, generator=g) * 10.0
+
+
+def _to_bin_sums(per_base: torch.Tensor, resolution: int) -> torch.Tensor:
+    """Bin the 1bp signal the way the pipeline does: sum the bases in each bin.
+
+    Mirrors datasets.py (`reshape(output_len, res, n_tracks).sum(axis=1)`) and
+    heads.predictions_scaling, which multiplies by `resolution` to reach
+    experimental space. This is what makes 128bp values bin sums.
+    """
+    n, c = per_base.shape
+    return per_base.reshape(n // resolution, resolution, c).sum(axis=1)
+
+
+def _one_gene_annotation(exon_start: int, exon_end: int, gene_end: int | None = None):
+    import pandas as pd
+
+    end = gene_end if gene_end is not None else exon_end
+    return GeneAnnotation(pd.DataFrame([
+        dict(Feature="gene", Chromosome="chr1", Start=exon_start, End=end, Strand="+",
+             gene_id="ENSG1", gene_name="G1", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=exon_start, End=exon_end, Strand="+",
+             gene_id="ENSG1", gene_name="G1", gene_type="protein_coding"),
+    ]))
+
+
+def test_aggregate_intervals_bin_size_normalizes_to_bases():
+    per_base = _per_base_signal(1280)
+    binned = _to_bin_sums(per_base, 128)          # [10, 1] bin sums
+
+    mask_1bp = torch.ones(1280, 1)
+    mask_128 = torch.ones(10, 1)
+
+    # Sums agree regardless of resolution: a sum of sums is the same total.
+    s1 = aggregate_intervals(per_base, mask_1bp, "sum")[0, 0, 0]
+    s128 = aggregate_intervals(binned, mask_128, "sum")[0, 0, 0]
+    assert torch.isclose(s1, s128, rtol=1e-5)
+
+    # Per-base means agree only once bin_size converts elements -> bases.
+    m1 = aggregate_intervals(per_base, mask_1bp, "mean", bin_size=1)[0, 0, 0]
+    m128 = aggregate_intervals(binned, mask_128, "mean", bin_size=128)[0, 0, 0]
+    assert torch.isclose(m1, m128, rtol=1e-5)
+    assert torch.isclose(m1, per_base.mean(), rtol=1e-5)
+
+    # Without bin_size the 128bp mean is a per-bin mean: 128x too large.
+    wrong = aggregate_intervals(binned, mask_128, "mean")[0, 0, 0]
+    assert torch.isclose(wrong, m1 * 128, rtol=1e-5)
+
+
+def test_aggregate_intervals_rejects_nonpositive_bin_size():
+    pred, mask = torch.ones(1, 4, 1), torch.ones(4, 1)
+    for bad in (0, -1, -128):
+        with pytest.raises(ValueError, match="bin_size must be positive"):
+            aggregate_intervals(pred, mask, "mean", bin_size=bad)
+
+
+def test_gene_expression_unit_consistent_for_bin_aligned_exons():
+    """Exon on 128bp boundaries -> 1bp and 128bp agree, in linear and log space."""
+    per_base = _per_base_signal(2560)
+    binned = _to_bin_sums(per_base, 128)
+    ann = _one_gene_annotation(0, 1280)           # exon [0,1280): bins [0,10)
+    tracks = [TrackMetadata(0, "rna_seq", 0, "t+", {"strand": "+"})]
+    iv = ("chr1", 0, 2560)
+    truth = per_base[0:1280].mean()
+
+    lin1 = gene_expression(per_base, ann, iv, track_metadata=tracks, log=None)
+    lin128 = gene_expression(binned, ann, iv, track_metadata=tracks, log=None)
+    assert torch.isclose(lin1.counts[0, 0, 0], truth, rtol=1e-5)
+    assert torch.isclose(lin128.counts[0, 0, 0], truth, rtol=1e-5)
+
+    # log1p(mean) must be taken after normalization, or the 128x lands inside the log.
+    log1 = gene_expression(per_base, ann, iv, track_metadata=tracks)
+    log128 = gene_expression(binned, ann, iv, track_metadata=tracks)
+    assert torch.isclose(log1.counts[0, 0, 0], torch.log1p(truth), rtol=1e-5)
+    assert torch.isclose(log128.counts[0, 0, 0], torch.log1p(truth), rtol=1e-5)
+
+
+def test_gene_expression_128bp_is_approximate_for_unaligned_exons():
+    """An exon off the bin grid cannot be recovered exactly from summed bins.
+
+    get_exon_bin_ranges includes every bin the exon *touches*, and such a bin is
+    an already-summed total mixing exonic and non-exonic bases. This pins the
+    approximation as expected behavior rather than a regression.
+    """
+    per_base = _per_base_signal(2560, seed=1)
+    binned = _to_bin_sums(per_base, 128)
+    ann = _one_gene_annotation(100, 1200)         # straddles bins 0 and 9
+    tracks = [TrackMetadata(0, "rna_seq", 0, "t+", {"strand": "+"})]
+    iv = ("chr1", 0, 2560)
+
+    exact = gene_expression(per_base, ann, iv, track_metadata=tracks, log=None)
+    approx = gene_expression(binned, ann, iv, track_metadata=tracks, log=None)
+    e, a = exact.counts[0, 0, 0], approx.counts[0, 0, 0]
+
+    # Same order of magnitude (units are right) but not equal (mask is coarse).
+    assert not torch.isclose(e, a, rtol=1e-4)
+    assert 0.5 < (a / e).item() < 2.0
+
+
+def test_accumulator_mean_is_per_base_at_128bp():
+    per_base = _per_base_signal(1280, seed=2)
+    binned = _to_bin_sums(per_base, 128)
+    ann = _one_gene_annotation(0, 1280)
+    truth = per_base[0:1280].mean()
+
+    acc1 = GeneCountAccumulator(ann, resolution=1, over="exons", reduce="mean")
+    acc1.add_tile(per_base, "chr1", 0, 1280)
+    acc128 = GeneCountAccumulator(ann, resolution=128, over="exons", reduce="mean")
+    acc128.add_tile(binned, "chr1", 0, 1280)
+
+    v1 = acc1.to_gene_counts().counts[0, 0, 0]
+    v128 = acc128.to_gene_counts().counts[0, 0, 0]
+    assert torch.isclose(v1, truth, rtol=1e-5)
+    assert torch.isclose(v128, truth, rtol=1e-5)
+
+
+def test_gene_expression_values_unit_consistent_at_both_resolutions():
+    per_base = _per_base_signal(2560, seed=3)
+    binned = _to_bin_sums(per_base, 128)
+    ann = _one_gene_annotation(0, 1280)
+    iv = ("chr1", 0, 2560)
+    truth = torch.log1p(per_base[0:1280].mean())
+
+    v1, ids1, _ = gene_expression_values(per_base, ann, iv, track_strands=None)
+    v128, ids128, _ = gene_expression_values(binned, ann, iv, track_strands=None)
+    assert ids1 == ids128 == ["ENSG1"]
+    assert torch.isclose(v1[0, 0], truth, rtol=1e-5)
+    assert torch.isclose(v128[0, 0], truth, rtol=1e-5)

--- a/tests/unit/test_aggregation.py
+++ b/tests/unit/test_aggregation.py
@@ -1,6 +1,6 @@
 """Unit tests for the gene / interval aggregation module.
 
-Covers the shared primitive, the Fig. 2d correlation helpers, and the two
+Covers the shared primitive, the gene-expression correlation helpers, and the two
 serving helpers (`aggregate_genes` gene-body, `gene_expression` exon-based),
 plus the `GeneCounts` converters. Uses dependency-free toy fixtures (no pyranges,
 no bigwigs).
@@ -16,6 +16,7 @@ import pytest
 import torch
 
 from alphagenome_pytorch.aggregation import (
+    GeneCountAccumulator,
     GeneCounts,
     aggregate_genes,
     aggregate_intervals,
@@ -69,7 +70,7 @@ def _make_annotation():
              gene_id="ENSGB", gene_name="B", gene_type="protein_coding"),
         dict(Feature="exon", Chromosome="chr1", Start=110, End=116, Strand="-",
              gene_id="ENSGB", gene_name="B", gene_type="protein_coding"),
-        # geneC : mostly outside interval — total exon 20bp, only 2bp inside -> dropped by >=50% rule
+        # geneC : 0 of its 2 exons fall fully within [100,120) -> dropped by the >=50% count rule
         dict(Feature="gene", Chromosome="chr1", Start=118, End=200, Strand="+",
              gene_id="ENSGC", gene_name="C", gene_type="protein_coding"),
         dict(Feature="exon", Chromosome="chr1", Start=118, End=128, Strand="+",
@@ -203,6 +204,42 @@ def test_gene_expression_exon_log_and_50pct_rule():
     assert ge.counts[0, row, 0].item() == pytest.approx(math.log1p(4.5), abs=1e-5)
 
 
+def test_gene_expression_50pct_rule_counts_contained_exons_not_basepairs():
+    """The >=50% rule counts whole exons *contained* in the interval, not bases.
+
+    ENSKEEP: 1 tiny in-window exon + 1 large out-of-window exon -> base-pair
+    fraction ~2% (the old rule dropped it) but 1/2 = 50% of exons are contained,
+    so the count rule keeps it. ENSDROP: 1 contained exon + a boundary-straddling
+    exon + 1 fully-outside exon -> only 1/3 contained (< 50%), so it is dropped;
+    the straddling exon is contained in neither side and does not count.
+    """
+    interval = ("chr1", 100, 120)
+    rows = [
+        dict(Feature="gene", Chromosome="chr1", Start=101, End=230, Strand="+",
+             gene_id="ENSKEEP", gene_name="K", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=101, End=103, Strand="+",
+             gene_id="ENSKEEP", gene_name="K", gene_type="protein_coding"),   # contained
+        dict(Feature="exon", Chromosome="chr1", Start=130, End=230, Strand="+",
+             gene_id="ENSKEEP", gene_name="K", gene_type="protein_coding"),   # outside
+        dict(Feature="gene", Chromosome="chr1", Start=104, End=127, Strand="+",
+             gene_id="ENSDROP", gene_name="D", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=104, End=106, Strand="+",
+             gene_id="ENSDROP", gene_name="D", gene_type="protein_coding"),   # contained
+        dict(Feature="exon", Chromosome="chr1", Start=118, End=122, Strand="+",
+             gene_id="ENSDROP", gene_name="D", gene_type="protein_coding"),   # straddles 120
+        dict(Feature="exon", Chromosome="chr1", Start=125, End=127, Strand="+",
+             gene_id="ENSDROP", gene_name="D", gene_type="protein_coding"),   # outside
+    ]
+    ann = GeneAnnotation("/tmp/does_not_exist.parquet")
+    ann._df = pd.DataFrame(rows)
+    ann._build_gene_index()
+
+    _, gene_ids, _ = gene_expression_values(
+        torch.ones(1, 20, 1), ann, interval, track_strands=None
+    )
+    assert gene_ids == ["ENSKEEP"]
+
+
 def test_gene_expression_linear_and_strand_default_match():
     pred = _position_preds()
     ann = _make_annotation()
@@ -326,3 +363,115 @@ def test_gene_expression_values_window_cache_reuse():
     # A different window adds a distinct cache entry.
     gene_expression_values(pred, ann, ("chr1", 100_000, 100_020), window_cache=cache)
     assert len(cache) == 2
+
+
+# --------------------------------------------------------------------------- #
+# GeneCountAccumulator (whole-chromosome streaming aggregation)
+# --------------------------------------------------------------------------- #
+def _two_tile_annotation():
+    """geneG spans two tiles; geneH lives only in the second tile.
+
+    geneG(+): exons [2,4) (tile A) and [12,15) (tile B); body [2,15).
+    geneH(-): exon [16,18) (tile B only); body [16,18).
+    """
+    rows = [
+        dict(Feature="gene", Chromosome="chr1", Start=2, End=15, Strand="+",
+             gene_id="ENSG", gene_name="G", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=2, End=4, Strand="+",
+             gene_id="ENSG", gene_name="G", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=12, End=15, Strand="+",
+             gene_id="ENSG", gene_name="G", gene_type="protein_coding"),
+        dict(Feature="gene", Chromosome="chr1", Start=16, End=18, Strand="-",
+             gene_id="ENSH", gene_name="H", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=16, End=18, Strand="-",
+             gene_id="ENSH", gene_name="H", gene_type="protein_coding"),
+    ]
+    ann = GeneAnnotation("/tmp/does_not_exist.parquet")
+    ann._df = pd.DataFrame(rows)
+    ann._build_gene_index()
+    return ann
+
+
+def _coord_preds(start, end, n_tracks=1):
+    """[n_bins, n_tracks] where every track's value == the genomic position."""
+    pos = torch.arange(start, end, dtype=torch.float32)
+    return torch.stack([pos for _ in range(n_tracks)], dim=-1)
+
+
+def test_accumulator_sum_reconstructs_gene_across_tiles():
+    ann = _two_tile_annotation()
+    acc = GeneCountAccumulator(ann, resolution=1, over="exons", reduce="sum")
+    # Tile A = genomic [0,10), tile B = [10,20); values == genomic position.
+    acc.add_tile(_coord_preds(0, 10), "chr1", 0, 10)
+    acc.add_tile(_coord_preds(10, 20), "chr1", 10, 20)
+
+    gc = acc.to_gene_counts()
+    assert list(gc.gene_metadata["gene_id"]) == ["ENSG", "ENSH"]  # first-seen order
+    g = gc.gene_metadata.index[gc.gene_metadata["gene_id"] == "ENSG"][0]
+    # geneG exon signal: tile A [2,4)->2+3=5 ; tile B [12,15)->12+13+14=39 ; total 44.
+    assert gc.counts[0, g, 0].item() == pytest.approx(44.0)
+    h = gc.gene_metadata.index[gc.gene_metadata["gene_id"] == "ENSH"][0]
+    assert gc.counts[0, h, 0].item() == pytest.approx(16.0 + 17.0)
+
+
+def test_accumulator_mean_and_log():
+    ann = _two_tile_annotation()
+    acc = GeneCountAccumulator(ann, resolution=1, over="exons", reduce="mean")
+    acc.add_tile(_coord_preds(0, 10), "chr1", 0, 10)
+    acc.add_tile(_coord_preds(10, 20), "chr1", 10, 20)
+    gc = acc.to_gene_counts(log=True)
+    g = gc.gene_metadata.index[gc.gene_metadata["gene_id"] == "ENSG"][0]
+    # mean over 5 exon bases = 44/5 = 8.8 ; then log1p.
+    assert gc.space == "log"
+    assert gc.counts[0, g, 0].item() == pytest.approx(math.log1p(44.0 / 5.0), abs=1e-5)
+
+
+def test_accumulator_gene_body_includes_introns():
+    ann = _two_tile_annotation()
+    acc = GeneCountAccumulator(ann, resolution=1, over="gene_body", reduce="sum")
+    acc.add_tile(_coord_preds(0, 10), "chr1", 0, 10)
+    acc.add_tile(_coord_preds(10, 20), "chr1", 10, 20)
+    gc = acc.to_gene_counts()
+    g = gc.gene_metadata.index[gc.gene_metadata["gene_id"] == "ENSG"][0]
+    # body [2,15): sum of positions 2..14 == 104 (includes the [4,12) intron).
+    assert gc.counts[0, g, 0].item() == pytest.approx(sum(range(2, 15)))
+
+
+def test_accumulator_merges_bins_shared_by_exons_at_128bp():
+    """Two exons landing in the same 128bp bin must not double-count that bin."""
+    rows = [
+        dict(Feature="gene", Chromosome="chr1", Start=10, End=150, Strand="+",
+             gene_id="ENSG", gene_name="G", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=10, End=20, Strand="+",
+             gene_id="ENSG", gene_name="G", gene_type="protein_coding"),   # -> bin 0
+        dict(Feature="exon", Chromosome="chr1", Start=30, End=40, Strand="+",
+             gene_id="ENSG", gene_name="G", gene_type="protein_coding"),   # -> bin 0 (shared)
+        dict(Feature="exon", Chromosome="chr1", Start=140, End=150, Strand="+",
+             gene_id="ENSG", gene_name="G", gene_type="protein_coding"),   # -> bin 1
+    ]
+    ann = GeneAnnotation("/tmp/does_not_exist.parquet")
+    ann._df = pd.DataFrame(rows)
+    ann._build_gene_index()
+    preds = torch.tensor([[5.0], [7.0]])  # [2 bins, 1 track]: bin0=5, bin1=7
+
+    acc = GeneCountAccumulator(ann, resolution=128, over="exons", reduce="sum")
+    acc.add_tile(preds, "chr1", 0, 256)  # 2 bins x 128bp
+    # bin0 counted once despite two exons in it: 5 + 7 = 12 (not 5 + 5 + 7).
+    assert acc.to_gene_counts().counts[0, 0, 0].item() == pytest.approx(12.0)
+
+    acc_mean = GeneCountAccumulator(ann, resolution=128, over="exons", reduce="mean")
+    acc_mean.add_tile(preds, "chr1", 0, 256)
+    # mean over 2 distinct bins = 6.0 (not 17/3 from counting bin0 twice).
+    assert acc_mean.to_gene_counts().counts[0, 0, 0].item() == pytest.approx(6.0)
+
+
+def test_accumulator_strand_and_track_metadata():
+    ann = _two_tile_annotation()
+    acc = GeneCountAccumulator(ann, resolution=1, over="exons", reduce="sum")
+    acc.add_tile(_coord_preds(0, 10, n_tracks=2), "chr1", 0, 10)
+    acc.add_tile(_coord_preds(10, 20, n_tracks=2), "chr1", 10, 20)
+    track_frame = pd.DataFrame({"track_index": [0, 1], "strand": ["+", "-"]})
+    gc = acc.to_gene_counts(track_metadata=track_frame, strand="match")
+    g = gc.gene_metadata.index[gc.gene_metadata["gene_id"] == "ENSG"][0]  # '+' gene
+    assert not torch.isnan(gc.counts[0, g, 0])       # '+' track kept
+    assert torch.isnan(gc.counts[0, g, 1])           # '-' track NaN'd

--- a/tests/unit/test_annotation_indexing.py
+++ b/tests/unit/test_annotation_indexing.py
@@ -20,9 +20,7 @@ from alphagenome_pytorch.variant_scoring.annotations import GeneAnnotation
 
 
 def _annotation(rows: list[dict]) -> GeneAnnotation:
-    ann = GeneAnnotation("/tmp/does_not_exist.parquet")  # suffix only; never read
-    ann._df = pd.DataFrame(rows)
-    ann._build_gene_index()
+    ann = GeneAnnotation(pd.DataFrame(rows))
     return ann
 
 
@@ -31,9 +29,9 @@ def _gene(gene_id, start, end, *, chrom="chr1", strand="+", gtype="protein_codin
                 gene_id=gene_id, gene_name=gene_id, gene_type=gtype)
 
 
-def _exon(gene_id, start, end, *, chrom="chr1", strand="+"):
+def _exon(gene_id, start, end, *, chrom="chr1", strand="+", gtype="protein_coding"):
     return dict(Feature="exon", Chromosome=chrom, Start=start, End=end, Strand=strand,
-                gene_id=gene_id, gene_name=gene_id, gene_type="protein_coding")
+                gene_id=gene_id, gene_name=gene_id, gene_type=gtype)
 
 
 def _brute_overlap(ann, interval, gene_types=None):
@@ -116,3 +114,55 @@ def test_exon_bin_ranges_consistent_with_mask():
         for b0, b1 in ranges:
             rebuilt[b0:b1] = True
         assert torch.equal(rebuilt, mask)
+
+
+class TestDataFrameConstructor:
+    """GeneAnnotation accepts a pre-filtered DataFrame, and rejects unusable ones.
+
+    Filtering with pandas is the supported way to restrict an annotation, so the
+    constructor has to validate what it is handed — a frame that lost its gene
+    rows answers every lookup with an empty result rather than raising, which is
+    the failure these tests pin down.
+    """
+
+    def test_dataframe_is_indexed_without_a_path(self):
+        ann = GeneAnnotation(pd.DataFrame([_gene("ENSG1", 100, 200), _exon("ENSG1", 100, 150)]))
+        assert ann.get_genes_in_interval(Interval("chr1", 0, 300)) == ["ENSG1"]
+        assert ann._get_exons_for_gene("ENSG1") == [(100, 150)]
+        # No file backs this annotation; the path aliases report that honestly.
+        assert ann.annotation_path is None
+        assert ann.gtf_path is None
+
+    def test_pre_filtering_restricts_the_gene_set(self):
+        rows = [
+            _gene("ENSG1", 100, 200), _exon("ENSG1", 100, 150),
+            _gene("ENSG2", 300, 400, gtype="lncRNA"), _exon("ENSG2", 300, 350, gtype="lncRNA"),
+        ]
+        df = pd.DataFrame(rows)
+        # gene_type sits on gene and exon rows alike, so one predicate covers both.
+        ann = GeneAnnotation(df[df.gene_type == "protein_coding"])
+        assert ann.get_genes_in_interval(Interval("chr1", 0, 500)) == ["ENSG1"]
+        assert ann._get_exons_for_gene("ENSG1") == [(100, 150)]
+        assert ann._get_exons_for_gene("ENSG2") == []
+
+    def test_filtering_away_gene_rows_raises(self):
+        """The MANE_Select footgun: transcript-level tags never match gene rows."""
+        df = pd.DataFrame([
+            dict(_gene("ENSG1", 100, 200), tag=None),
+            dict(_exon("ENSG1", 100, 150), tag="MANE_Select"),
+        ])
+        kept = df[df["tag"].astype(str).str.contains("MANE_Select")]
+        assert len(kept) == 1 and (kept.Feature == "gene").sum() == 0  # gene row dropped
+        with pytest.raises(ValueError, match="no `Feature == 'gene'` rows"):
+            GeneAnnotation(kept)
+
+    def test_missing_required_columns_raise(self):
+        df = pd.DataFrame([_gene("ENSG1", 100, 200)]).drop(columns=["gene_id"])
+        with pytest.raises(ValueError, match="missing required column"):
+            GeneAnnotation(df)
+
+    def test_gene_only_annotation_is_allowed(self):
+        """Exon rows are optional — gene-body aggregation does not need them."""
+        ann = GeneAnnotation(pd.DataFrame([_gene("ENSG1", 100, 200)]))
+        assert ann.get_genes_in_interval(Interval("chr1", 0, 300)) == ["ENSG1"]
+        assert not ann.has_exon_annotations()

--- a/tests/unit/test_annotation_indexing.py
+++ b/tests/unit/test_annotation_indexing.py
@@ -1,0 +1,118 @@
+"""Tests for GeneAnnotation's performance indices (exon index + interval index).
+
+These guard the optimizations behind the gene-expression metric:
+  - `_get_exons_for_gene` builds a merged-exon index in one pass (behavior must
+    match the old per-gene filter, including exon merging).
+  - `get_genes_in_interval` uses a start-sorted per-chromosome index but must
+    preserve the original `_gene_index` insertion order and overlap/chr-prefix
+    semantics (it's shared with variant scoring).
+  - `get_exon_bin_ranges` must be consistent with `get_exon_mask`.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+import torch
+
+from alphagenome_pytorch.variant_scoring import Interval
+from alphagenome_pytorch.variant_scoring.annotations import GeneAnnotation
+
+
+def _annotation(rows: list[dict]) -> GeneAnnotation:
+    ann = GeneAnnotation("/tmp/does_not_exist.parquet")  # suffix only; never read
+    ann._df = pd.DataFrame(rows)
+    ann._build_gene_index()
+    return ann
+
+
+def _gene(gene_id, start, end, *, chrom="chr1", strand="+", gtype="protein_coding"):
+    return dict(Feature="gene", Chromosome=chrom, Start=start, End=end, Strand=strand,
+                gene_id=gene_id, gene_name=gene_id, gene_type=gtype)
+
+
+def _exon(gene_id, start, end, *, chrom="chr1", strand="+"):
+    return dict(Feature="exon", Chromosome=chrom, Start=start, End=end, Strand=strand,
+                gene_id=gene_id, gene_name=gene_id, gene_type="protein_coding")
+
+
+def _brute_overlap(ann, interval, gene_types=None):
+    """Reference: original O(G) insertion-order overlap scan."""
+    out = []
+    for gid, info in ann._gene_index.items():
+        chrom = interval.chromosome
+        if info.chromosome != chrom and not (
+            info.chromosome == "chr" + chrom or chrom == "chr" + info.chromosome
+        ):
+            continue
+        if info.end <= interval.start or info.start >= interval.end:
+            continue
+        if gene_types is not None and info.gene_type not in gene_types:
+            continue
+        out.append(gid)
+    return out
+
+
+def test_get_genes_in_interval_preserves_insertion_order():
+    # Insertion order deliberately differs from start-sorted order.
+    ann = _annotation([
+        _gene("LATE", 5000, 5200),
+        _gene("EARLY", 100, 200),
+        _gene("BIG", 0, 9000),   # long gene starting far before the query window
+    ])
+    iv = Interval("chr1", 4000, 6000)
+    got = ann.get_genes_in_interval(iv)
+    # BIG must be found despite starting at 0 (the max-gene-span lower bound),
+    # and results come back in _gene_index insertion order: LATE before BIG.
+    assert got == ["LATE", "BIG"]
+    assert got == _brute_overlap(ann, iv)
+
+
+def test_get_genes_in_interval_matches_bruteforce_over_many_windows():
+    rows = [_gene(f"G{i}", start=i * 137 % 9000, end=i * 137 % 9000 + (i % 5) * 300 + 50)
+            for i in range(60)]
+    ann = _annotation(rows)
+    for qs in range(0, 9000, 250):
+        iv = Interval("chr1", qs, qs + 500)
+        assert ann.get_genes_in_interval(iv) == _brute_overlap(ann, iv)
+
+
+def test_get_genes_in_interval_chr_prefix_and_gene_types():
+    ann = _annotation([
+        _gene("A", 100, 200, chrom="1"),               # stored WITHOUT chr prefix
+        _gene("B", 100, 200, chrom="chr1", gtype="lncRNA"),
+    ])
+    # Query 'chr1' still finds the '1'-stored gene, and vice versa.
+    assert set(ann.get_genes_in_interval(Interval("chr1", 50, 300))) == {"A", "B"}
+    assert set(ann.get_genes_in_interval(Interval("1", 50, 300))) == {"A", "B"}
+    # gene_types filter preserved.
+    assert ann.get_genes_in_interval(Interval("chr1", 50, 300), gene_types=["lncRNA"]) == ["B"]
+
+
+def test_exon_index_merges_overlapping_exons():
+    ann = _annotation([
+        _gene("A", 100, 400),
+        _exon("A", 100, 150),
+        _exon("A", 140, 200),   # overlaps previous -> merge to (100, 200)
+        _exon("A", 300, 350),
+    ])
+    assert ann._get_exons_for_gene("A") == [(100, 200), (300, 350)]
+    # Versioned lookups collapse to the same base id.
+    ann2 = _annotation([_gene("ENSG1.7", 100, 200), _exon("ENSG1.7", 100, 200)])
+    assert ann2._get_exons_for_gene("ENSG1") == [(100, 200)]
+
+
+def test_exon_bin_ranges_consistent_with_mask():
+    ann = _annotation([
+        _gene("A", 100, 400),
+        _exon("A", 110, 130),
+        _exon("A", 200, 264),
+    ])
+    iv = Interval("chr1", 100, 356)  # width 256
+    for resolution, seq_length in ((1, 256), (128, 2)):
+        ranges = ann.get_exon_bin_ranges("A", iv, resolution, seq_length)
+        mask = ann.get_exon_mask("A", iv, resolution, seq_length)
+        rebuilt = torch.zeros(seq_length, dtype=torch.bool)
+        for b0, b1 in ranges:
+            rebuilt[b0:b1] = True
+        assert torch.equal(rebuilt, mask)

--- a/tests/unit/test_dataset_gene_mask.py
+++ b/tests/unit/test_dataset_gene_mask.py
@@ -223,3 +223,37 @@ class TestMultimodalDatasetGeneMask:
         seq, modality_targets, gene_mask = result
         assert set(modality_targets.keys()) == {"atac", "rna_seq"}
         assert gene_mask.shape == (2048, 2, 4)
+
+    def test_return_coords_appends_window_coords(
+        self, fasta_file, bigwig_file, bed_file
+    ):
+        ds = GenomicDataset(
+            genome_fasta=fasta_file, bigwig_files=[bigwig_file],
+            bed_file=bed_file, sequence_length=2048, resolutions=(1,),
+        )
+        multi = MultimodalDataset({"atac": ds}, return_coords=True)
+        result = multi[0]
+        # No gene_mask, so coords are the sole trailing element.
+        assert len(result) == 3
+        seq, modality_targets, coords = result
+        assert "atac" in modality_targets
+        # coords is the window this sample spans, taken from the primary dataset.
+        assert coords == ds._positions_list[0]
+        chrom, start, end = coords
+        assert isinstance(chrom, str) and end - start == 2048
+
+    def test_return_coords_with_gene_mask_orders_mask_then_coords(
+        self, fasta_file, bigwig_file, bed_file, extractor
+    ):
+        rna = GenomicDataset(
+            genome_fasta=fasta_file, bigwig_files=[bigwig_file],
+            bed_file=bed_file, sequence_length=2048, resolutions=(1,),
+            gene_mask_extractor=extractor, g_max=4,
+        )
+        multi = MultimodalDataset({"rna_seq": rna}, return_coords=True)
+        result = multi[0]
+        # gene_mask (Tensor) first, then coords (tuple) — the order collate sniffs.
+        assert len(result) == 4
+        seq, modality_targets, gene_mask, coords = result
+        assert gene_mask.shape == (2048, 2, 4)
+        assert coords == rna._positions_list[0]

--- a/tests/unit/test_finetune_multitask.py
+++ b/tests/unit/test_finetune_multitask.py
@@ -368,6 +368,110 @@ class TestCollateMultimodal:
         assert torch.equal(modality_targets["atac"][128][0], targets1)
         assert torch.equal(modality_targets["atac"][128][1], targets2)
 
+    def test_collate_preserves_gene_mask(self):
+        # Regression guard: the collate historically dropped item[2], silently
+        # no-op'ing the gene-LFC training loss. It must now survive collation as
+        # extras["gene_mask"], stacked with a leading batch axis.
+        gm1 = torch.zeros(256, 2, 4, dtype=torch.bool)
+        gm2 = torch.ones(256, 2, 4, dtype=torch.bool)
+        batch = [
+            (torch.randn(256, 4), {"rna_seq": {1: torch.randn(256, 3)}}, gm1),
+            (torch.randn(256, 4), {"rna_seq": {1: torch.randn(256, 3)}}, gm2),
+        ]
+        sequences, modality_targets, extras = collate_multimodal(batch)
+        assert "gene_mask" in extras
+        assert extras["gene_mask"].shape == (2, 256, 2, 4)
+        assert torch.equal(extras["gene_mask"][0], gm1)
+        assert torch.equal(extras["gene_mask"][1], gm2)
+        assert "coords" not in extras
+
+    def test_collate_preserves_coords(self):
+        batch = [
+            (torch.randn(256, 4), {"rna_seq": {1: torch.randn(256, 3)}}, ("chr1", 0, 256)),
+            (torch.randn(256, 4), {"rna_seq": {1: torch.randn(256, 3)}}, ("chr2", 5, 261)),
+        ]
+        sequences, modality_targets, extras = collate_multimodal(batch)
+        assert extras["coords"] == [("chr1", 0, 256), ("chr2", 5, 261)]
+        assert "gene_mask" not in extras
+
+    def test_collate_preserves_gene_mask_and_coords(self):
+        gm = torch.ones(256, 2, 4, dtype=torch.bool)
+        batch = [
+            (torch.randn(256, 4), {"rna_seq": {1: torch.randn(256, 3)}}, gm, ("chr1", 0, 256)),
+        ]
+        sequences, modality_targets, extras = collate_multimodal(batch)
+        assert extras["gene_mask"].shape == (1, 256, 2, 4)
+        assert extras["coords"] == [("chr1", 0, 256)]
+
+    def test_unpack_batch_decodes_collate_contract(self):
+        # _unpack_batch is the consumer-side decode of the collate output.
+        from alphagenome_pytorch.extensions.finetuning.training import _unpack_batch
+
+        seqs = torch.randn(2, 8, 4)
+        targets = {"rna_seq": {1: torch.randn(2, 8, 3)}}
+        # 2-tuple (no extras) -> empty extras dict
+        s, t, e = _unpack_batch((seqs, targets))
+        assert s is seqs and t is targets and e == {}
+        # 3-tuple -> extras passed straight through
+        extras = {"gene_mask": torch.ones(2, 8, 2, 4), "coords": [("chr1", 0, 8), ("chr2", 5, 13)]}
+        s, t, e = _unpack_batch((seqs, targets, extras))
+        assert e is extras
+
+
+@pytest.mark.unit
+class TestParseArgsGeneExprEval:
+    """Validation of the --gene-expr-eval flag in scripts/finetune.py."""
+
+    def _rna_cli(self, monkeypatch, extra):
+        monkeypatch.setattr(
+            sys, "argv",
+            _required_cli_args()
+            + ["--modality", "rna_seq", "--bigwig", "rna1.bw"] + extra,
+        )
+
+    def test_happy_path_sets_flags(self, monkeypatch):
+        self._rna_cli(monkeypatch, [
+            "--gene-expr-eval",
+            "--gene-expr-annotation", "gencode.parquet",
+            "--track-strands", "+",
+        ])
+        args = parse_args()
+        assert args.gene_expr_eval is True
+        assert args.gene_expr_annotation == "gencode.parquet"
+
+    def test_falls_back_to_gtf_annotation(self, monkeypatch):
+        self._rna_cli(monkeypatch, [
+            "--gene-expr-eval", "--gtf", "genes.gtf", "--track-strands", "+",
+        ])
+        args = parse_args()  # --gtf satisfies the annotation requirement
+        assert args.gene_expr_eval is True
+
+    def test_requires_annotation(self, monkeypatch):
+        self._rna_cli(monkeypatch, ["--gene-expr-eval", "--track-strands", "+"])
+        with pytest.raises(SystemExit):
+            parse_args()
+
+    def test_requires_strands(self, monkeypatch):
+        self._rna_cli(monkeypatch, [
+            "--gene-expr-eval", "--gene-expr-annotation", "gencode.parquet",
+        ])
+        with pytest.raises(SystemExit):
+            parse_args()
+
+    def test_requires_rna_seq_modality(self, monkeypatch):
+        monkeypatch.setattr(
+            sys, "argv",
+            _required_cli_args()
+            + ["--modality", "atac", "--bigwig", "atac1.bw",
+               "--gene-expr-eval", "--gene-expr-annotation", "gencode.parquet"],
+        )
+        with pytest.raises(SystemExit):
+            parse_args()
+
+    def test_off_by_default(self, monkeypatch):
+        self._rna_cli(monkeypatch, [])
+        assert parse_args().gene_expr_eval is False
+
 
 @pytest.mark.unit
 class TestUnwrapTrainingModel:

--- a/tests/unit/test_full_chromosome.py
+++ b/tests/unit/test_full_chromosome.py
@@ -385,6 +385,37 @@ class TestStitchingWithMockModel:
         assert counts["ENSX"] == pytest.approx(3.0)  # 3 exon bins, all-A -> 1.0 each
         assert counts["ENSY"] == pytest.approx(3.0)  # reconstructed across the tile seam
 
+    def test_gene_counts_anndata_requires_exon_rows(self):
+        """over='exons' with a gene-only annotation errors up front, not after inference."""
+        import pandas as pd
+        from alphagenome_pytorch.extensions.inference.full_chromosome import (
+            predict_full_chromosomes_to_anndata,
+            GenomeSequenceProvider,
+        )
+        from alphagenome_pytorch.variant_scoring.annotations import GeneAnnotation
+
+        chrom_len = 131072
+        config = TilingConfig(crop_bp=0, resolution=128, batch_size=1)
+        model = self._MockModel(resolution=128, n_tracks=1)
+        provider = self._build_in_memory_provider(GenomeSequenceProvider, chrom_len)
+        # Gene-only annotation: no exon rows.
+        ann = GeneAnnotation("/tmp/does_not_exist.parquet")
+        ann._df = pd.DataFrame([
+            dict(Feature="gene", Chromosome="chr1", Start=256, End=640, Strand="+",
+                 gene_id="ENSX", gene_name="X", gene_type="protein_coding"),
+        ])
+        ann._build_gene_index()
+
+        kwargs = dict(chromosomes=["chr1"], config=config, track_indices=[0],
+                      device="cpu", show_progress=False)
+        with pytest.raises(ValueError, match="exon rows"):
+            predict_full_chromosomes_to_anndata(model, provider, ann, "atac",
+                                                over="exons", **kwargs)
+        # gene_body works with the same gene-only annotation.
+        gc = predict_full_chromosomes_to_anndata(model, provider, ann, "atac",
+                                                 over="gene_body", **kwargs)
+        assert list(gc.gene_metadata["gene_id"]) == ["ENSX"]
+
     def test_gene_counts_anndata_write_path(self, tmp_path):
         """End-to-end: write .h5ad and read it back; check orientation + metadata."""
         import pandas as pd

--- a/tests/unit/test_full_chromosome.py
+++ b/tests/unit/test_full_chromosome.py
@@ -370,9 +370,7 @@ class TestStitchingWithMockModel:
             dict(Feature="exon", Chromosome="chr1", Start=130944, End=131328, Strand="+",
                  gene_id="ENSY", gene_name="Y", gene_type="protein_coding"),
         ]
-        ann = GeneAnnotation("/tmp/does_not_exist.parquet")
-        ann._df = pd.DataFrame(rows)
-        ann._build_gene_index()
+        ann = GeneAnnotation(pd.DataFrame(rows))
 
         gc = predict_full_chromosomes_to_anndata(
             model, provider, ann, "atac",
@@ -399,12 +397,10 @@ class TestStitchingWithMockModel:
         model = self._MockModel(resolution=128, n_tracks=1)
         provider = self._build_in_memory_provider(GenomeSequenceProvider, chrom_len)
         # Gene-only annotation: no exon rows.
-        ann = GeneAnnotation("/tmp/does_not_exist.parquet")
-        ann._df = pd.DataFrame([
+        ann = GeneAnnotation(pd.DataFrame([
             dict(Feature="gene", Chromosome="chr1", Start=256, End=640, Strand="+",
                  gene_id="ENSX", gene_name="X", gene_type="protein_coding"),
-        ])
-        ann._build_gene_index()
+        ]))
 
         kwargs = dict(chromosomes=["chr1"], config=config, track_indices=[0],
                       device="cpu", show_progress=False)
@@ -436,9 +432,7 @@ class TestStitchingWithMockModel:
             dict(Feature="exon", Chromosome="chr1", Start=256, End=640, Strand="+",
                  gene_id="ENSX", gene_name="X", gene_type="protein_coding"),  # bins [2,5)
         ]
-        ann = GeneAnnotation("/tmp/does_not_exist.parquet")
-        ann._df = pd.DataFrame(rows)
-        ann._build_gene_index()
+        ann = GeneAnnotation(pd.DataFrame(rows))
 
         out = tmp_path / "gene_counts.h5ad"
         predict_full_chromosomes_to_anndata(

--- a/tests/unit/test_full_chromosome.py
+++ b/tests/unit/test_full_chromosome.py
@@ -343,6 +343,88 @@ class TestStitchingWithMockModel:
         # Check no zeros in the interior (would indicate gaps in stitching)
         assert np.all(preds[1:-1, 0] > 0)
 
+    def test_gene_counts_anndata_across_tiles(self):
+        """Whole-chromosome gene counts reconstruct a gene that spans two tiles."""
+        import pandas as pd
+        from alphagenome_pytorch.extensions.inference.full_chromosome import (
+            predict_full_chromosomes_to_anndata,
+            GenomeSequenceProvider,
+        )
+        from alphagenome_pytorch.variant_scoring.annotations import GeneAnnotation
+
+        chrom_len = 131072 * 2  # two 131072bp tiles at crop_bp=0
+        config = TilingConfig(crop_bp=0, resolution=128, batch_size=1)
+        model = self._MockModel(resolution=128, n_tracks=1)  # all-A genome -> every bin == 1.0
+        provider = self._build_in_memory_provider(GenomeSequenceProvider, chrom_len)
+
+        # geneX: exon [256,640) -> bins [2,5) in tile 0 (3 bins).
+        # geneY: exon [130944,131328) straddles the tile-0/tile-1 boundary at 131072
+        #        -> 1 bin in tile 0 + 2 bins in tile 1 (3 bins total).
+        rows = [
+            dict(Feature="gene", Chromosome="chr1", Start=256, End=640, Strand="+",
+                 gene_id="ENSX", gene_name="X", gene_type="protein_coding"),
+            dict(Feature="exon", Chromosome="chr1", Start=256, End=640, Strand="+",
+                 gene_id="ENSX", gene_name="X", gene_type="protein_coding"),
+            dict(Feature="gene", Chromosome="chr1", Start=130944, End=131328, Strand="+",
+                 gene_id="ENSY", gene_name="Y", gene_type="protein_coding"),
+            dict(Feature="exon", Chromosome="chr1", Start=130944, End=131328, Strand="+",
+                 gene_id="ENSY", gene_name="Y", gene_type="protein_coding"),
+        ]
+        ann = GeneAnnotation("/tmp/does_not_exist.parquet")
+        ann._df = pd.DataFrame(rows)
+        ann._build_gene_index()
+
+        gc = predict_full_chromosomes_to_anndata(
+            model, provider, ann, "atac",
+            chromosomes=["chr1"], config=config, track_indices=[0],
+            over="exons", reduce="sum", device="cpu", show_progress=False,
+        )
+
+        counts = {gid: gc.counts[0, i, 0].item()
+                  for i, gid in enumerate(gc.gene_metadata["gene_id"])}
+        assert counts["ENSX"] == pytest.approx(3.0)  # 3 exon bins, all-A -> 1.0 each
+        assert counts["ENSY"] == pytest.approx(3.0)  # reconstructed across the tile seam
+
+    def test_gene_counts_anndata_write_path(self, tmp_path):
+        """End-to-end: write .h5ad and read it back; check orientation + metadata."""
+        import pandas as pd
+        anndata = pytest.importorskip("anndata")
+        from alphagenome_pytorch.extensions.inference.full_chromosome import (
+            predict_full_chromosomes_to_anndata,
+            GenomeSequenceProvider,
+        )
+        from alphagenome_pytorch.variant_scoring.annotations import GeneAnnotation
+
+        chrom_len = 131072
+        config = TilingConfig(crop_bp=0, resolution=128, batch_size=1)
+        model = self._MockModel(resolution=128, n_tracks=2)  # track 0 == 1.0, track 1 == 0.0
+        provider = self._build_in_memory_provider(GenomeSequenceProvider, chrom_len)
+        rows = [
+            dict(Feature="gene", Chromosome="chr1", Start=256, End=640, Strand="+",
+                 gene_id="ENSX", gene_name="X", gene_type="protein_coding"),
+            dict(Feature="exon", Chromosome="chr1", Start=256, End=640, Strand="+",
+                 gene_id="ENSX", gene_name="X", gene_type="protein_coding"),  # bins [2,5)
+        ]
+        ann = GeneAnnotation("/tmp/does_not_exist.parquet")
+        ann._df = pd.DataFrame(rows)
+        ann._build_gene_index()
+
+        out = tmp_path / "gene_counts.h5ad"
+        predict_full_chromosomes_to_anndata(
+            model, provider, ann, "atac",
+            output_path=str(out), chromosomes=["chr1"], config=config,
+            track_indices=[0, 1], track_names=["t0", "t1"],
+            over="exons", reduce="sum", device="cpu", show_progress=False,
+        )
+
+        assert out.exists()
+        adata = anndata.read_h5ad(str(out))
+        assert adata.shape == (2, 1)                       # obs=tracks, var=genes
+        assert list(adata.var_names) == ["ENSX"]
+        assert list(adata.obs["track_name"]) == ["t0", "t1"]
+        assert float(adata.X[0, 0]) == pytest.approx(3.0)  # track 0: 3 exon bins x 1.0
+        assert float(adata.X[1, 0]) == pytest.approx(0.0)  # track 1: mock is 0
+
 
 @pytest.mark.unit
 class TestHeadConfigs:

--- a/tests/unit/test_gene_expr_val_metric.py
+++ b/tests/unit/test_gene_expr_val_metric.py
@@ -1,0 +1,173 @@
+"""Tests for the exon-based gene-expression validation metric glue.
+
+The correlation math, exon masking, >=50% rule, and strand matching are covered
+in ``test_aggregation.py``. Here we test the training-side glue that connects
+``validate_multihead`` to those helpers: ``_accumulate_gene_expr_windows`` builds
+per-window ``(gene_ids, pred, obs)`` triples from batched predictions + coords,
+which ``combine_gene_expression`` then dedups and correlates.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+import pytest
+import torch
+
+from alphagenome_pytorch.aggregation import combine_gene_expression
+from alphagenome_pytorch.extensions.finetuning.training import (
+    _accumulate_gene_expr_windows,
+    _gene_expr_metrics,
+)
+from alphagenome_pytorch.variant_scoring.annotations import GeneAnnotation
+
+INTERVAL = ("chr1", 100, 120)  # width 20, 1bp resolution
+
+
+def _make_annotation() -> GeneAnnotation:
+    rows = [
+        # geneA + : exons [102,104) and [106,108) (intron 104-106)
+        dict(Feature="gene", Chromosome="chr1", Start=102, End=108, Strand="+",
+             gene_id="ENSGA", gene_name="A", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=102, End=104, Strand="+",
+             gene_id="ENSGA", gene_name="A", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=106, End=108, Strand="+",
+             gene_id="ENSGA", gene_name="A", gene_type="protein_coding"),
+        # geneB - : exon [110,116)
+        dict(Feature="gene", Chromosome="chr1", Start=110, End=116, Strand="-",
+             gene_id="ENSGB", gene_name="B", gene_type="protein_coding"),
+        dict(Feature="exon", Chromosome="chr1", Start=110, End=116, Strand="-",
+             gene_id="ENSGB", gene_name="B", gene_type="protein_coding"),
+    ]
+    ann = GeneAnnotation("/tmp/does_not_exist.parquet")  # suffix only; never read
+    ann._df = pd.DataFrame(rows)
+    ann._build_gene_index()
+    return ann
+
+
+def _position_preds(batch=2, seq_len=20, n_tracks=3):
+    """[B, S, C] where channel c = position index * (c + 1)."""
+    pos = torch.arange(seq_len, dtype=torch.float32)
+    one = torch.stack([pos * (c + 1) for c in range(n_tracks)], dim=-1)
+    return one.unsqueeze(0).repeat(batch, 1, 1)
+
+
+def test_accumulate_builds_windows_and_dedups():
+    ann = _make_annotation()
+    pred = _position_preds(batch=2)
+    obs = pred.clone()  # perfect prediction -> correlation 1
+    coords = [INTERVAL, INTERVAL]  # same window twice -> genes dedup across windows
+
+    windows: list = []
+    _accumulate_gene_expr_windows(
+        windows,
+        pred_unscaled=pred,
+        targets=obs,
+        coords=coords,
+        annotation=ann,
+        track_strands=None,
+    )
+    # One triple per batch window; each holds both genes (geneA, geneB).
+    assert len(windows) == 2
+    for gene_ids, p, o in windows:
+        assert gene_ids == ["ENSGA", "ENSGB"]
+        assert p.shape == (2, 3) and o.shape == (2, 3)
+        # log1p of the exon-mean; geneA channel0 mean over exon positions = 4.5
+        assert p[0, 0].item() == pytest.approx(math.log1p(4.5), abs=1e-5)
+
+    out = combine_gene_expression(windows)
+    assert out["n_genes"] == 2  # deduped across the two identical windows
+    assert out["across_genes"] == pytest.approx(1.0, abs=1e-4)
+    assert set(out) == {"across_genes", "across_genes_norm", "across_tracks_norm", "n_genes"}
+
+
+def test_accumulate_strand_matching_nans_incompatible_cells():
+    ann = _make_annotation()
+    pred = _position_preds(batch=1)
+    windows: list = []
+    _accumulate_gene_expr_windows(
+        windows,
+        pred_unscaled=pred,
+        targets=pred.clone(),
+        coords=[INTERVAL],
+        annotation=ann,
+        track_strands=["+", "-", "."],
+    )
+    gene_ids, p, _ = windows[0]
+    # geneA(+): '+' kept, '-' NaN, '.' kept.
+    assert not torch.isnan(p[0, 0]) and torch.isnan(p[0, 1]) and not torch.isnan(p[0, 2])
+    # geneB(-): '+' NaN, '-' kept.
+    assert torch.isnan(p[1, 0]) and not torch.isnan(p[1, 1])
+
+
+def test_accumulate_skips_windows_without_genes():
+    ann = _make_annotation()
+    pred = _position_preds(batch=2)
+    # Second window is far from any annotated gene -> no qualifying genes.
+    coords = [INTERVAL, ("chr1", 100_000, 100_020)]
+    windows: list = []
+    _accumulate_gene_expr_windows(
+        windows,
+        pred_unscaled=pred,
+        targets=pred.clone(),
+        coords=coords,
+        annotation=ann,
+        track_strands=None,
+    )
+    assert len(windows) == 1  # empty window skipped
+    assert windows[0][0] == ["ENSGA", "ENSGB"]
+
+
+def test_accumulate_window_cache_builds_once_per_window():
+    ann = _make_annotation()
+    pred = _position_preds(batch=2)  # both items are the same INTERVAL window
+    coords = [INTERVAL, INTERVAL]
+    cache: dict = {}
+    windows: list = []
+    _accumulate_gene_expr_windows(
+        windows,
+        pred_unscaled=pred,
+        targets=pred.clone(),
+        coords=coords,
+        annotation=ann,
+        track_strands=["+", "-", "."],
+        window_cache=cache,
+    )
+    # Two batch items × (pred + obs) = 4 lookups, but a single unique window.
+    assert len(cache) == 1
+    assert len(windows) == 2
+    # Reusing the same cache on a later "epoch" adds nothing new.
+    _accumulate_gene_expr_windows(
+        windows, pred_unscaled=pred, targets=pred.clone(), coords=coords,
+        annotation=ann, track_strands=["+", "-", "."], window_cache=cache,
+    )
+    assert len(cache) == 1
+
+
+# --------------------------------------------------------------------------- #
+# _gene_expr_metrics: the reduce/emit step (single-rank path)
+# --------------------------------------------------------------------------- #
+def test_gene_expr_metrics_emits_named_keys():
+    torch.manual_seed(4)
+    truth = torch.randn(6, 4)
+    pred = truth + 0.02 * torch.randn(6, 4)
+    windows = [
+        (["g0", "g1", "g2"], pred[:3], truth[:3]),
+        (["g3", "g4", "g5"], pred[3:], truth[3:]),
+    ]
+    m = _gene_expr_metrics(windows, modality="rna_seq", world_size=1)
+    assert set(m) == {
+        "rna_seq_gene_log_expr_pearson_across_genes",
+        "rna_seq_gene_log_expr_pearson_across_genes_norm",
+        "rna_seq_gene_log_expr_pearson_across_tracks_norm",
+        "rna_seq_gene_log_expr_n_genes",
+    }
+    assert m["rna_seq_gene_log_expr_n_genes"] == 6
+    assert m["rna_seq_gene_log_expr_pearson_across_genes"] > 0.9
+
+
+def test_gene_expr_metrics_modality_prefix_and_empty():
+    m = _gene_expr_metrics([], modality="cage", world_size=1)
+    assert m["cage_gene_log_expr_n_genes"] == 0
+    assert math.isnan(m["cage_gene_log_expr_pearson_across_genes"])

--- a/tests/unit/test_gene_expr_val_metric.py
+++ b/tests/unit/test_gene_expr_val_metric.py
@@ -169,3 +169,45 @@ def test_gene_expr_metrics_modality_prefix_and_empty():
     m = _gene_expr_metrics([], modality="cage", world_size=1)
     assert m["cage_gene_log_expr_n_genes"] == 0
     assert math.isnan(m["cage_gene_log_expr_pearson_across_genes"])
+
+
+class TestGeneExprResolutionSelection:
+    """The metric only reads the head output at `gene_expr_resolution`.
+
+    A resolution the modality never emits matches nothing, so no window
+    accumulates and every epoch reports n_genes=0 with NaN correlations and no
+    error — a whole run's metric silently void. These pin the guard and the
+    encoder-only default that caused it.
+    """
+
+    class _Stub:
+        def eval(self):
+            return self
+
+    def _validate(self, *, encoder_only, res_weights, gene_expr_resolution=None):
+        from alphagenome_pytorch.extensions.finetuning.training import validate_multihead
+
+        return validate_multihead(
+            model=self._Stub(), heads={"rna_seq": self._Stub()}, val_loader=[],
+            device="cpu", modality_weights={"rna_seq": 1.0},
+            resolution_weights={"rna_seq": res_weights},
+            positional_weight=1.0, count_weight=1.0, use_amp=False,
+            encoder_only=encoder_only, gene_annotation=_make_annotation(),
+            gene_expr_resolution=gene_expr_resolution,
+        )
+
+    def test_encoder_only_defaults_to_128bp(self):
+        # Encoder-only heads emit 128bp only; the 1bp default would match nothing.
+        self._validate(encoder_only=True, res_weights={128: 1.0})
+
+    def test_default_is_1bp_otherwise(self):
+        self._validate(encoder_only=False, res_weights={1: 1.0, 128: 1.0})
+
+    def test_resolution_the_modality_never_emits_raises(self):
+        with pytest.raises(ValueError, match="requested at 1bp"):
+            self._validate(encoder_only=False, res_weights={128: 1.0})
+
+    def test_encoder_only_forced_to_1bp_raises_and_says_why(self):
+        with pytest.raises(ValueError, match="encoder_only forces 128bp"):
+            self._validate(encoder_only=True, res_weights={128: 1.0},
+                           gene_expr_resolution=1)

--- a/tests/unit/test_gene_expr_val_metric.py
+++ b/tests/unit/test_gene_expr_val_metric.py
@@ -40,9 +40,7 @@ def _make_annotation() -> GeneAnnotation:
         dict(Feature="exon", Chromosome="chr1", Start=110, End=116, Strand="-",
              gene_id="ENSGB", gene_name="B", gene_type="protein_coding"),
     ]
-    ann = GeneAnnotation("/tmp/does_not_exist.parquet")  # suffix only; never read
-    ann._df = pd.DataFrame(rows)
-    ann._build_gene_index()
+    ann = GeneAnnotation(pd.DataFrame(rows))
     return ann
 
 


### PR DESCRIPTION
## Signal aggregation and exon masking for RNA-seq

Default validation has been reported for profile and count prediction by default. For RNA-seq, we should also report log-transformed mean coverage across annotated exons. We can also rely on the same core code to turn per-position predictions into gene x track matrices.

1. **Gene aggregation API** — `aggregate_genes` / `gene_expression` → `GeneCounts` → AnnData.
2. **Gene-expression validation metric** for RNA-seq fine-tuning (`--gene-expr-eval`).
3. **Whole-chromosome gene-count export** to `.h5ad` (`predict_full_chromosome.py --anndata`).


## 1. Per-gene count matrix from whole-chromosome predictions

```bash
python scripts/predict_full_chromosome.py \
  --model model.pth --fasta hg38.fa --output out/ \
  --head rna_seq --resolution 1 --crop-bp 16384 \
  --anndata rna_seq_gene_counts.h5ad \
  --annotation gencode.v46.parquet \
  --aggregate-over exons --aggregate-func sum \
  --chromosomes chr20,chr21
```

Writes `out/rna_seq_gene_counts.h5ad` with tracks in `obs`, genes in `var`, and `X` matrix with aggregated counts.

| flag | description |
|---|---|
| `--anndata NAME` | write the gene-count table into `--output` (instead of BigWig) |
| `--annotation` | GTF/parquet; needs exon rows for `--aggregate-over exons` |
| `--aggregate-over {exons,gene-body}` | exons (default) or the whole gene body (needs only gene rows) |
| `--aggregate-func {sum,mean,log-mean}` | raw counts (default), length-normalized mean, or `log1p(mean)` |
| `--gene-strand {all,match}` | keep every track (default), or NaN strand-incompatible cells |
| `--track-strands` | per-track `+`/`-`/`.` (required for `--gene-strand match`) |

Tiling covers every base exactly once (`--crop-bp` trims edge artifacts), so a gene's signal is
summed across whatever tiles it spans — counts are complete, with no window-overlap filter.

### 2. Python API

```python
from alphagenome_pytorch import aggregate_genes, gene_expression

# coverage over annotated gene bodies
gc = aggregate_genes(preds["rna_seq"][1], gene_table, ("chr1", start, end),
                     track_metadata=runtime.get_track_metadata(0, "rna_seq"))
X, obs, var = gc.to_tables()   # X: [tracks, genes]
adata = gc.to_anndata()

# log-mean coverage over annotated exons, strand-matched
ge = gene_expression(preds["rna_seq"][1], annotation, interval, track_metadata=...)
```

### 3. Gene-expression metric during fine-tuning (opt-in)

```bash
python scripts/finetune.py ... \
  --modality rna_seq --bigwig r1.bw r2.bw ... \
  --gene-expr-eval \
  --gene-expr-annotation gencode.v46.parquet \   # MUST have exon rows
  --track-strands '+-+-...'
```

Emits per validation epoch (straight to wandb):

- `rna_seq_gene_log_expr_pearson_across_genes` ← main value
- `rna_seq_gene_log_expr_pearson_across_genes_norm`
- `rna_seq_gene_log_expr_pearson_across_tracks_norm`
- `rna_seq_gene_log_expr_n_genes`

The default count/profile Pearson metrics are kept as well.

## Implementation

### Files

1. **`src/alphagenome_pytorch/aggregation.py`** — aggregation core.
   - `aggregate_intervals(predictions[B,S,C], mask[S,R]) -> [B,R,C]`: one einsum primitive every
     consumer shares.
   - `aggregate_genes` (gene body, linear) / `gene_expression` (exons, log-mean, strand-matched,
     ≥50% rule) → `GeneCounts` (`.to_dataframe/.to_tables/.to_anndata`).
   - `GeneCountAccumulator`: streams tiled predictions into a running `[gene, track]` matrix.
   - Correlation helpers: `_nan_pearson`, `normalize_expression`, `gene_expression_correlations`,
     `combine_gene_expression`.
2. **`extensions/inference/full_chromosome.py`** — `_iter_tile_predictions` (shared by the BigWig
   and gene-count paths) and `predict_full_chromosomes_to_anndata`.
3. **`extensions/finetuning/training.py`** — the val-metric glue inside `validate_multihead`.
4. **`scripts/`** — CLI wiring.

### Decisions and defaults

- **The ≥50% rule counts fully-contained exons, not base pairs.** "Exons" means the gene's
  *merged* exonic blocks (collapsed across transcripts), not raw GTF rows — documented inline in
  `_build_exon_window`.
  - This follows the evaluation of ["genes with at least 50% of their exons falling within a test interval"](https://www.biorxiv.org/content/10.1101/2025.06.25.661532v2.full) with its stated purpose to avoid duplicate genes across test intervals.
- **`_nan_pearson` scores zero-variance columns as `r=0` and includes them in the mean.** This
  is to stay compatible with `alphagenome_research/evals/regression_metrics.py`, which masks its mean only by
  `count > 0`.
- **The export accumulates per gene during tiling** rather than materializing a chromosome-length
  array (768 tracks @ 1 bp would be ~750 GB/chromosome).
- **`--anndata` produces the gene-count table *instead of* BigWig.** Most likely it's a different use case (gene counts x many tracks) than 1 bp signal x a few track of interests.

### Fixes along the way

- `gene_mask` in `collate_multimodal`for the gene-LFC training loss.
- checkpoint track name subsetting by `--tracks`.
- `_merge_strand_pairs` memory allocation device.
- 128 bp bin counting by`GeneCountAccumulator.add_tile` when shared by two exons.

### Performance optimizations

- `GeneAnnotation`: one-pass exon index and a start-sorted per-chromosome bisect index for `get_genes_in_interval`.
- Per-window exon-mask cache, built once and reused across epochs in the val loop.

