### PR TITLE
Organism index provenance for fine-tuning

### DIFF
--- a/scripts/evaluate_finetuned.py
+++ b/scripts/evaluate_finetuned.py
@@ -57,18 +57,16 @@ from scipy import stats
 from torch.utils.data import DataLoader, Subset
 from tqdm import tqdm
 
-from alphagenome_pytorch import AlphaGenome
 from alphagenome_pytorch.extensions.finetuning.checkpointing import (
     is_delta_checkpoint,
     load_delta_checkpoint,
     load_finetuned_model as _load_finetuned_model,
+    select_organism_index,
 )
+from alphagenome_pytorch.extensions.finetuning.evaluation import load_native_model
 from alphagenome_pytorch.extensions.finetuning.datasets import GenomicDataset
-from alphagenome_pytorch.extensions.finetuning.heads import create_finetuning_head
 from alphagenome_pytorch.extensions.finetuning.training import collate_genomic
-from alphagenome_pytorch.extensions.finetuning.transfer import load_trunk
 from alphagenome_pytorch.losses import multinomial_loss
-from alphagenome_pytorch.named_outputs import TrackMetadataCatalog
 
 log = logging.getLogger(__name__)
 
@@ -102,73 +100,6 @@ def load_finetuned_model(
     return model, meta
 
 
-def load_native_model(
-    pretrained_weights: str,
-    native_biosample: str | None,
-    native_track_index: int | None,
-    modality: str,
-    device: torch.device,
-) -> tuple[nn.Module, int, str]:
-    """Load pretrained model with all native heads and find matching track.
-
-    Returns (model, track_index, display_name).
-    """
-    log.info("Loading native model for comparison...")
-    model = AlphaGenome.from_pretrained(pretrained_weights, device=device)
-    model.eval()
-    for p in model.parameters():
-        p.requires_grad = False
-
-    catalog = TrackMetadataCatalog.load_builtin("human")
-    model.set_track_metadata_catalog(catalog)
-
-    if native_track_index is not None:
-        # Direct index — validate it exists
-        tracks = catalog.get_tracks(modality, organism=0)
-        if native_track_index >= len(tracks):
-            raise ValueError(
-                f"Track index {native_track_index} out of range for "
-                f"{modality} ({len(tracks)} tracks)"
-            )
-        track = tracks[native_track_index]
-        display_name = track.get("biosample_name") or track.track_name
-        log.info(
-            "Native track: index=%d, name=%s", native_track_index, display_name
-        )
-        return model, native_track_index, display_name
-
-    # Search by biosample name (substring, case-insensitive)
-    tracks = catalog.get_tracks(modality, organism=0)
-    query = native_biosample.lower()
-    matches = [
-        t for t in tracks
-        if not t.is_padding and query in (t.get("biosample_name") or "").lower()
-    ]
-
-    if not matches:
-        available = sorted({
-            t.get("biosample_name")
-            for t in tracks
-            if not t.is_padding and t.get("biosample_name")
-        })
-        raise ValueError(
-            f"No {modality} track found matching biosample '{native_biosample}'. "
-            f"Available biosamples ({len(available)}): {available[:20]}"
-        )
-
-    if len(matches) > 1:
-        log.warning(
-            "Multiple tracks match '%s': %s. Using first.",
-            native_biosample,
-            [(m.track_index, m.get("biosample_name")) for m in matches[:5]],
-        )
-
-    track = matches[0]
-    display_name = track.get("biosample_name") or track.track_name
-    log.info("Native track: index=%d, name=%s", track.track_index, display_name)
-    return model, track.track_index, display_name
-
-
 # =============================================================================
 # Inference
 # =============================================================================
@@ -181,9 +112,11 @@ def evaluate_split(
     loader: DataLoader,
     device: torch.device,
     resolutions: tuple[int, ...],
+    *,
+    organism_index: int,
     positional_weight: float = 5.0,
 ) -> tuple[dict[int, np.ndarray], dict[int, np.ndarray], float]:
-    """Run finetuned model inference. Returns (preds, targets, avg_loss).
+    """Run finetuned model inference at ``organism_index``. Returns (preds, targets, avg_loss).
 
     Predictions are in experimental space (unscaled).
     """
@@ -197,8 +130,8 @@ def evaluate_split(
 
     for sequences, targets_dict in tqdm(loader, desc="Evaluating (finetuned)"):
         sequences = sequences.to(device)
-        organism_idx = torch.zeros(
-            sequences.shape[0], dtype=torch.long, device=device
+        organism_idx = torch.full(
+            (sequences.shape[0],), organism_index, dtype=torch.long, device=device,
         )
 
         with torch.autocast(
@@ -266,8 +199,10 @@ def evaluate_native_split(
     loader: DataLoader,
     device: torch.device,
     resolutions: tuple[int, ...],
+    *,
+    organism_index: int,
 ) -> dict[int, np.ndarray]:
-    """Run native model on same data, extract a single track.
+    """Run native model on same data at ``organism_index``, extract a single track.
 
     Returns dict[resolution -> (N, seq_len, 1)] predictions.
     """
@@ -277,8 +212,8 @@ def evaluate_native_split(
 
     for sequences, _ in tqdm(loader, desc="Evaluating (native)"):
         sequences = sequences.to(device)
-        organism_idx = torch.zeros(
-            sequences.shape[0], dtype=torch.long, device=device,
+        organism_idx = torch.full(
+            (sequences.shape[0],), organism_index, dtype=torch.long, device=device,
         )
 
         with torch.autocast(
@@ -816,6 +751,11 @@ def parse_args() -> argparse.Namespace:
         "--native-track-index", type=int,
         help="Direct track index for native head (alternative to --native-biosample)",
     )
+    p.add_argument(
+        "--organism", type=int, default=None, choices=[0, 1],
+        help="Organism index to evaluate at. Default: the organism the checkpoint "
+             "was trained on (from its metadata). Override for a mixed/legacy checkpoint.",
+    )
 
     # Options
     p.add_argument("--sequence-length", type=int, default=131072)
@@ -872,6 +812,12 @@ def main() -> None:
     model, ckpt_meta = load_finetuned_model(
         args.checkpoint, args.pretrained_weights, device,
     )
+    # Evaluate at the organism the checkpoint was trained on (explicit --organism
+    # overrides). The native comparison below uses the same organism.
+    organism_index = select_organism_index(
+        model.finetuned_organism_context, explicit=args.organism,
+        num_organisms=model.num_organisms,
+    )
     modality = ckpt_meta["modality"]
     if isinstance(modality, list):
         modality = modality[0]  # single-task evaluation
@@ -895,6 +841,7 @@ def main() -> None:
         native_model, native_track_idx, native_display_name = load_native_model(
             args.pretrained_weights, args.native_biosample,
             args.native_track_index, modality, device,
+            organism_index=organism_index,
         )
 
     # ---- Feature: metrics ----
@@ -939,6 +886,7 @@ def main() -> None:
         # Finetuned evaluation
         ft_preds, targets, loss = evaluate_split(
             model, modality, loader, device, resolutions,
+            organism_index=organism_index,
         )
         log.info("Loss: %.4f", loss)
 
@@ -976,6 +924,7 @@ def main() -> None:
             native_preds = evaluate_native_split(
                 native_model, modality, native_track_idx,
                 loader, device, resolutions,
+                organism_index=organism_index,
             )
 
             for res in resolutions:
@@ -1065,6 +1014,7 @@ def main() -> None:
         # Finetuned predictions on regions
         ft_region_preds, region_targets, _ = evaluate_split(
             model, modality, region_loader, device, resolutions,
+            organism_index=organism_index,
         )
 
         # Native predictions on regions
@@ -1075,6 +1025,7 @@ def main() -> None:
             native_region_preds = evaluate_native_split(
                 native_model, modality, native_track_idx,
                 region_loader, device, resolutions,
+                organism_index=organism_index,
             )
             native_model.cpu()
             model = model.to(device)

--- a/src/alphagenome_pytorch/cli/predict.py
+++ b/src/alphagenome_pytorch/cli/predict.py
@@ -66,8 +66,10 @@ def register(subparsers: argparse._SubParsersAction) -> None:
                    help="Batch size for inference")
     p.add_argument("--window-size", type=int, default=131072,
                    help="Model input window size (default: 131072)")
-    p.add_argument("--organism", type=int, default=0, choices=[0, 1],
-                   help="Organism: 0=human, 1=mouse")
+    p.add_argument("--organism", type=int, default=None, choices=[0, 1],
+                   help="Organism: 0=human, 1=mouse. Default: 0 for a pretrained model; "
+                        "for a fine-tuned checkpoint, the organism it was trained on "
+                        "(from checkpoint metadata). Pass explicitly to override.")
     p.add_argument("--device", type=str, default="cuda", help="PyTorch device")
     p.add_argument("--dtype-policy", type=str, default="full_float32",
                    choices=["full_float32", "mixed_precision"],
@@ -245,6 +247,28 @@ def _load_model(args, dtype_policy, json_mode):
     return model, None, None
 
 
+def _effective_organism(model, requested: int | None) -> tuple[int, str]:
+    """Resolve the organism index to forward at, plus its source, for logging.
+
+    For a fine-tuned checkpoint the model carries a ``finetuned_organism_context``:
+    an explicit ``--organism`` wins, else the checkpoint's default. For a pretrained
+    model there is no context, so an explicit value wins, else human (0).
+    """
+    context = getattr(model, "finetuned_organism_context", None)
+    if context is not None:
+        from alphagenome_pytorch.extensions.finetuning.checkpointing import (
+            select_organism_index,
+        )
+        index = select_organism_index(
+            context, explicit=requested, num_organisms=model.num_organisms,
+        )
+        source = "explicit" if requested is not None else context.source
+        return index, source
+    return (requested if requested is not None else 0), (
+        "explicit" if requested is not None else "default"
+    )
+
+
 def _describe_handling(info, json_mode: bool, quiet: bool) -> None:
     """Print a per-region status line and any warnings.
 
@@ -366,7 +390,10 @@ def run(args: argparse.Namespace) -> int:
     # weights; a finetuned checkpoint's strands are resolved after it loads.
     strands_needed = bool(args.anndata) and args.gene_strand == "match"
     if strands_needed and track_strands is None and not args.checkpoint:
-        track_strands = _resolve_track_strands(args.head, args.organism, track_indices)
+        # Pre-load (pretrained/native) strand lookup: no model yet, so an omitted
+        # --organism means human here.
+        native_default = args.organism if args.organism is not None else 0
+        track_strands = _resolve_track_strands(args.head, native_default, track_indices)
         if track_strands is None:
             raise ValueError(
                 f"--gene-strand match needs per-track strands for head '{args.head}', "
@@ -391,10 +418,17 @@ def run(args: argparse.Namespace) -> int:
         if track_indices is not None:
             track_names = [track_names[i] for i in track_indices]
 
+    # Resolve the organism to forward at now that the model (and its fine-tune
+    # organism context, if any) is loaded. Used for all forwards and metadata below.
+    organism_index, organism_source = _effective_organism(model, args.organism)
+    if not json_mode and not getattr(args, "quiet", False):
+        _org_name = "mouse" if organism_index == 1 else "human"
+        print(f"  Organism: {_org_name} ({organism_index}), source: {organism_source}")
+
     # Finetuned checkpoint strands are only known now that meta is loaded.
     if strands_needed and track_strands is None and args.checkpoint:
         track_strands = _resolve_track_strands(
-            args.head, args.organism, track_indices,
+            args.head, organism_index, track_indices,
             checkpoint_meta=track_metadata_from_ckpt, from_checkpoint=True,
         )
         if track_strands is None:
@@ -446,7 +480,7 @@ def run(args: argparse.Namespace) -> int:
                 reduce="sum" if args.aggregate_func == "sum" else "mean",
                 log=args.aggregate_func == "log-mean",
                 strand=None if args.gene_strand == "all" else args.gene_strand,
-                organism_index=args.organism,
+                organism_index=organism_index,
                 device=args.device,
                 show_progress=show_progress,
             )
@@ -476,7 +510,7 @@ def run(args: argparse.Namespace) -> int:
             config=config,
             track_indices=track_indices,
             track_names=track_names,
-            organism_index=args.organism,
+            organism_index=organism_index,
             device=args.device,
             show_progress=show_progress,
         )
@@ -509,7 +543,7 @@ def run(args: argparse.Namespace) -> int:
             head=args.head, config=config,
             tile=args.tile,
             track_indices=track_indices,
-            organism_index=args.organism,
+            organism_index=organism_index,
             device=args.device,
         )
         _describe_handling(info, json_mode, args.quiet)
@@ -565,7 +599,7 @@ def run(args: argparse.Namespace) -> int:
                 tile=args.tile,
                 name=r.name,
                 track_indices=track_indices,
-                organism_index=args.organism,
+                organism_index=organism_index,
                 device=args.device,
             )
             _describe_handling(info, json_mode, args.quiet)
@@ -626,7 +660,7 @@ def run(args: argparse.Namespace) -> int:
                 head=args.head, config=config,
                 tile=args.tile,
                 track_indices=track_indices,
-                organism_index=args.organism,
+                organism_index=organism_index,
                 device=args.device,
             )
             _describe_handling(info, json_mode, args.quiet)

--- a/src/alphagenome_pytorch/extensions/finetuning/__init__.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/__init__.py
@@ -33,6 +33,8 @@ from alphagenome_pytorch.extensions.finetuning.checkpointing import (
     export_model_weights, export_delta_weights,
     load_delta_config, load_delta_weights, is_delta_weights_export,
     load_finetuned_model,
+    FinetunedOrganismContext, resolve_finetuned_organism,
+    select_organism_index, finalize_finetuned_organism_context,
 )
 
 # Transfer config serialization
@@ -170,6 +172,11 @@ __all__ = [
     "is_delta_weights_export",
     # Inference loading
     "load_finetuned_model",
+    # Organism provenance / selection
+    "FinetunedOrganismContext",
+    "resolve_finetuned_organism",
+    "select_organism_index",
+    "finalize_finetuned_organism_context",
     # Data transforms (lazy-loaded)
     "apply_atac_transforms",
     "apply_rnaseq_transforms",

--- a/src/alphagenome_pytorch/extensions/finetuning/checkpointing.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/checkpointing.py
@@ -1576,6 +1576,12 @@ def load_finetuned_model(
     if "delta_checkpoint_version" in ckpt:
         model = AlphaGenome(dtype_policy=dtype_policy)
         model = load_trunk(model, str(pretrained_weights), exclude_heads=True)
+        # Strip the base model's (untrained) pretrained heads before reconstructing,
+        # matching the exported-delta and full-checkpoint paths. Without this a
+        # .delta.pth reload keeps the randomly-initialised native heads (atac,
+        # dnase, ...) alongside the fine-tuned head, so a full forward or iterating
+        # ``model.heads`` yields garbage from heads that were never trained.
+        model = remove_all_heads(model)
         config, metadata = load_delta_checkpoint(
             ckpt_path, model, verify_hash=False, strict=False,
         )

--- a/src/alphagenome_pytorch/extensions/finetuning/checkpointing.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/checkpointing.py
@@ -9,9 +9,11 @@ import hashlib
 import os
 import signal
 import tempfile
+import warnings
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 import torch
 import torch.distributed as dist
@@ -20,6 +22,10 @@ from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LRScheduler
 
 from alphagenome_pytorch.extensions.finetuning.distributed import is_main_process
+from alphagenome_pytorch.organisms import (
+    normalize_organism_index,
+    normalize_organism_indices,
+)
 
 if TYPE_CHECKING:
     from alphagenome_pytorch.extensions.finetuning.transfer import TransferConfig
@@ -937,6 +943,7 @@ def export_delta_weights(
     track_names: dict[str, list[str]] | list[str] | None = None,
     track_metadata: list[dict[str, Any]] | None = None,
     organism: str | None = None,
+    organism_indices: list[int] | None = None,
 ) -> None:
     """Export only delta weights (adapters + new heads) for sharing.
 
@@ -958,6 +965,10 @@ def export_delta_weights(
         organism: Optional organism label (``"human"``/``"mouse"``) the tracks
             were trained on. Embedded so recipients know the provenance without
             inspecting per-track metadata.
+        organism_indices: Optional forward-facing set of trained organism indices
+            (e.g. ``[1]`` for mouse). Validated at export against the model's
+            ``num_organisms``; if both ``organism`` and ``organism_indices`` are
+            given, the scalar must be a member of the plural set.
 
     Example:
         >>> # Export just the LoRA weights + head for sharing
@@ -975,6 +986,26 @@ def export_delta_weights(
     import json
 
     path = Path(path)
+
+    # Validate + normalize organism provenance up front so a conflicting artifact
+    # (e.g. organism="mouse" + organism_indices=[0]) can never be written to disk.
+    # Only when an organism is actually supplied — otherwise there is nothing to
+    # embed and no need to require the model expose ``num_organisms``.
+    norm_organism_indices = None
+    norm_organism = None
+    if organism is not None or organism_indices is not None:
+        bound = model.num_organisms
+        norm_organism_indices = normalize_organism_indices(organism_indices, num_organisms=bound)
+        norm_organism = normalize_organism_index(organism, num_organisms=bound)
+        if (
+            norm_organism_indices is not None
+            and norm_organism is not None
+            and norm_organism not in norm_organism_indices
+        ):
+            raise ValueError(
+                f"organism {organism!r} (index {norm_organism}) is not in organism_indices "
+                f"{list(norm_organism_indices)}"
+            )
 
     # Get adapter, head, and trainable norm weights
     adapter_weights = get_adapter_state_dict(model)
@@ -1004,6 +1035,8 @@ def export_delta_weights(
             extras["track_metadata"] = track_metadata
         if organism is not None:
             extras["organism"] = organism
+        if norm_organism_indices is not None:
+            extras["organism_indices"] = list(norm_organism_indices)
         # safetensors metadata must be str -> str
         metadata = {k: json.dumps(v) for k, v in extras.items()}
         save_file({k: v.cpu() for k, v in weights.items()}, path, metadata=metadata)
@@ -1017,6 +1050,8 @@ def export_delta_weights(
             extras["track_metadata"] = track_metadata
         if organism is not None:
             extras["organism"] = organism
+        if norm_organism_indices is not None:
+            extras["organism_indices"] = list(norm_organism_indices)
         torch.save({"weights": weights, **extras}, path)
     else:
         raise ValueError(f"Unknown format: {format}. Use 'safetensors' or 'pth'.")
@@ -1056,6 +1091,8 @@ def _read_delta_export_header(path: Path | str) -> dict[str, Any]:
             header["track_metadata"] = json.loads(metadata["track_metadata"])
         if "organism" in metadata:
             header["organism"] = json.loads(metadata["organism"])
+        if "organism_indices" in metadata:
+            header["organism_indices"] = json.loads(metadata["organism_indices"])
     else:
         data = torch.load(path, map_location="cpu", weights_only=False)
         if not isinstance(data, dict) or "transfer_config" not in data:
@@ -1069,6 +1106,8 @@ def _read_delta_export_header(path: Path | str) -> dict[str, Any]:
             header["track_metadata"] = data["track_metadata"]
         if "organism" in data:
             header["organism"] = data["organism"]
+        if "organism_indices" in data:
+            header["organism_indices"] = data["organism_indices"]
 
     return header
 
@@ -1233,6 +1272,165 @@ def _has_adapter_keys(state_dict: dict[str, Any]) -> bool:
     )
 
 
+@dataclass(frozen=True, slots=True)
+class FinetunedOrganismContext:
+    """What organism(s) a fine-tuned checkpoint was trained on, and the default to use.
+
+    ``organism_indices`` is the declared/inferred set (``None`` only when unknown).
+    ``default_organism_index`` is the single index to forward at when unambiguous, else
+    ``None`` (a mixed checkpoint requires an explicit per-request choice); a checkpoint with
+    no organism metadata gets the compatibility default ``0`` with ``source="fallback"``.
+    ``source`` records provenance; ``conflicts`` are human-readable notes the loader warns on.
+    """
+
+    organism_indices: tuple[int, ...] | None
+    default_organism_index: int | None
+    source: Literal["checkpoint", "track_metadata", "fallback"]
+    conflicts: tuple[str, ...] = ()
+
+
+def _organisms_from_track_metadata(
+    track_metadata: Any, *, num_organisms: int
+) -> tuple[int, ...] | None:
+    """Distinct, explicitly-present organism indices from metadata rows, or ``None``.
+
+    Organism-less rows provide no evidence — they are skipped, never treated as human.
+    """
+    if not track_metadata:
+        return None
+    present: set[int] = set()
+    for row in track_metadata:
+        if not isinstance(row, dict):
+            continue
+        value = row.get("organism")
+        if value is None:
+            continue
+        index = normalize_organism_index(value, num_organisms=num_organisms)
+        if index is not None:
+            present.add(index)
+    return tuple(sorted(present)) if present else None
+
+
+def resolve_finetuned_organism(
+    *,
+    organism_indices: Any = None,
+    checkpoint_organism: Any = None,
+    track_metadata: Any = None,
+    num_organisms: int,
+) -> FinetunedOrganismContext:
+    """Resolve checkpoint organism provenance into a :class:`FinetunedOrganismContext`.
+
+    Pure — never warns; returns ``.conflicts`` for the caller to emit. Precedence:
+    plural ``organism_indices`` > scalar ``organism`` > track-metadata evidence > fallback ``0``.
+    Checkpoint declarations are authoritative: track metadata may only *broaden* to a mixed
+    set when no checkpoint organism is present. Invalid values raise.
+    """
+    conflicts: list[str] = []
+
+    plural = normalize_organism_indices(organism_indices, num_organisms=num_organisms)
+    scalar = normalize_organism_index(checkpoint_organism, num_organisms=num_organisms)
+    catalog = _organisms_from_track_metadata(track_metadata, num_organisms=num_organisms)
+
+    declared: tuple[int, ...] | None = None
+    source: Literal["checkpoint", "track_metadata", "fallback"] = "fallback"
+
+    if plural is not None:
+        declared = plural
+        source = "checkpoint"
+        if scalar is not None and scalar not in plural:
+            conflicts.append(
+                f"Checkpoint scalar organism {scalar} is not in declared "
+                f"organism_indices {list(plural)}; using the plural set."
+            )
+    elif scalar is not None:
+        declared = (scalar,)
+        source = "checkpoint"
+
+    if declared is not None:
+        if catalog is not None and set(catalog) != set(declared):
+            conflicts.append(
+                f"Track metadata organisms {list(catalog)} differ from the checkpoint "
+                f"declaration {list(declared)}; using the checkpoint declaration."
+            )
+    elif catalog is not None:
+        declared = catalog
+        source = "track_metadata"
+
+    if declared is None:
+        return FinetunedOrganismContext(
+            organism_indices=None,
+            default_organism_index=0,
+            source="fallback",
+            conflicts=tuple(conflicts),
+        )
+
+    default = declared[0] if len(declared) == 1 else None
+    return FinetunedOrganismContext(
+        organism_indices=declared,
+        default_organism_index=default,
+        source=source,
+        conflicts=tuple(conflicts),
+    )
+
+
+def select_organism_index(
+    context: FinetunedOrganismContext,
+    explicit: Any = None,
+    *,
+    num_organisms: int,
+) -> int:
+    """Pick the single ``organism_index`` for one inference request.
+
+    Explicit request wins (validated + bounds-checked). Warn only when the explicit choice
+    is outside a *known* declared set — a fallback context (``organism_indices is None``) is
+    unknown provenance, not proof the organism was untrained, so it must not warn. Without an
+    explicit request, use the derived default; a mixed checkpoint with no default raises.
+    """
+    if explicit is not None:
+        index = normalize_organism_index(explicit, num_organisms=num_organisms)
+        if context.organism_indices is not None and index not in context.organism_indices:
+            warnings.warn(
+                f"Requested organism {index} is not in the checkpoint's declared organisms "
+                f"{list(context.organism_indices)}; forwarding at {index} anyway.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return index
+    if context.default_organism_index is not None:
+        return context.default_organism_index
+    raise ValueError(
+        "This checkpoint has no single default organism (declared: "
+        f"{list(context.organism_indices) if context.organism_indices else None}); "
+        "pass an explicit organism."
+    )
+
+
+def finalize_finetuned_organism_context(
+    model: nn.Module, meta: dict[str, Any]
+) -> FinetunedOrganismContext:
+    """Resolve + attach the organism context. **Mutates both ``meta`` and ``model``.**
+
+    Reads the raw ``organism_indices``/``organism``/``track_metadata`` already in ``meta``,
+    resolves them against ``model.num_organisms``, emits any conflict warnings once, overwrites
+    the metadata with the resolved values, and attaches ``model.finetuned_organism_context``.
+    Called by every fine-tuned loading path (``load_finetuned_model`` and
+    ``AlphaGenome.from_delta``) after each has reconstructed its own model.
+    """
+    ctx = resolve_finetuned_organism(
+        organism_indices=meta.get("organism_indices"),
+        checkpoint_organism=meta.get("organism"),
+        track_metadata=meta.get("track_metadata"),
+        num_organisms=model.num_organisms,
+    )
+    for message in ctx.conflicts:
+        warnings.warn(message, UserWarning, stacklevel=2)
+    meta["organism_indices"] = ctx.organism_indices
+    meta["default_organism_index"] = ctx.default_organism_index
+    meta["organism_resolution_source"] = ctx.source
+    model.finetuned_organism_context = ctx
+    return ctx
+
+
 def load_finetuned_model(
     checkpoint_path: str | Path,
     pretrained_weights: str | Path,
@@ -1317,6 +1515,17 @@ def load_finetuned_model(
 
     ckpt_path = Path(checkpoint_path)
 
+    def _finalize_and_return(model, meta):
+        """Resolve+attach the organism context, then move to device and eval.
+
+        The single exit for every branch. Does NOT freeze parameters: this loader is shared
+        by serving and by gradient-based ISM/DeepLIFT, which need gradients. Consumers that
+        want an inference-frozen model freeze at their own boundary.
+        """
+        finalize_finetuned_organism_context(model, meta)
+        model.eval()
+        return model.to(device), meta
+
     def _finalize_delta_export(header, weights):
         """Build an inference model from an exported delta header + weight dict.
 
@@ -1339,13 +1548,12 @@ def load_finetuned_model(
             "track_names": header.get("track_names"),
             "track_metadata": header.get("track_metadata"),
             "organism": header.get("organism"),
+            "organism_indices": header.get("organism_indices"),
             "epoch": -1,
             "val_loss": None,
             "head_names": list(config.new_heads.keys()),
         }
-        model = model.to(device)
-        model.eval()
-        return model, meta
+        return _finalize_and_return(model, meta)
 
     # --- Path A2 (safetensors): a .safetensors file is always an exported
     # delta-weights file, never a torch pickle — handle it by suffix BEFORE any
@@ -1380,13 +1588,12 @@ def load_finetuned_model(
             "track_names": metadata.get("track_names"),
             "track_metadata": metadata.get("track_metadata"),
             "organism": metadata.get("organism"),
+            "organism_indices": metadata.get("organism_indices"),
             "epoch": metadata.get("epoch", -1),
             "val_loss": metadata.get("val_loss"),
             "head_names": head_names,
         }
-        model = model.to(device)
-        model.eval()
-        return model, meta
+        return _finalize_and_return(model, meta)
 
     # --- Path A2 (.pth): Exported delta weights (transfer_config + weights) ---
     if "transfer_config" in ckpt and "weights" in ckpt:
@@ -1395,6 +1602,7 @@ def load_finetuned_model(
             "track_names": ckpt.get("track_names"),
             "track_metadata": ckpt.get("track_metadata"),
             "organism": ckpt.get("organism"),
+            "organism_indices": ckpt.get("organism_indices"),
         }
         return _finalize_delta_export(header, ckpt["weights"])
 
@@ -1466,13 +1674,12 @@ def load_finetuned_model(
         "track_names": ckpt.get("track_names"),
         "track_metadata": ckpt.get("track_metadata"),
         "organism": ckpt.get("organism"),
+        "organism_indices": ckpt.get("organism_indices"),
         "epoch": ckpt.get("epoch", -1),
         "val_loss": ckpt.get("val_loss"),
         "head_names": head_names,
     }
-    model = model.to(device)
-    model.eval()
-    return model, meta
+    return _finalize_and_return(model, meta)
 
 
 __all__ = [
@@ -1496,6 +1703,11 @@ __all__ = [
     "is_delta_weights_export",
     # Inference loading
     "load_finetuned_model",
+    # Organism provenance / selection
+    "FinetunedOrganismContext",
+    "resolve_finetuned_organism",
+    "select_organism_index",
+    "finalize_finetuned_organism_context",
     # Utilities
     "split_model_state_dict",
     "get_trunk_state_dict",

--- a/src/alphagenome_pytorch/extensions/finetuning/evaluation.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/evaluation.py
@@ -21,16 +21,11 @@ from tqdm import tqdm
 
 from alphagenome_pytorch import AlphaGenome
 from alphagenome_pytorch.extensions.finetuning.checkpointing import (
-    is_delta_checkpoint,
-    load_delta_checkpoint,
+    load_finetuned_model as _canonical_load_finetuned_model,
+    select_organism_index,
 )
-from alphagenome_pytorch.extensions.finetuning.heads import create_finetuning_head
 from alphagenome_pytorch.extensions.finetuning.training import NUM_SEGMENTS
 from alphagenome_pytorch.extensions.finetuning.transfer import (
-    TransferConfig,
-    add_head,
-    prepare_for_transfer,
-    remove_all_heads,
     transfer_config_from_dict,
 )
 from alphagenome_pytorch.losses import multinomial_loss
@@ -73,98 +68,45 @@ def _normalize_metadata(meta: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _apply_transfer_config_from_json(
-    model: nn.Module, config_path: str | Path,
-) -> nn.Module:
-    with open(config_path) as f:
-        cfg_dict = json.load(f)
-    config = transfer_config_from_dict(cfg_dict)
-    return prepare_for_transfer(model, config)
-
-
-def _apply_heads_from_metadata(
-    model: nn.Module, modality: str, track_names: list[str], resolutions: tuple[int, ...],
-) -> nn.Module:
-    """Attach a fresh finetuning head matching a full-checkpoint's head shapes.
-
-    For linear-probe / full finetuning, no adapters are needed — only the new
-    head must exist before ``load_state_dict``. We remove the pretrained heads
-    and add the finetuning head named after ``modality``.
-    """
-    model = remove_all_heads(model)
-    head = create_finetuning_head(
-        modality=modality,
-        n_tracks=len(track_names),
-        resolutions=resolutions,
-    )
-    add_head(model, modality, head)
-    return model
-
-
 def load_finetuned_model(
     checkpoint_path: str | Path,
     pretrained_weights: str | Path,
     device: torch.device,
     transfer_config_json: str | Path | None = None,
 ) -> tuple[nn.Module, dict]:
-    """Load a finetuned model regardless of checkpoint format.
+    """Load a finetuned model for evaluation, delegating to the canonical loader.
 
-    Supports:
-    - ``best_model.delta.pth`` (delta; TransferConfig embedded).
-    - ``best_model.pth`` (full) with adapter modes, if ``transfer_config_json``
-      is supplied (dumped alongside training).
-    - ``best_model.pth`` (full) without adapters (linear-probe / full mode)
-      — architecture is reconstructed from metadata.
+    Thin wrapper over ``checkpointing.load_finetuned_model`` that preserves this
+    module's historical signature (``transfer_config_json`` is a path to a JSON dump
+    of a ``TransferConfig``). Freezes parameters for the eval-only workflow — the
+    canonical loader deliberately leaves them trainable so gradient-based uses keep
+    working.
 
-    Returns (model, normalized_metadata_dict) with keys: modality, resolutions,
-    track_names, epoch, val_loss. Parameters are frozen.
+    Returns ``(model, metadata)``. ``metadata`` carries the organism provenance the
+    canonical loader resolved (``organism_indices``, ``default_organism_index``,
+    ``organism_resolution_source``) plus back-compat coerced ``modality``,
+    ``resolutions``, ``track_names``, ``epoch``, ``val_loss``.
     """
-    checkpoint_path = Path(checkpoint_path)
+    transfer_config = None
+    if transfer_config_json is not None:
+        with open(transfer_config_json) as f:
+            transfer_config = transfer_config_from_dict(json.load(f))
+
     log.info("Loading checkpoint: %s", checkpoint_path)
+    model, meta = _canonical_load_finetuned_model(
+        checkpoint_path=checkpoint_path,
+        pretrained_weights=pretrained_weights,
+        device=device,
+        transfer_config=transfer_config,
+    )
 
-    model = AlphaGenome.from_pretrained(str(pretrained_weights), device=device)
-
-    if is_delta_checkpoint(checkpoint_path):
-        config, metadata = load_delta_checkpoint(
-            checkpoint_path, model, verify_hash=False,
-        )
-        model.to(device)
-    else:
-        raw = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
-        metadata = {
-            k: raw[k] for k in
-            ("modality", "resolutions", "track_names", "epoch", "val_loss")
-            if k in raw
-        }
-        norm = _normalize_metadata(metadata)
-
-        if transfer_config_json is not None:
-            model = _apply_transfer_config_from_json(model, transfer_config_json)
-        else:
-            has_adapter_keys = any(
-                ".lora_" in k or ".locon_" in k or ".scale" in k
-                or ".adapter." in k
-                for k in raw["model_state_dict"].keys()
-            )
-            if has_adapter_keys:
-                raise RuntimeError(
-                    f"Full checkpoint {checkpoint_path.name} contains adapter "
-                    "weights but no transfer_config.json was supplied. Pass "
-                    "--transfer-config (a JSON dumped from TransferConfig) or "
-                    "re-train with --save-delta for a self-describing checkpoint."
-                )
-            model = _apply_heads_from_metadata(
-                model, norm["modality"], norm["track_names"], norm["resolutions"],
-            )
-
-        model.load_state_dict(raw["model_state_dict"], strict=False)
-        model.to(device)
-
-    model.eval()
+    # Eval-only workflow: freeze parameters (the canonical loader does not).
     for p in model.parameters():
         p.requires_grad = False
 
-    return model, _normalize_metadata(metadata)
+    # Overlay back-compat coerced shapes without dropping any canonical keys.
+    meta.update(_normalize_metadata(meta))
+    return model, meta
 
 
 def load_native_model(
@@ -173,24 +115,31 @@ def load_native_model(
     native_track_index: int | None,
     modality: str,
     device: torch.device,
+    *,
+    organism_index: int = 0,
 ) -> tuple[nn.Module, int, str]:
     """Load pretrained model with native heads and resolve the comparison track.
 
     Pass either ``native_biosample`` (substring match, case-insensitive) or
     ``native_track_index``. Returns (model, track_index, display_name).
+
+    ``organism_index`` selects which organism's built-in catalog and tracks to
+    compare against — a mouse fine-tune (index 1) must compare against the mouse
+    native head/track, not the human default.
     """
     model = AlphaGenome.from_pretrained(str(pretrained_weights), device=device)
     model.eval()
     for p in model.parameters():
         p.requires_grad = False
 
-    catalog = TrackMetadataCatalog.load_builtin("human")
+    organism_name = "mouse" if organism_index == 1 else "human"
+    catalog = TrackMetadataCatalog.load_builtin(organism_name)
     model.set_track_metadata_catalog(catalog)
 
-    tracks = catalog.get_tracks(modality, organism=0)
+    tracks = catalog.get_tracks(modality, organism=organism_index)
 
     if native_track_index is not None:
-        if native_track_index >= len(tracks):
+        if not 0 <= native_track_index < len(tracks):
             raise ValueError(
                 f"Track index {native_track_index} out of range for "
                 f"{modality} ({len(tracks)} tracks)"
@@ -238,13 +187,19 @@ def evaluate_split(
     loader: DataLoader,
     device: torch.device,
     resolutions: tuple[int, ...],
+    *,
+    organism_index: int,
     positional_weight: float = 5.0,
     progress_desc: str = "Evaluating (finetuned)",
 ) -> tuple[dict[int, np.ndarray], dict[int, np.ndarray], float]:
-    """Run finetuned model inference.
+    """Run finetuned model inference at ``organism_index``.
 
     Returns (preds, targets, avg_loss). Predictions are in experimental
     (unscaled) space so they can be compared directly to BigWig values.
+
+    ``organism_index`` selects the trunk organism embedding; it must match what the
+    checkpoint was trained on (resolve it once via ``select_organism_index`` at the
+    call boundary — do not default to 0 for a mouse fine-tune).
     """
     model.eval()
     head = model.heads[modality]
@@ -256,8 +211,8 @@ def evaluate_split(
 
     for sequences, targets_dict in tqdm(loader, desc=progress_desc):
         sequences = sequences.to(device)
-        organism_idx = torch.zeros(
-            sequences.shape[0], dtype=torch.long, device=device,
+        organism_idx = torch.full(
+            (sequences.shape[0],), organism_index, dtype=torch.long, device=device,
         )
 
         with torch.autocast(
@@ -330,19 +285,23 @@ def evaluate_native_split(
     loader: DataLoader,
     device: torch.device,
     resolutions: tuple[int, ...],
+    *,
+    organism_index: int,
     progress_desc: str = "Evaluating (native)",
 ) -> dict[int, np.ndarray]:
-    """Run native model on the same loader, extract a single track.
+    """Run native model on the same loader at ``organism_index``, extract a single track.
 
-    Returns dict[resolution -> (N, seq_len, 1)].
+    Returns dict[resolution -> (N, seq_len, 1)]. ``organism_index`` must match the
+    fine-tuned comparison's organism (and the track selected in ``load_native_model``),
+    otherwise the native baseline is computed for the wrong species.
     """
     model.eval()
     preds_by_res: dict[int, list[np.ndarray]] = {r: [] for r in resolutions}
 
     for sequences, _ in tqdm(loader, desc=progress_desc):
         sequences = sequences.to(device)
-        organism_idx = torch.zeros(
-            sequences.shape[0], dtype=torch.long, device=device,
+        organism_idx = torch.full(
+            (sequences.shape[0],), organism_index, dtype=torch.long, device=device,
         )
 
         with torch.autocast(

--- a/src/alphagenome_pytorch/extensions/finetuning/runner.py
+++ b/src/alphagenome_pytorch/extensions/finetuning/runner.py
@@ -788,15 +788,25 @@ def main(args: argparse.Namespace | None = None) -> None:
             organism=args.organism, rank=rank,
         )
 
+    # The organism this fine-tune trains, resolved once here and reused for both
+    # checkpoint metadata and the training/validation forward pass so producer
+    # metadata can never drift from actual training routing. Note: args.organism
+    # is None for a default-human run, so we persist the *resolved* name/index
+    # (not args.organism) — otherwise a new human checkpoint records "unknown".
+    organism_index = organism_index_from_args(args)
+    organism_name = "mouse" if organism_index == 1 else "human"
+
     # Track identity embedded into every checkpoint/delta save below. Defined
     # once and spread as **metadata_kwargs so a new save site cannot silently
-    # drop the embedded metadata.
+    # drop the embedded metadata. ``organism`` is the compatibility scalar;
+    # ``organism_indices`` is the forward-facing plural form.
     metadata_kwargs = dict(
         track_names=modality_track_names,
         modality=args.modalities,
         resolutions=modality_resolutions,
         track_metadata=track_metadata_rows,
-        organism=args.organism,
+        organism=organism_name,
+        organism_indices=[organism_index],
     )
 
     # Build resolution weights per modality.
@@ -1067,11 +1077,11 @@ def main(args: argparse.Namespace | None = None) -> None:
         args.mode in ("lora", "locon", "lora+locon") and not has_active_adapters
     )
     encoder_only = args.mode == "encoder-only"
-    # Forward at the fine-tune's organism so mouse data uses the mouse trunk
-    # embedding. Fine-tuned heads are single-organism (num_organisms=1, see
-    # create_model) and organism-agnostic — they always use slot 0 — so the
-    # organism index only selects the trunk embedding, not a head weight slot.
-    organism_index = organism_index_from_args(args)
+    # ``organism_index`` was resolved once above (near metadata_kwargs) and is
+    # reused here: mouse data forwards the trunk at index 1 so it uses the mouse
+    # trunk embedding. Fine-tuned heads are single-organism (num_organisms=1) and
+    # organism-agnostic — they map any index to slot 0 — so the organism index
+    # only selects the trunk embedding, not a head weight slot.
 
     try:
         for epoch in range(start_epoch, args.epochs + 1):

--- a/src/alphagenome_pytorch/extensions/serving/cli.py
+++ b/src/alphagenome_pytorch/extensions/serving/cli.py
@@ -212,29 +212,22 @@ def _resolve_finetuned_metadata_catalog(
     return None
 
 
-def _finetuned_default_organism(
-    metadata_catalog: "TrackMetadataCatalog | None",
-    meta: dict | None = None,
-) -> str | int:
-    """Default organism for a fine-tuned model.
+def _finetuned_default_organism(meta: dict) -> int:
+    """Default organism index for a fine-tuned model, from the resolved metadata.
 
-    When the embedded catalog labels a single organism (e.g. a mouse fine-tune),
-    default to it so a request that omits organism still resolves to the
-    organism the tracks belong to and is labelled correctly. The runtime maps
-    that organism onto the head's single trained slot.
-
-    When no single-organism catalog is available, fall back to the top-level
-    ``organism`` recorded in the checkpoint metadata (``finetune.py --organism``),
-    which labels a mouse fine-tune correctly even without ``--track-metadata``.
-    Falls back to human when neither source resolves a single organism.
+    Consumes the ``default_organism_index`` the canonical loader already resolved
+    (checkpoint provenance + embedded catalog) — this must not re-run resolution.
+    A mixed checkpoint has no single default (``None``); since mixed-organism serving
+    is not yet supported, that fails at server construction rather than silently
+    defaulting to human.
     """
-    if metadata_catalog is not None and not metadata_catalog.is_empty():
-        present = sorted(set(metadata_catalog.organisms))
-        if len(present) == 1:
-            return present[0]
-    if meta is not None and meta.get("organism"):
-        return meta["organism"]
-    return "human"
+    default = meta.get("default_organism_index")
+    if default is None:
+        raise ValueError(
+            "This checkpoint has no single default organism. "
+            "Mixed-organism serving is not yet supported."
+        )
+    return default
 
 
 def _build_checkpoint_adapter(args: argparse.Namespace) -> LocalDnaModelAdapter:
@@ -266,7 +259,7 @@ def _build_checkpoint_adapter(args: argparse.Namespace) -> LocalDnaModelAdapter:
         metadata_catalog=metadata_catalog,
         track_names=meta.get('track_names'),
         device=args.device,
-        default_organism=_finetuned_default_organism(metadata_catalog, meta),
+        default_organism=_finetuned_default_organism(meta),
     )
     scorer = _make_variant_scorer(
         runtime=runtime,

--- a/src/alphagenome_pytorch/model.py
+++ b/src/alphagenome_pytorch/model.py
@@ -493,23 +493,30 @@ class AlphaGenome(nn.Module):
             ... )
         """
         from alphagenome_pytorch.extensions.finetuning.checkpointing import (
-            load_delta_config,
+            _read_delta_export_header,
+            finalize_finetuned_organism_context,
             load_delta_weights,
         )
         from alphagenome_pytorch.extensions.finetuning.transfer import (
             load_trunk,
             prepare_for_transfer,
+            transfer_config_from_dict,
         )
 
         if dtype_policy is None:
             dtype_policy = DtypePolicy.default()
 
-        # 1. Create base model and load pretrained trunk
+        # 1. Create base model and load pretrained trunk. Note ``cls(**kwargs)`` is
+        #    built here (preserving subclass + constructor kwargs like num_organisms),
+        #    so from_delta must NOT delegate to the canonical loader — it only shares
+        #    the organism-context finalizer below.
         model = cls(dtype_policy=dtype_policy, **kwargs)
         model = load_trunk(model, base_path, exclude_heads=True)
 
-        # 2. Read config and set up adapters/heads
-        config = load_delta_config(delta_path)
+        # 2. Read the exported header once (config + organism provenance) and set up
+        #    adapters/heads.
+        header = _read_delta_export_header(delta_path)
+        config = transfer_config_from_dict(header["transfer_config"])
         model = prepare_for_transfer(model, config)
 
         # 3. Load delta weights
@@ -518,6 +525,17 @@ class AlphaGenome(nn.Module):
         # 4. Move to target device
         if device:
             model.to(device)
+
+        # 5. Attach the fine-tune organism context (same helper the canonical loader
+        #    uses) so from_delta and load_finetuned_model behave consistently.
+        finalize_finetuned_organism_context(
+            model,
+            {
+                "organism": header.get("organism"),
+                "organism_indices": header.get("organism_indices"),
+                "track_metadata": header.get("track_metadata"),
+            },
+        )
 
         return model
 

--- a/src/alphagenome_pytorch/organisms.py
+++ b/src/alphagenome_pytorch/organisms.py
@@ -1,0 +1,92 @@
+"""Strict, model-bound organism normalization.
+
+Public, strict counterpart to :func:`alphagenome_pytorch.named_outputs._resolve_organism_index`
+(which silently maps unknown input to a default). Values are validated against the target model's
+``num_organisms`` so a malformed organism fails loudly instead of defaulting to human.
+
+Intended to be the single shared home for organism string/int normalization; finetuning,
+serving, prediction, and variant scoring can converge on it over time.
+"""
+from __future__ import annotations
+
+import operator
+from collections.abc import Iterable
+
+__all__ = ["ORGANISM_ALIASES", "normalize_organism_index", "normalize_organism_indices"]
+
+
+# Canonical organism name/alias -> backbone slot index. Index is a model-local slot,
+# not a biological identifier; a future registry may add taxonomy ids alongside these.
+ORGANISM_ALIASES: dict[str, int] = {
+    "human": 0,
+    "homo_sapiens": 0,
+    "mouse": 1,
+    "mus_musculus": 1,
+}
+
+
+def normalize_organism_index(value, *, num_organisms: int) -> int | None:
+    """Normalize a single organism value to a bounded index, or ``None`` when missing.
+
+    Accepts ``None`` (missing), an alias string (``"human"``/``"mouse"``/...), a decimal
+    string (``"0"``/``"1"`` as produced by CSV/TSV metadata), or an integer-like value
+    (including numpy ints via ``operator.index``). Rejects ``bool`` (``True``/``False`` are
+    ``int`` subclasses but must not become organisms 1/0), unknown strings, non-integers,
+    and any index outside ``[0, num_organisms)``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"organism must not be a bool, got {value!r}")
+
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in ORGANISM_ALIASES:
+            index = ORGANISM_ALIASES[text]
+        elif text.isdecimal():
+            index = int(text)
+        else:
+            raise ValueError(
+                f"Unknown organism {value!r}; expected one of {sorted(ORGANISM_ALIASES)} "
+                "or an integer index"
+            )
+    else:
+        try:
+            index = operator.index(value)
+        except TypeError:
+            raise ValueError(
+                f"organism must be an int or known string, got {type(value).__name__}"
+            ) from None
+
+    if not 0 <= index < num_organisms:
+        raise ValueError(
+            f"organism index {index} out of range for num_organisms={num_organisms} "
+            f"(valid: 0..{num_organisms - 1})"
+        )
+    return index
+
+
+def normalize_organism_indices(value, *, num_organisms: int) -> tuple[int, ...] | None:
+    """Normalize a scalar or collection of organisms to a sorted, unique tuple.
+
+    ``None`` -> ``None`` (missing information). A string is treated as a scalar. A
+    ``list``/``tuple``/``set`` (or other non-string iterable) is plural: each member is
+    normalized, deduplicated, and sorted. An **empty** collection is invalid — use ``None``
+    for "missing"; an empty declared set is almost certainly corrupt metadata.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) or not isinstance(value, Iterable):
+        return (normalize_organism_index(value, num_organisms=num_organisms),)
+
+    members = list(value)
+    if not members:
+        raise ValueError("organism_indices must contain at least one organism")
+
+    normalized: set[int] = set()
+    for member in members:
+        index = normalize_organism_index(member, num_organisms=num_organisms)
+        if index is None:
+            raise ValueError("organism_indices members must not be None")
+        normalized.add(index)
+    return tuple(sorted(normalized))

--- a/tests/unit/test_delta_checkpointing.py
+++ b/tests/unit/test_delta_checkpointing.py
@@ -593,6 +593,7 @@ class TestExportAndLoadDeltaWeights:
         from alphagenome_pytorch.extensions.finetuning.adapters import LoRA
 
         model = nn.Module()
+        model.num_organisms = 2
         model.q_proj = LoRA(nn.Linear(64, 64), rank=4)
         model.heads = nn.ModuleDict({
             "my_head": nn.Linear(64, 10),
@@ -728,6 +729,32 @@ class TestExportAndLoadDeltaWeights:
             assert header["track_metadata"] == track_metadata
             assert header["organism"] == "mouse"
 
+    def test_export_organism_indices_roundtrip(self):
+        """organism_indices=[0, 1] survives both .pth and safetensors headers."""
+        model, config = self._make_lora_model_and_config()
+        for fmt, ext in [("pth", ".pth"), ("safetensors", ".safetensors")]:
+            if fmt == "safetensors":
+                pytest.importorskip("safetensors")
+            with tempfile.TemporaryDirectory() as tmpdir:
+                path = Path(tmpdir) / f"delta{ext}"
+                export_delta_weights(
+                    model, config, path, format=fmt, organism_indices=[0, 1],
+                )
+                header = _read_delta_export_header(path)
+                assert header["organism_indices"] == [0, 1]
+
+    def test_export_rejects_scalar_not_in_plural(self):
+        """A conflicting organism/organism_indices export fails before writing."""
+        model, config = self._make_lora_model_and_config()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "delta.pth"
+            with pytest.raises(ValueError):
+                export_delta_weights(
+                    model, config, path, format="pth",
+                    organism="mouse", organism_indices=[0],
+                )
+            assert not path.exists()
+
     def test_export_without_metadata_is_backwards_compatible(self):
         """Old call sites without track_names/track_metadata still work."""
         model, config = self._make_lora_model_and_config()
@@ -750,6 +777,7 @@ class TestIsDeltaWeightsExport:
     def _make_lora_model_and_config(self):
         from alphagenome_pytorch.extensions.finetuning.adapters import LoRA
         model = nn.Module()
+        model.num_organisms = 2
         model.q_proj = LoRA(nn.Linear(64, 64), rank=4)
         model.heads = nn.ModuleDict({"my_head": nn.Linear(64, 10)})
         config = TransferConfig(
@@ -847,6 +875,7 @@ class TestSaveDeltaCheckpointEmbedsTrackMetadata:
     def test_track_metadata_round_trips(self):
         from alphagenome_pytorch.extensions.finetuning.adapters import LoRA
         model = nn.Module()
+        model.num_organisms = 2
         model.q_proj = LoRA(nn.Linear(64, 64), rank=4)
         model.heads = nn.ModuleDict({"my_head": nn.Linear(64, 10)})
         config = TransferConfig(
@@ -1009,6 +1038,8 @@ class TestLoadFinetunedModelNullTransferConfig:
         from alphagenome_pytorch.extensions.finetuning import transfer as tr_mod
 
         class _Stub(nn.Module):
+            num_organisms = 2
+
             def __init__(self, *_, **__):
                 super().__init__()
                 self.heads = nn.ModuleDict()
@@ -1088,6 +1119,7 @@ class TestLoadFinetunedModelExportedDelta:
     def _make_lora_model_and_config(self):
         from alphagenome_pytorch.extensions.finetuning.adapters import LoRA
         model = nn.Module()
+        model.num_organisms = 2
         model.q_proj = LoRA(nn.Linear(64, 64), rank=4)
         model.heads = nn.ModuleDict({"my_head": nn.Linear(64, 10)})
         config = TransferConfig(

--- a/tests/unit/test_delta_checkpointing.py
+++ b/tests/unit/test_delta_checkpointing.py
@@ -1113,6 +1113,57 @@ class TestLoadFinetunedModelNullTransferConfig:
             )
 
 
+class TestLoadFinetunedModelDeltaStripsNativeHeads:
+    """A .delta.pth reload must drop the base model's untrained native heads."""
+
+    def test_delta_reload_strips_pretrained_native_heads(self, tmp_path, monkeypatch):
+        """Parity with the exported-delta and full-checkpoint paths: after reload
+        only the fine-tuned head remains, not the randomly-initialised native
+        heads that a fresh AlphaGenome starts with.
+        """
+        import alphagenome_pytorch as agp
+        from alphagenome_pytorch.extensions.finetuning import transfer as tr_mod
+        from alphagenome_pytorch.extensions.finetuning import checkpointing as ck_mod
+        from alphagenome_pytorch.extensions.finetuning.checkpointing import (
+            load_finetuned_model,
+        )
+
+        class _StubWithNativeHeads(nn.Module):
+            num_organisms = 2
+
+            def __init__(self, *_, **__):
+                super().__init__()
+                # A fresh AlphaGenome ships with these pretrained heads.
+                self.heads = nn.ModuleDict({
+                    "atac": nn.Linear(1, 1),
+                    "dnase": nn.Linear(1, 1),
+                })
+
+        def _fake_load_delta(_ckpt_path, model, **_kwargs):
+            # Stand in for load_delta_checkpoint: reconstruct only the new head.
+            model.heads["my_head"] = nn.Linear(1, 1)
+            cfg = TransferConfig(
+                mode="lora",
+                new_heads={"my_head": {"modality": "atac", "num_tracks": 1}},
+            )
+            return cfg, {"modality": "atac", "organism": "mouse"}
+
+        monkeypatch.setattr(agp, "AlphaGenome", lambda **_: _StubWithNativeHeads())
+        monkeypatch.setattr(tr_mod, "load_trunk", lambda m, *_, **__: m)
+        monkeypatch.setattr(ck_mod, "load_delta_checkpoint", _fake_load_delta)
+        # remove_all_heads is intentionally left real — it is the code under test.
+
+        ckpt_path = tmp_path / "model.delta.pth"
+        torch.save({"delta_checkpoint_version": 1}, ckpt_path)
+
+        model, meta = load_finetuned_model(
+            ckpt_path, "unused.pth", device="cpu", merge=False,
+        )
+
+        assert set(model.heads.keys()) == {"my_head"}, set(model.heads.keys())
+        assert meta["default_organism_index"] == 1  # organism context still attached
+
+
 class TestLoadFinetunedModelExportedDelta:
     """End-to-end load_finetuned_model over the exported-delta sharing formats."""
 

--- a/tests/unit/test_organism_resolution.py
+++ b/tests/unit/test_organism_resolution.py
@@ -1,0 +1,289 @@
+"""Unit tests for fine-tune organism normalization, resolution, and selection.
+
+Covers the pieces that make the fine-tune organism authoritative at inference:
+``alphagenome_pytorch.organisms`` (strict normalizers) and the
+``checkpointing`` context/resolver/selector/finalizer. Pure logic only — no model
+weights required.
+
+Run: ``pytest tests/unit/test_organism_resolution.py -v`` (or ``-k organism``).
+"""
+from __future__ import annotations
+
+import types
+
+import numpy as np
+import pytest
+
+from alphagenome_pytorch.organisms import (
+    ORGANISM_ALIASES,
+    normalize_organism_index,
+    normalize_organism_indices,
+)
+from alphagenome_pytorch.extensions.finetuning.checkpointing import (
+    FinetunedOrganismContext,
+    finalize_finetuned_organism_context,
+    resolve_finetuned_organism,
+    select_organism_index,
+)
+
+
+# ---------------------------------------------------------------------------
+# normalize_organism_index
+# ---------------------------------------------------------------------------
+
+def test_normalize_index_none_is_none():
+    assert normalize_organism_index(None, num_organisms=2) is None
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("human", 0), ("Human", 0), ("homo_sapiens", 0),
+    ("mouse", 1), ("MOUSE", 1), ("mus_musculus", 1),
+    (0, 0), (1, 1),
+    ("0", 0), ("1", 1),          # decimal strings from CSV/TSV metadata
+])
+def test_normalize_index_valid(value, expected):
+    assert normalize_organism_index(value, num_organisms=2) == expected
+
+
+def test_normalize_index_accepts_numpy_int():
+    assert normalize_organism_index(np.int64(1), num_organisms=2) == 1
+
+
+@pytest.mark.parametrize("bad", [True, False])
+def test_normalize_index_rejects_bool(bad):
+    with pytest.raises(ValueError):
+        normalize_organism_index(bad, num_organisms=2)
+
+
+@pytest.mark.parametrize("bad", ["rat", "dog", "", "  ", 1.0, np.float64(1.0), object()])
+def test_normalize_index_rejects_garbage(bad):
+    with pytest.raises(ValueError):
+        normalize_organism_index(bad, num_organisms=2)
+
+
+@pytest.mark.parametrize("bad", [2, "2", -1, "-1"])
+def test_normalize_index_bounds(bad):
+    # Out of range for a 2-organism model.
+    with pytest.raises(ValueError):
+        normalize_organism_index(bad, num_organisms=2)
+
+
+def test_normalize_index_third_organism_valid_with_larger_bound():
+    # A future three-organism model: index 2 is valid, 3 is not.
+    assert normalize_organism_index(2, num_organisms=3) == 2
+    with pytest.raises(ValueError):
+        normalize_organism_index(3, num_organisms=3)
+
+
+# ---------------------------------------------------------------------------
+# normalize_organism_indices
+# ---------------------------------------------------------------------------
+
+def test_normalize_indices_none():
+    assert normalize_organism_indices(None, num_organisms=2) is None
+
+
+def test_normalize_indices_string_is_scalar():
+    assert normalize_organism_indices("mouse", num_organisms=2) == (1,)
+
+
+def test_normalize_indices_dedupe_and_sort():
+    assert normalize_organism_indices([1, 0, 1], num_organisms=2) == (0, 1)
+    assert normalize_organism_indices({1, 0}, num_organisms=2) == (0, 1)
+
+
+def test_normalize_indices_empty_raises():
+    with pytest.raises(ValueError):
+        normalize_organism_indices([], num_organisms=2)
+
+
+def test_normalize_indices_invalid_member_raises():
+    with pytest.raises(ValueError):
+        normalize_organism_indices(["mouse", "rat"], num_organisms=2)
+
+
+# ---------------------------------------------------------------------------
+# resolve_finetuned_organism
+# ---------------------------------------------------------------------------
+
+def test_resolve_mouse_scalar():
+    ctx = resolve_finetuned_organism(checkpoint_organism="mouse", num_organisms=2)
+    assert ctx == FinetunedOrganismContext(
+        organism_indices=(1,), default_organism_index=1, source="checkpoint",
+    )
+
+
+def test_resolve_human_scalar():
+    ctx = resolve_finetuned_organism(checkpoint_organism="human", num_organisms=2)
+    assert ctx.organism_indices == (0,) and ctx.default_organism_index == 0
+
+
+def test_resolve_legacy_fallback():
+    ctx = resolve_finetuned_organism(num_organisms=2)
+    assert ctx.organism_indices is None
+    assert ctx.default_organism_index == 0
+    assert ctx.source == "fallback"
+
+
+def test_resolve_from_track_metadata_only():
+    ctx = resolve_finetuned_organism(
+        track_metadata=[{"organism": 1}, {"organism": 1}, {"foo": "bar"}],
+        num_organisms=2,
+    )
+    assert ctx.organism_indices == (1,)
+    assert ctx.default_organism_index == 1
+    assert ctx.source == "track_metadata"
+
+
+def test_resolve_organism_less_rows_are_no_evidence():
+    ctx = resolve_finetuned_organism(
+        track_metadata=[{"foo": 1}, {"strand": "+"}], num_organisms=2,
+    )
+    assert ctx.source == "fallback"
+    assert ctx.default_organism_index == 0
+
+
+def test_resolve_multi_organism_metadata_has_no_default():
+    ctx = resolve_finetuned_organism(
+        track_metadata=[{"organism": 0}, {"organism": 1}], num_organisms=2,
+    )
+    assert set(ctx.organism_indices) == {0, 1}
+    assert ctx.default_organism_index is None
+
+
+def test_resolve_plural_precedence_over_scalar():
+    ctx = resolve_finetuned_organism(
+        organism_indices=[0, 1], checkpoint_organism="mouse", num_organisms=2,
+    )
+    assert set(ctx.organism_indices) == {0, 1}
+    assert ctx.default_organism_index is None
+    # scalar "mouse" IS in the plural set -> no conflict
+    assert ctx.conflicts == ()
+
+
+def test_resolve_plural_scalar_conflict_noted_once():
+    ctx = resolve_finetuned_organism(
+        organism_indices=[0], checkpoint_organism="mouse", num_organisms=2,
+    )
+    assert ctx.organism_indices == (0,)
+    assert ctx.default_organism_index == 0
+    assert len(ctx.conflicts) == 1
+
+
+def test_resolve_checkpoint_authoritative_over_broader_catalog():
+    # checkpoint says mouse; catalog lists both -> checkpoint wins, one conflict note.
+    ctx = resolve_finetuned_organism(
+        checkpoint_organism="mouse",
+        track_metadata=[{"organism": 0}, {"organism": 1}],
+        num_organisms=2,
+    )
+    assert ctx.organism_indices == (1,)
+    assert ctx.default_organism_index == 1
+    assert ctx.source == "checkpoint"
+    assert len(ctx.conflicts) == 1
+
+
+def test_resolve_invalid_value_raises():
+    with pytest.raises(ValueError):
+        resolve_finetuned_organism(checkpoint_organism="rat", num_organisms=2)
+
+
+# ---------------------------------------------------------------------------
+# select_organism_index
+# ---------------------------------------------------------------------------
+
+def test_select_uses_default_when_no_explicit():
+    ctx = resolve_finetuned_organism(checkpoint_organism="mouse", num_organisms=2)
+    assert select_organism_index(ctx, num_organisms=2) == 1
+
+
+def test_select_explicit_overrides_and_warns_vs_single_species():
+    ctx = resolve_finetuned_organism(checkpoint_organism="mouse", num_organisms=2)
+    with pytest.warns(UserWarning):
+        idx = select_organism_index(ctx, explicit=0, num_organisms=2)
+    assert idx == 0  # explicit forwarded despite the warning
+
+
+def test_select_fallback_explicit_does_not_warn(recwarn):
+    ctx = resolve_finetuned_organism(num_organisms=2)  # fallback, organism_indices=None
+    idx = select_organism_index(ctx, explicit=1, num_organisms=2)
+    assert idx == 1
+    assert len(recwarn) == 0  # unknown provenance -> no "untrained" warning
+
+
+def test_select_mixed_without_explicit_raises():
+    ctx = resolve_finetuned_organism(organism_indices=[0, 1], num_organisms=2)
+    with pytest.raises(ValueError):
+        select_organism_index(ctx, num_organisms=2)
+
+
+def test_select_mixed_with_explicit_ok():
+    ctx = resolve_finetuned_organism(organism_indices=[0, 1], num_organisms=2)
+    assert select_organism_index(ctx, explicit=1, num_organisms=2) == 1
+
+
+def test_select_explicit_out_of_bounds_raises():
+    ctx = resolve_finetuned_organism(checkpoint_organism="mouse", num_organisms=2)
+    with pytest.raises(ValueError):
+        select_organism_index(ctx, explicit=2, num_organisms=2)
+
+
+# ---------------------------------------------------------------------------
+# finalize_finetuned_organism_context
+# ---------------------------------------------------------------------------
+
+def _stub_model(num_organisms: int = 2):
+    return types.SimpleNamespace(num_organisms=num_organisms)
+
+
+def test_finalize_attaches_context_and_writes_metadata():
+    model = _stub_model()
+    meta = {"organism": "mouse", "track_metadata": None}
+    ctx = finalize_finetuned_organism_context(model, meta)
+    assert model.finetuned_organism_context is ctx
+    assert meta["organism_indices"] == (1,)
+    assert meta["default_organism_index"] == 1
+    assert meta["organism_resolution_source"] == "checkpoint"
+
+
+def test_finalize_metadata_and_attribute_agree():
+    model = _stub_model()
+    meta = {"organism_indices": [1]}
+    finalize_finetuned_organism_context(model, meta)
+    ctx = model.finetuned_organism_context
+    assert meta["organism_indices"] == ctx.organism_indices
+    assert meta["default_organism_index"] == ctx.default_organism_index
+
+
+def test_finalize_legacy_checkpoint_defaults_to_human():
+    model = _stub_model()
+    meta: dict = {}
+    finalize_finetuned_organism_context(model, meta)
+    assert meta["default_organism_index"] == 0
+    assert meta["organism_resolution_source"] == "fallback"
+
+
+def test_finalize_emits_conflict_warning_once():
+    model = _stub_model()
+    meta = {"organism_indices": [0], "organism": "mouse"}
+    with pytest.warns(UserWarning) as record:
+        finalize_finetuned_organism_context(model, meta)
+    assert len(record) == 1
+
+
+# ---------------------------------------------------------------------------
+# export_delta_weights validation (fails before writing a conflicting artifact)
+# ---------------------------------------------------------------------------
+
+def test_export_rejects_scalar_not_in_plural(tmp_path):
+    from alphagenome_pytorch.extensions.finetuning.checkpointing import (
+        export_delta_weights,
+    )
+    # organism="mouse" (1) is not in organism_indices=[0] -> must raise up front,
+    # before any weights are extracted or written.
+    with pytest.raises(ValueError):
+        export_delta_weights(
+            _stub_model(), config=None, path=tmp_path / "x.safetensors",
+            organism="mouse", organism_indices=[0],
+        )
+    assert not (tmp_path / "x.safetensors").exists()

--- a/tests/unit/test_serving_cli.py
+++ b/tests/unit/test_serving_cli.py
@@ -69,7 +69,7 @@ def _stub_model():
 
 def test_checkpoint_path_creates_scoring_adapter():
     """``--checkpoint`` builds a ``LocalDnaModelAdapter`` with scoring enabled."""
-    fake_meta = {'track_names': {'dnase': ['t0', 't1']}}
+    fake_meta = {'track_names': {'dnase': ['t0', 't1']}, 'default_organism_index': 0}
 
     with (
         patch(
@@ -100,6 +100,7 @@ def test_checkpoint_uses_embedded_track_metadata():
     fake_meta = {
         'track_names': {'dnase': ['t0', 't1']},
         'track_metadata': embedded_rows,
+        'default_organism_index': 0,
     }
 
     with (
@@ -137,6 +138,7 @@ def test_checkpoint_cli_track_metadata_overrides_embedded(tmp_path, caplog):
         'track_metadata': [
             {"output_name": "dnase", "track_name": "from_embedded", "biosample_name": "K562"},
         ],
+        'default_organism_index': 0,
     }
 
     with (
@@ -166,7 +168,8 @@ def test_checkpoint_cli_track_metadata_overrides_embedded(tmp_path, caplog):
 
 def test_checkpoint_without_metadata_yields_no_catalog():
     """Bare checkpoints (no embedded metadata, no --track-metadata) leave the catalog unset."""
-    fake_meta = {'track_names': {'dnase': ['t0']}, 'track_metadata': None}
+    fake_meta = {'track_names': {'dnase': ['t0']}, 'track_metadata': None,
+                 'default_organism_index': 0}
 
     with (
         patch(
@@ -183,16 +186,17 @@ def test_checkpoint_without_metadata_yields_no_catalog():
     assert adapter.runtime.metadata_catalog is None
 
 
-def test_default_organism_falls_back_to_checkpoint_meta():
-    """Without a single-organism catalog, the top-level meta organism is used."""
+def test_default_organism_uses_resolved_default_index():
+    """Serving consumes the loader-resolved ``default_organism_index`` (no re-resolution)."""
+    import pytest
+
     from alphagenome_pytorch.extensions.serving.cli import _finetuned_default_organism
 
-    # No catalog: the recorded organism labels a mouse fine-tune correctly even
-    # when --track-metadata was not supplied at train time.
-    assert _finetuned_default_organism(None, {'organism': 'mouse'}) == 'mouse'
-    # Neither catalog nor meta organism: fall back to human.
-    assert _finetuned_default_organism(None, {'organism': None}) == 'human'
-    assert _finetuned_default_organism(None, None) == 'human'
+    assert _finetuned_default_organism({'default_organism_index': 1}) == 1
+    assert _finetuned_default_organism({'default_organism_index': 0}) == 0
+    # A mixed checkpoint has no single default -> fail clearly at construction.
+    with pytest.raises(ValueError):
+        _finetuned_default_organism({'default_organism_index': None})
 
 
 def test_weights_path_creates_scoring_adapter():


### PR DESCRIPTION
Fine-tuned models must run at the organism they were trained on. 

This should improve user experience with fine-tuned models on mouse data.